### PR TITLE
#159629440 paginate users 

### DIFF
--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -28,6 +28,7 @@ class CreateUser(graphene.Mutation):
 
         return CreateUser(user=user)
 
+
 class PaginatedUsers(graphene.ObjectType):
     pages = graphene.Int()
     query_total = graphene.Int()
@@ -87,9 +88,10 @@ class PaginatedUsers(graphene.ObjectType):
 
         return has_previous
 
+
 class Query(graphene.ObjectType):
     users = graphene.Field(PaginatedUsers, page=graphene.Int(),
-                               per_page=graphene.Int())
+                           per_page=graphene.Int())
     user = graphene.Field(lambda: User, email=graphene.String())
 
     def resolve_users(self, info, **kwargs):

--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -1,4 +1,5 @@
 import graphene
+from math import ceil
 
 from graphene_sqlalchemy import (SQLAlchemyObjectType)
 from graphql import GraphQLError
@@ -27,14 +28,73 @@ class CreateUser(graphene.Mutation):
 
         return CreateUser(user=user)
 
-
-class Query(graphene.ObjectType):
+class PaginatedUsers(graphene.ObjectType):
+    pages = graphene.Int()
+    query_total = graphene.Int()
+    has_next = graphene.Boolean()
+    has_previous = graphene.Boolean()
     users = graphene.List(User)
-    user = graphene.Field(lambda: User, email=graphene.String())
+
+    def __init__(self, **kwargs):
+        self.page = kwargs.pop('page', None)
+        self.per_page = kwargs.pop('per_page', None)
+        self.query_total
+        self.pages
 
     def resolve_users(self, info):
+        page = self.page
+        per_page = self.per_page
         query = User.get_query(info)
-        return query.all()
+        if not page:
+            return query.all()
+
+        if page:
+            if page < 1:
+                return GraphQLError("No page requested")
+
+            page = page - 1
+            self.query_total = query.count()
+            result = query.limit(per_page).offset(page*per_page)
+            if result.count() == 0:
+                return GraphQLError("No more resources")
+            return result
+
+    def resolve_pages(self, pages):
+        if self.per_page:
+            self.pages = ceil(self.query_total / self.per_page)
+        pages = self.pages
+        return pages
+
+    def resolve_has_next(self, has_next):
+        if self.page:
+            page = self.page
+            pages = self.pages
+            pages = self.resolve_pages(pages)
+            if page < pages:
+                has_next = True
+            else:
+                has_next = False
+        return has_next
+
+    def resolve_has_previous(self, has_previous):
+        if self.page:
+            page = self.page
+            pages = self.resolve_pages(self.pages)
+            if (page > 1) and (pages > 1) and (page <= pages):
+                has_previous = True
+            else:
+                has_previous = False
+
+        return has_previous
+
+class Query(graphene.ObjectType):
+    users = graphene.Field(PaginatedUsers, page=graphene.Int(),
+                               per_page=graphene.Int())
+    user = graphene.Field(lambda: User, email=graphene.String())
+
+    def resolve_users(self, info, **kwargs):
+        response = PaginatedUsers(**kwargs)
+        return response
 
     def resolve_user(self, info, email):
         query = User.get_query(info)

--- a/fixtures/room/room_fixtures.py
+++ b/fixtures/room/room_fixtures.py
@@ -307,23 +307,7 @@ room_search_by_empty_name = '''
 }
 
 '''
