### PR TITLE
#158326634 Enable backward relationship

### DIFF
--- a/api/block/models.py
+++ b/api/block/models.py
@@ -11,4 +11,5 @@ class Block(Base, Utility):
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
     location_id = Column(Integer, ForeignKey('locations.id'))
+    location = relationship('Location')
     floors = relationship('Floor')

--- a/api/floor/models.py
+++ b/api/floor/models.py
@@ -11,4 +11,5 @@ class Floor(Base, Utility):
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
     block_id = Column(Integer, ForeignKey('blocks.id'))
+    block = relationship('Block')
     rooms = relationship('Room')

--- a/api/room/models.py
+++ b/api/room/models.py
@@ -14,6 +14,7 @@ class Room(Base, Utility):
     capacity = Column(Integer, nullable=False)
     image_url = Column(String)
     floor_id = Column(Integer, ForeignKey('floors.id'))
+    floor = relationship('Floor')
     resources = relationship('Resource')
 
     def __init__(self, **kwargs):

--- a/api/room_resource/models.py
+++ b/api/room_resource/models.py
@@ -1,4 +1,5 @@
 from sqlalchemy import (Column, String, Integer, ForeignKey)
+from sqlalchemy.orm import relationship
 
 from helpers.database import Base
 from utilities.utility import Utility, validate_empty_fields
@@ -10,6 +11,7 @@ class Resource(Base, Utility):
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
     room_id = Column(Integer, ForeignKey('rooms.id'))
+    room = relationship('Room')
 
     def __init__(self, **kwargs):
         validate_empty_fields(**kwargs)


### PR DESCRIPTION
**What does this PR do?**

- Fix Bug on backward relationship

**Description of the task to be completed**

- For example Get all rooms should return a list of rooms, floor, block, location for particular room 
   object.

**How should this be manually tested?**

- N/A

**Any background context you want to provide?**
- Executing the query below
allRooms {
id
name
capacity
floorId
}

- Response:
{
"data": {
"allRooms": [
{
"id": "3",
"name": "Gulu",
"capacity": 4,
"roomType": "Meeting Room",
"floorId": 1
},
{
"id": "4",
"name": "Entebbe",
"capacity": 8,
"roomType": "Meeting Room",
"floorId": 1
}
}
With this query it clearly shows that we only have floorId for a given room object which does not satisfy what the frontend mockup need. This means making another query to get more information needed which is not best practice with GraphQL

- With GraphQL the expected query would be
allRooms {
id
name
capacity
floorId
floor {
id
name
block {
id
name
location {
id
name
}
}
}
}

**What are the relevant pivotal tracker stories?**

- #158326634

**Screenshots (if appropriate)**

![screen shot 2018-06-13 at 5 40 25 pm](https://user-images.githubusercontent.com/6010217/41358584-5956b510-6f31-11e8-97de-652c07658981.png)
