### PR TITLE
bug(dependencies): add blinker to requirement.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic==0.9.8
 bugsnag==3.4.2
+blinker==1.4
 coverage==4.5.1
 Flask==0.12.2
 Flask-Cors==3.0.4


### PR DESCRIPTION
#### What does this PR do?
include blinker
 dependency in requirements

#### Relevant Pivotal Tracker story
[159622094](<https://www.pivotaltracker.com/n/projects/2154921/stories/159622094>)