### PR TITLE
#159461602 Change User Roles 

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -167,15 +167,16 @@ class Query(graphene.ObjectType):
         capacity=graphene.Int(),
         resources=graphene.String(),
         location=graphene.String()
-        )
+    )
     get_room_by_id = graphene.Field(
         Room,
         room_id=graphene.Int()
-        )
+    )
+
     get_room_by_name = graphene.List(
         Room,
         name=graphene.String()
-        )
+    )
     get_room_by_id = graphene.Field(
         Room,
         room_id=graphene.Int(),

--- a/fixtures/room/room_fixtures.py
+++ b/fixtures/room/room_fixtures.py
@@ -105,6 +105,62 @@ room_invalid_wingId_mutation = '''
 '''
 
 
+room_invalid_officeId_mutation = '''
+    mutation {
+        createRoom(
+            name: "aso", roomType: "Meeting", capacity: 4, floorId: 1,
+            officeId: 10
+            calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            room {
+                name
+                roomType
+                capacity
+                floorId
+                imageUrl
+            }
+        }
+    }
+'''
+
+room_invalid_floorId_mutation = '''
+    mutation {
+        createRoom(
+            name: "aso", roomType: "Meeting", capacity: 4, floorId: 10,
+            officeId: 1
+            calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            room {
+                name
+                roomType
+                capacity
+                floorId
+                imageUrl
+            }
+        }
+    }
+'''
+
+room_invalid_wingId_mutation = '''
+    mutation {
+        createRoom(
+            name: "aso", roomType: "Meeting", capacity: 4, floorId: 1,
+            wingId: 3
+            officeId: 1
+            calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            room {
+                name
+                roomType
+                capacity
+                floorId
+                imageUrl
+            }
+        }
+    }
+'''
+
+
 rooms_query = '''
 query {
   allRooms{
@@ -168,18 +224,18 @@ paginated_rooms_query = '''
 '''
 
 paginated_rooms_response = {
-  "data": {
-    "allRooms": {
-      "rooms": [
-        {
-          "name": "Entebbe"
+    "data": {
+        "allRooms": {
+            "rooms": [
+                {
+                    "name": "Entebbe"
+                }
+            ],
+            "hasNext": False,
+            "hasPrevious": False,
+            "pages": 1
         }
-      ],
-      "hasNext": False,
-      "hasPrevious": False,
-      "pages": 1
     }
-  }
 }
 
 room_query_by_id = '''
@@ -295,7 +351,7 @@ room_search_by_name_response = {
         "getRoomByName": [
             {
                 "name": "Entebbe"
-                }]
+            }]
     }
 }
 
