### PR TITLE
#156461691 Create a room GraphQL end point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,107 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# vscode
+.vscode/
+
+# sqlite DB
+*.sqlite
+
+# alembic
+alembic/
+alembic.ini

--- a/app.py
+++ b/app.py
@@ -1,10 +1,27 @@
 from flask import Flask
+from flask_graphql import GraphQLView
 
 from config import config
+from database import db_session
+from schema import schema
 
 
 def create_app(config_name):
     app = Flask(__name__)
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
+
+    app.add_url_rule(
+        '/mrm',
+        view_func=GraphQLView.as_view(
+            'mrm',
+            schema=schema,
+            graphiql=True # for having the GraphiQL interface
+        )
+    )
+
+    @app.teardown_appcontext
+    def shutdown_session(exception=None):
+        db_session.remove()
+    
     return app

--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@ import os
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'hard to guess string'
+    SECRET_KEY = os.getenv('SECRET_KEY') or 'hard to guess string'
     SQLALCHEMY_COMMIT_ON_TEARDOWN = True
 
     @staticmethod
@@ -12,24 +12,24 @@ class Config:
 
 class DevelopmentConfig(Config):
     DEBUG = True
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DEV_DATABASE_URL') or \
+    SQLALCHEMY_DATABASE_URI = os.getenv('DEV_DATABASE_URL') or \
     'sqlite:///' + os.path.join(basedir, 'dev-db.sqlite')
 
 class TestingConfig(Config):
     TESTING = True
-    SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL') or \
+    SQLALCHEMY_DATABASE_URI = os.getenv('TEST_DATABASE_URL') or \
     'sqlite:///' + os.path.join(basedir, 'test-db.sqlite')
 
 
 class ProductionConfig(Config):
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL') or \
     'sqlite:///' + os.path.join(basedir, 'data.sqlite')
 
 
 config = {
-'development': DevelopmentConfig,
-'testing': TestingConfig,
-'production': ProductionConfig,
-'default': DevelopmentConfig
+    'development': DevelopmentConfig,
+    'testing': TestingConfig,
+    'production': ProductionConfig,
+    'default': DevelopmentConfig
 }
  

--- a/database.py
+++ b/database.py
@@ -1,0 +1,17 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from config import config
+
+config_name = os.getenv('FLASK_CONFIG')
+database_uri = config.get(config_name).SQLALCHEMY_DATABASE_URI
+engine = create_engine(database_uri, convert_unicode=True)
+db_session = scoped_session(sessionmaker(autocommit=False,
+                                         autoflush=False,
+                                         bind=engine))
+
+Base = declarative_base()
+Base.query = db_session.query_property()

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,6 @@ import os
 from flask_script import Manager, Shell
 
 from app import create_app
-import config
 
 
 app = create_app(os.getenv('FLASK_CONFIG') or 'default')
@@ -15,7 +14,6 @@ def make_shell_context():
 manager.add_command(
     "shell", Shell(
         make_context=make_shell_context))
-
 
 
 if __name__ == '__main__':