-room_search_by_empty_name_response = {
-    "errors": [
-        {
-           "message": "Please input Room Name",
-           "locations": [
-               {
-                   "line": 3,
-                   "column": 5
-                   }
-                   ], "path": [
-                       "getRoomByName"
-                       ]
-                       }
-                       ],  "data": {
-                           "getRoomByName": null
-                           }
-                           }
+room_search_by_empty_name_response = "Please input Room Name"
 
 room_search_by_invalid_name = '''
 {
@@ -333,23 +317,8 @@ room_search_by_invalid_name = '''
 }
 '''
 
-room_search_by_invalid_name_response = {
-    "errors": [
-        {
-            "message": "Room not found",
-            "locations": [
-                {
-                    "line": 3,
-                    "column": 5
-                    }
-                ], "path": [
-                    "getRoomByName"
-                    ]
-        }
-    ], "data": {
-        "getRoomByName": null
-    }
-}
+room_search_by_invalid_name_response = "Room not found"
+
 filter_rooms_by_capacity = '''
 query {
   allRooms(capacity:6){

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -34,16 +34,16 @@ query {
 user_query_response = {
   "data": {
     "users": {
-    "users": [
-      {
-        "email": "peter.walugembe@andela.com",
-        "location": "Kampala"
-      },
-      {
-        "email": "mrm@andela.com",
-        "location": "Lagos"
-      },
-    ]
+      "users": [
+        {
+          "email": "peter.walugembe@andela.com",
+          "location": "Kampala"
+        },
+        {
+          "email": "mrm@andela.com",
+          "location": "Lagos"
+        },
+      ]
     }
   }
 }
@@ -67,7 +67,7 @@ paginated_users_response = {
     "users": {
       "users": [
         {
-          "email": "patrick.walukagga@andela.com",
+          "email": "peter.walugembe@andela.com",
           "location": "Kampala"
         }
       ],

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -22,15 +22,18 @@ user_mutation_response = {
 
 user_query = '''
 query {
-  users{
-    email,
-    location
-  }
+    users{
+      users{
+         email,
+         location
+      }
+   }
 }
 '''
 
 user_query_response = {
   "data": {
+    "users": {
     "users": [
       {
         "email": "peter.walugembe@andela.com",
@@ -41,6 +44,37 @@ user_query_response = {
         "location": "Lagos"
       },
     ]
+    }
+  }
+}
+
+paginated_users_query = '''
+query {
+    users(page:1, perPage:1){
+      users{
+         email
+         location
+      }
+      hasNext
+      hasPrevious
+      pages
+   }
+}
+'''
+
+paginated_users_response = {
+  "data": {
+    "users": {
+      "users": [
+        {
+          "email": "patrick.walukagga@andela.com",
+          "location": "Kampala"
+        }
+      ],
+      "hasNext": False,
+      "hasPrevious": False,
+      "pages": 1
+    }
   }
 }
 

--- a/tests/test_rooms/test_search_room_by_name.py
+++ b/tests/test_rooms/test_search_room_by_name.py
@@ -31,11 +31,15 @@ class SearchRoomsByName(BaseTestCase):
         search_room_empty_query = self.app_test.post(
             '/mrm?query='+room_search_by_empty_name, headers=api_headers)
         actual_response = json.loads(search_room_empty_query.data)
-        self.assertEquals(actual_response, room_search_by_empty_name_response)
+        expected_response = room_search_by_empty_name_response
+        self.assertEquals(
+            actual_response["errors"][0]['message'], expected_response)
 
     def test_search_room_by_invalid_name(self):
         api_headers = {'token': user_api_token}
         search_room_by_invalid_name = self.app_test.post(
             '/mrm?query='+room_search_by_invalid_name, headers=api_headers)
         actual_response = json.loads(search_room_by_invalid_name.data)
-        self.assertEquals(actual_response, room_search_by_invalid_name_response)
+        expected_response = room_search_by_invalid_name_response
+        self.assertEquals(
+            actual_response["errors"][0]['message'], expected_response)

--- a/tests/test_user/test_query_user.py
+++ b/tests/test_user/test_query_user.py
@@ -32,9 +32,7 @@ class TestQueryUser(BaseTestCase):
 
     def test_paginate__users_query(self):
         response = self.app_test.post('/mrm?query='+paginated_users_query)
-        print("the awaited response is!!!!!!!!!!!!!!!!!!", paginated_users_response)
         paginate_query = json.loads(response.data)
-        print("the returned response is???????????????????????????", paginate_query)
         expected_response = paginated_users_response
         self.assertEqual(paginate_query, expected_response)
 

--- a/tests/test_user/test_query_user.py
+++ b/tests/test_user/test_query_user.py
@@ -1,13 +1,15 @@
 from tests.base import BaseTestCase
 from fixtures.user.user_fixture import (
     user_query, user_query_response,
-    query_user_by_email, query_user_email_response
+    query_user_by_email, query_user_email_response,
+    paginated_users_query, paginated_users_response
 )
 from helpers.database import db_session
 from api.user.models import User
 
 import sys
 import os
+import json
 sys.path.append(os.getcwd())
 
 
@@ -27,6 +29,14 @@ class TestQueryUser(BaseTestCase):
 
         expected_responese = user_query_response
         self.assertEqual(execute_query, expected_responese)
+
+    def test_paginate__users_query(self):
+        response = self.app_test.post('/mrm?query='+paginated_users_query)
+        print("the awaited response is!!!!!!!!!!!!!!!!!!", paginated_users_response)
+        paginate_query = json.loads(response.data)
+        print("the returned response is???????????????????????????", paginate_query)
+        expected_response = paginated_users_response
+        self.assertEqual(paginate_query, expected_response)
 
     def test_query_users_by_email(self):
         user = User(email='mrm@andela.com', location="Lagos")


### PR DESCRIPTION
**What does this PR do?**
Adds a pagination feature to the users query.
Allows queries to be run, with or without pagination.

**Description of the task to be completed**
A user should specify the page number and the items per page when using pagination:

<img width="1049" alt="screen shot 2018-08-13 at 17 35 50" src="https://user-images.githubusercontent.com/26790578/44041261-09f7c4d0-9f26-11e8-812a-fdcd5a7b8252.png">

When pagination is not needed, the query needs to be specified as follows:

<img width="1064" alt="screen shot 2018-08-13 at 17 36 19" src="https://user-images.githubusercontent.com/26790578/44041323-30487f6c-9f26-11e8-8c29-20c4a1524d18.png">

**How should this be manually tested?**
Provide pagination's page and perPage on the users query as shown in the image above (first image)
To test functionality without pagination, just run the query normally (see second image)

**What are related Pivotal Tracker stories?**
Story: Paginate users
Story ID: #159629440