@@ -310,20 +366,20 @@ room_search_by_empty_name = '''
 room_search_by_empty_name_response = {
     "errors": [
         {
-           "message": "Please input Room Name",
-           "locations": [
-               {
-                   "line": 3,
-                   "column": 5
-                   }
-                   ], "path": [
-                       "getRoomByName"
-                       ]
-                       }
-                       ],  "data": {
-                           "getRoomByName": null
-                           }
-                           }
+            "message": "Please input Room Name",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 5
+                }
+            ], "path": [
+                "getRoomByName"
+            ]
+        }
+    ],  "data": {
+        "getRoomByName": null
+    }
+}
 
 room_search_by_invalid_name = '''
 {
@@ -341,10 +397,10 @@ room_search_by_invalid_name_response = {
                 {
                     "line": 3,
                     "column": 5
-                    }
-                ], "path": [
-                    "getRoomByName"
-                    ]
+                }
+            ], "path": [
+                "getRoomByName"
+            ]
         }
     ], "data": {
         "getRoomByName": null

--- a/fixtures/user_role/user_role_fixtures.py
+++ b/fixtures/user_role/user_role_fixtures.py
@@ -1,3 +1,4 @@
+null = None
 user_role_mutation_query = '''
 mutation{
   createUsersRole(userId: 2, roleId: 1){
@@ -10,14 +11,14 @@ mutation{
 '''
 
 user_role_mutation_response = {
-  "data": {
-    "createUsersRole": {
-      "userRole": {
-        "roleId": 1,
-        "userId": 2
-      }
+    "data": {
+        "createUsersRole": {
+            "userRole": {
+                "roleId": 1,
+                "userId": 2
+            }
+        }
     }
-  }
 }
 
 user_role_query = '''
@@ -30,18 +31,18 @@ query {
 '''
 
 user_role_query_response = {
-  "data": {
-    "usersRole": [
-      {
-        "userId": 1,
-        "roleId": 1
-      },
-      {
-        "userId": 2,
-        "roleId": 1
-      }
-    ]
-  }
+    "data": {
+        "usersRole": [
+            {
+                "userId": 1,
+                "roleId": 1
+            },
+            {
+                "userId": 2,
+                "roleId": 1
+            }
+        ]
+    }
 }
 
 query_user_by_user_id = '''
@@ -54,10 +55,71 @@ query {
 '''
 
 query_user_by_user_id_response = {
-  "data": {
-    "userRole": {
-      "userId": 1,
-      "roleId": 1
+    "data": {
+        "userRole": {
+            "userId": 1,
+            "roleId": 1
+        }
+    }
+}
+
+change_user_role_mutation_query = '''
+mutation{
+  changeUserRole(email:"mrm@andela.com", roleId:1){
+    user{
+      email
+      roles{
+        id
+      }
     }
   }
+}
+'''
+
+change_user_role_mutation_response = {
+    "data": {
+        "changeUserRole": {
+            "user": {
+                "email": "mrm@andela.com",
+                "roles": [
+                    {
+                        "id": "1"
+                    }
+                ]
+            }
+        }
+    }
+}
+
+change_unavailable_user_role_mutation_query = '''
+mutation{
+  changeUserRole(email:"someemail@andela.com", roleId:1){
+    user{
+      email
+      roles{
+        id
+      }
+    }
+  }
+}
+'''
+
+change_unavailable_user_role_mutation_response = {
+    "errors": [
+        {
+            "message": "User not found",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 3
+                }
+            ],
+            "path": [
+                "changeUserRole"
+            ]
+        }
+    ],
+    "data": {
+        "changeUserRole": null
+    }
 }

--- a/tests/test_user_roles/test_query_user_role.py
+++ b/tests/test_user_roles/test_query_user_role.py
@@ -1,14 +1,17 @@
 from tests.base import BaseTestCase
 from fixtures.user_role.user_role_fixtures import (
     user_role_query, user_role_query_response,
-    query_user_by_user_id, query_user_by_user_id_response
+    query_user_by_user_id, query_user_by_user_id_response, change_user_role_mutation_query, change_unavailable_user_role_mutation_query, change_unavailable_user_role_mutation_response,  # noqa E501
+    change_user_role_mutation_response
 )
 from helpers.database import db_session
 from api.user.models import User
 from api.user_role.models import UsersRole
+from fixtures.token.token_fixture import admin_api_token, user_api_token
 
 import sys
 import os
+import json
 sys.path.append(os.getcwd())
 
 
@@ -42,5 +45,52 @@ class TestQueryUserRole(BaseTestCase):
             query_user_by_user_id,
             context_value={'session': db_session})
 
-        expected_responese = query_user_by_user_id_response
-        self.assertEqual(execute_query, expected_responese)
+        expected_response = query_user_by_user_id_response
+        self.assertEqual(execute_query, expected_response)
+
+    def test_change_user_role(self):
+        api_headers = {'token': admin_api_token}
+        user = User(email='mrm@andela.com', location="Lagos")
+        user.save()
+        user_role = UsersRole(user_id=user.id, role_id=1)
+        user_role.save()
+        db_session().commit()
+
+        query_response = self.app_test.post(
+            '/mrm?query='+change_user_role_mutation_query, headers=api_headers)
+        actual_response = json.loads(query_response.data)
+
+        expected_response = change_user_role_mutation_response
+        self.assertEqual(actual_response, expected_response)
+
+    def test_change_unavailable_user_role(self):
+        api_headers = {'token': admin_api_token}
+        user = User(email='mrm@andela.com', location="Lagos")
+        user.save()
+        user_role = UsersRole(user_id=user.id, role_id=1)
+        user_role.save()
+        db_session().commit()
+
+        query_response = self.app_test.post(
+            '/mrm?query='+change_unavailable_user_role_mutation_query,
+            headers=api_headers)
+        actual_response = json.loads(query_response.data)
+
+        expected_response = change_unavailable_user_role_mutation_response
+        self.assertEqual(actual_response, expected_response)
+
+    def test_change_user_role_by_default_user(self):
+        api_headers = {'token': user_api_token}
+        user = User(email='mrm@andela.com', location="Lagos")
+        user.save()
+        user_role = UsersRole(user_id=user.id, role_id=1)
+        user_role.save()
+        db_session().commit()
+
+        query_response = self.app_test.post(
+            '/mrm?query='+change_user_role_mutation_query, headers=api_headers)
+        actual_response = json.loads(query_response.data)
+
+        expected_response = "You are not authorized to perform this action"
+        self.assertEqual(actual_response["errors"][0]["message"],
+                         expected_response)


### PR DESCRIPTION
#### What does this PR do?
 Allow users to have an end point from which the admin can change user roles,
 such as `Default User` to `Admin` and `Admin` to `Default User`
#### How should this be manually tested?
- Run the server
- Test the queries at localhost:5000/mrm
- Run `changeUserRole` mutation with `email` and `roleId` as  the keyword arguments
#### Screenshots 
     When a user performing the action is not an admin.
<img width="1440" alt="screen shot 2018-08-13 at 21 20 09" src="https://user-images.githubusercontent.com/28715887/44050567-f73dc2e4-9f3f-11e8-9dc9-d11f807af259.png">
     When a user whose role is being changed is not available.
<img width="1440" alt="screen shot 2018-08-13 at 21 26 39" src="https://user-images.githubusercontent.com/28715887/44050582-0612c468-9f40-11e8-8f8d-8dcc8b736ff6.png">
     When the correct user is found.
<img width="1440" alt="screen shot 2018-08-13 at 21 31 40" src="https://user-images.githubusercontent.com/28715887/44050650-4bbd38f4-9f40-11e8-9670-3b1314ca9eb6.png">

#### What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/159461602