### PR TITLE
#159652407 fix get rooms in block query

### DIFF
--- a/api/block/schema.py
+++ b/api/block/schema.py
@@ -2,6 +2,8 @@ import graphene
 
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from api.block.models import Block as BlockModel
+from api.room.schema import Room
+from helpers.room_filter.room_filter import room_join_location
 
 
 class Block(SQLAlchemyObjectType):
@@ -12,7 +14,7 @@ class Block(SQLAlchemyObjectType):
 class Query(graphene.ObjectType):
     all_blocks = graphene.List(Block)
     get_rooms_in_a_block = graphene.List(
-        lambda: Block,
+        lambda: Room,
         block_id=graphene.Int()
     )
 
@@ -21,6 +23,7 @@ class Query(graphene.ObjectType):
         return query.all()
 
     def resolve_get_rooms_in_a_block(self, info, block_id):
-        query = Block.get_query(info)
-        result = query.filter(BlockModel.id == block_id)
+        query = Room.get_query(info)
+        new_query = room_join_location(query)
+        result = new_query.filter(BlockModel.id == block_id)
         return result

--- a/fixtures/block/block_fixtures.py
+++ b/fixtures/block/block_fixtures.py
@@ -21,14 +21,8 @@ rooms_in_block_query = '''
     {
         getRoomsInABlock(blockId:1){
             name
-            floors{
-                name
-                rooms{
-                    name
-                    capacity
-                    roomType
-                }
-            }
+            capacity
+            roomType
         }
     }
 '''
@@ -38,19 +32,9 @@ rooms_in_block_query_response = {
     "data": {
         "getRoomsInABlock": [
             {
-                "name": "EC",
-                "floors": [
-                    {
-                        "name": "3rd",
-                        "rooms": [
-                            {
-                                "name": "Entebbe",
-                                "capacity": 6,
-                                "roomType": "meeting"
-                            }
-                        ]
-                    }
-                ]
+                "name": "Entebbe",
+                "capacity": 6,
+                "roomType": "meeting"
             }
         ]
     }


### PR DESCRIPTION
**What does this PR do?**
Ensures that a list of rooms in a block is returned when the query `getRoomsInABlock` is executed. Previously, the block was returned instead, and not the desired output, rooms.

**How should this be tested?**

- Run the server
- Test the queries at localhost:5000/mrm
- Run getRoomsInABlock query

<img width="1038" alt="screen shot 2018-08-16 at 11 39 40" src="https://user-images.githubusercontent.com/26790578/44198487-3db93580-a14a-11e8-9d7f-c0a6ed0ea053.png">

**What are relevant PivotalTracker stories?**
Story: Fix get rooms in block query
Id: #159652407