### PR TITLE
#159074707 paginate rooms query 

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -152,7 +152,7 @@ class DeleteRoom(graphene.Mutation):
 
 class Query(graphene.ObjectType):
     all_rooms = graphene.Field(PaginatedRooms, page=graphene.Int(),
-                                   per_page=graphene.Int())
+                               per_page=graphene.Int())
     get_room_by_id = graphene.Field(
         Room,
         room_id=graphene.Int()

--- a/fixtures/room/room_fixtures.py
+++ b/fixtures/room/room_fixtures.py
@@ -106,14 +106,16 @@ room_invalid_wingId_mutation = '''
 
 
 rooms_query = '''
-    {
-    allRooms{
-                name
-                capacity
-                roomType
-                imageUrl
-                }
+query {
+  allRooms{
+   rooms{
+      name
+      capacity
+      roomType
+      imageUrl
+        }
     }
+}
     '''
 db_rooms_query = '''
     {
@@ -139,13 +141,45 @@ db_rooms_query_response = {
 
 query_rooms_response = {
     "data": {
-        "allRooms": [{
-                "name": "Entebbe",
-                "capacity": 6,
-                "roomType": "meeting",
-                "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
-            }]
+        "allRooms": {
+            "rooms": [
+                {
+                    "name": "Entebbe",
+                    "capacity": 6,
+                    "roomType": "meeting",
+                    "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+                }
+            ]
+        }
     }
+}
+
+paginated_rooms_query = '''
+ query {
+  allRooms(page:1, perPage:1){
+   rooms{
+      name
+   }
+   hasNext
+   hasPrevious
+   pages
+}
+}
+'''
+
+paginated_rooms_response = {
+  "data": {
+    "allRooms": {
+      "rooms": [
+        {
+          "name": "Entebbe"
+        }
+      ],
+      "hasNext": False,
+      "hasPrevious": False,
+      "pages": 1
+    }
+  }
 }
 
 room_query_by_id = '''

--- a/tests/test_rooms/test_query_rooms.py
+++ b/tests/test_rooms/test_query_rooms.py
@@ -4,6 +4,8 @@ from tests.base import BaseTestCase
 from fixtures.room.room_fixtures import (
     rooms_query,
     query_rooms_response,
+    paginated_rooms_query,
+    paginated_rooms_response,
     room_query_by_id,
     room_query_by_id_response,
     room_with_non_existant_id,
@@ -14,8 +16,16 @@ from fixtures.room.room_fixtures import (
 
 class QueryRooms(BaseTestCase):
     def test_query_rooms(self):
-        query_rooms = self.client.execute(rooms_query)
-        self.assertEquals(query_rooms, query_rooms_response)
+        execute_query = self.client.execute(
+            rooms_query)
+        expected_response = query_rooms_response
+        self.assertEqual(execute_query, expected_response)
+
+    def test_paginate_room_query(self):
+        response = self.app_test.post('/mrm?query='+paginated_rooms_query)
+        paginate_query = json.loads(response.data)
+        expected_response = paginated_rooms_response
+        self.assertEqual(paginate_query, expected_response)
 
     def test_query_room_with_id(self):
         query = self.client.execute(room_query_by_id)


### PR DESCRIPTION
**What does this PR do?**
Adds a pagination feature to the rooms query.
Allows queries to be run, with or without pagination.

**Description of the task to be completed**
A user should specify the page number and the items per page when using pagination:

<img width="1038" alt="screen shot 2018-08-07 at 23 11 13" src="https://user-images.githubusercontent.com/26790578/43800397-e00e78ee-9a98-11e8-94f2-5df600b439b9.png">

When pagination is not needed, the query needs to be specified as follows:

<img width="967" alt="screen shot 2018-08-07 at 23 11 40" src="https://user-images.githubusercontent.com/26790578/43800477-1ca22788-9a99-11e8-8c61-407c873fc54a.png">

**How should this be manually tested?**
Create room with the required mutation
Provide pagination's page and perPage as shown in the image above (first image)
To test functionality without pagination, just run the query normally (see second image)

**What are related Pivotal Tracker stories?**
Story: Paginate rooms query
Story ID: #159074707