--- a/models.py
+++ b/models.py
@@ -1,0 +1,56 @@
+from sqlalchemy import (
+    Column, String, Integer, ForeignKey, func, 
+    DateTime, create_engine)
+from sqlalchemy.orm import relationship
+from sqlalchemy_utils import ScalarListType
+
+from database import Base, db_session
+
+
+class Utility(object):
+    
+    def save(self):
+        """Function for saving new objects"""
+        db_session.add(self)
+        db_session.commit()
+
+
+class Location(Base, Utility):
+    __tablename__ = 'locations'
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    abbreviation = Column(String)
+    block = relationship('Block')
+
+
+class Block(Base, Utility):
+    __tablename__ = 'blocks'
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    location_id = Column(Integer, ForeignKey('locations.id'))
+    floor = relationship('Floor')
+
+
+class Floor(Base, Utility):
+    __tablename__ = 'floors'
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    block_id = Column(Integer, ForeignKey('blocks.id'))
+    room = relationship('Room')
+
+
+class Room(Base, Utility):
+    __tablename__ = 'rooms'
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    type = Column(String)
+    capacity = Column(Integer)
+    floor_id = Column(Integer, ForeignKey('floors.id'))
+    equipment = relationship('Equipment')
+
+
+class Equipment(Base, Utility):
+    __tablename__ = 'equipments'
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    room_id = Column(Integer, ForeignKey('rooms.id'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alembic==0.9.8
 click==6.7
 Flask==0.12.2
+Flask-Script==2.0.6
 Flask-GraphQL==1.4.1
 graphene==2.0.1
 graphene-sqlalchemy==2.0.0
@@ -19,5 +20,6 @@ Rx==1.6.1
 singledispatch==3.4.0.3
 six==1.11.0
 SQLAlchemy==1.2.5
+SQLAlchemy-Utils==0.33.2
 typing==3.6.4
 Werkzeug==0.14.1

--- a/schema.py
+++ b/schema.py
@@ -1,0 +1,50 @@
+import graphene
+
+from graphene import relay, Schema
+from graphene_sqlalchemy import (SQLAlchemyObjectType, 
+                                 SQLAlchemyConnectionField)
+
+from models import (
+    Room as RoomModel, Equipment as EquipmentModel)
+
+
+class Room(SQLAlchemyObjectType):
+    
+    class Meta:
+        model = RoomModel
+        interfaces = (relay.Node, )
+
+
+class Equipment(SQLAlchemyObjectType):
+    
+    class Meta:
+        model = EquipmentModel
+        interfaces = (relay.Node, )
+
+
+class CreateRoom(graphene.Mutation):
+    
+    class Arguments:
+        name = graphene.String()
+        type = graphene.String()
+        capacity = graphene.Int()
+        floor_id = graphene.Int()
+    room = graphene.Field(Room)
+
+    def mutate(self, info, **kwargs):
+        room  = RoomModel(**kwargs)
+        room.save()
+
+        return CreateRoom(room=room)
+
+
+class Query(graphene.ObjectType):
+    node = relay.Node.Field()
+    rooms = SQLAlchemyConnectionField(Room)
+    equipments = SQLAlchemyConnectionField(Equipment)
+
+
+class Mutations(graphene.ObjectType):
+    create_room = CreateRoom.Field()
+
+schema = Schema(query=Query, mutation=Mutations)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,39 @@
+from flask_testing import TestCase
+from graphene.test import Client
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from mrm_api.app import create_app
+from schema import schema
+from config import config
+from database import engine, db_session, Base
+from models import Floor, Location, Block
+
+
+class BaseTestCase(TestCase):
+    
+    def create_app(self):
+        app = create_app('testing')
+        self.base_url = 'https://127.0.0.1:5000/mrm'
+        self.headers = {'content-type': 'application/json'}
+        self.client = Client(schema)
+        return app
+    
+    def setUp(self):
+        app = self.create_app()
+        with app.app_context():
+            Base.metadata.create_all(bind=engine)
+            location = Location(name='Uganda', abbreviation='KLA')
+            location.save()
+            block = Block(name='EC', location_id=location.id)
+            block.save()
+            floor = Floor(name='3rd', block_id=block.id)
+            floor.save()
+            db_session.commit()
+    
+    def tearDown(self):
+        app = self.create_app()
+        with app.app_context():
+            db_session.remove()
+            Base.metadata.drop_all(bind=engine)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,25 @@
+room_mutation_query = '''
+    mutation {
+        createRoom(name: "Mbarara", type: "Meeting", capacity: 4, floorId: 1) {
+            room {
+                name
+                type
+                capacity
+                floorId
+            }
+        }
+    }
+'''
+
+room_mutation_response = {
+    "data": {
+        "createRoom": {
+            "room": {
+                "name": "Mbarara",
+                "type": "Meeting",
+                "capacity": 4,
+                "floorId": 1,
+            }
+        }
+    }
+}

--- a/tests/test_create_room.py
+++ b/tests/test_create_room.py
@@ -1,0 +1,41 @@
+import sys
+
+from graphene.test import Client
+from os.path import dirname, abspath
+mrm_api = dirname(dirname(abspath(__file__)))
+sys.path.insert(0, mrm_api)
+
+from tests.base import BaseTestCase
+from database import db_session
+
+
+class TestCreateRoom(BaseTestCase):
+
+    def test_room_creation(self):
+        query = '''
+                mutation {
+                    createRoom(name: "Mbarara", type: "Meeting", capacity: 4, floorId: 1) {
+                        room {
+                            name
+                            type
+                            capacity
+                            floorId
+                        }
+                    }
+                }
+            '''
+        execute_query = self.client.execute(query, context_value={'session': db_session})
+        
+        expected_responese = {
+            "data": {
+                "createRoom": {
+                    "room": {
+                        "name": "Mbarara",
+                        "type": "Meeting",
+                        "capacity": 4,
+                        "floorId": 1,
+                    }
+                }
+            }
+        }
+        self.assertEqual(execute_query, expected_responese)

--- a/tests/test_create_room.py
+++ b/tests/test_create_room.py
@@ -6,36 +6,16 @@ mrm_api = dirname(dirname(abspath(__file__)))
 sys.path.insert(0, mrm_api)
 
 from tests.base import BaseTestCase
+from tests.fixtures import room_mutation_query, room_mutation_response
 from database import db_session
 
 
 class TestCreateRoom(BaseTestCase):
 
     def test_room_creation(self):
-        query = '''
-                mutation {
-                    createRoom(name: "Mbarara", type: "Meeting", capacity: 4, floorId: 1) {
-                        room {
-                            name
-                            type
-                            capacity
-                            floorId
-                        }
-                    }
-                }
-            '''
-        execute_query = self.client.execute(query, context_value={'session': db_session})
+        execute_query = self.client.execute(
+            room_mutation_query,
+            context_value={'session': db_session})
         
-        expected_responese = {
-            "data": {
-                "createRoom": {
-                    "room": {
-                        "name": "Mbarara",
-                        "type": "Meeting",
-                        "capacity": 4,
-                        "floorId": 1,
-                    }
-                }
-            }
-        }
+        expected_responese = room_mutation_response
         self.assertEqual(execute_query, expected_responese)


### PR DESCRIPTION
**What does this PR do?**

- As a user, I should be able to create a room by sending data with room fields to a GraphQL end point

**Description of the task to be completed**

- Build a graphql endpoint to add a room, it should accept the fields.
       - name
       - location
       - list of equipments &
       - number of occupants

**How can this be manually tested?**

- This can be tested by using the GraphiQL GUI interface through this graphql endpoint 
   **localhost:5000/mrm**

<img width="1050" alt="screen shot 2018-04-12 at 9 29 26 pm" src="https://user-images.githubusercontent.com/6010217/38733266-eed2ec4a-3f29-11e8-8c9b-6d3cec9f4332.png">

**Any background  context you would like to provide**

- N/A

**What are the relevant pivotal tracker stories?**

- #156461691
