### PR TITLE
#159817747 Add unique filter for resource instances

### DIFF
--- a/api/room_resource/schema.py
+++ b/api/room_resource/schema.py
@@ -20,8 +20,11 @@ class PaginatedResource(Paginate):
     def resolve_resources(self, info):
         page = self.page
         per_page = self.per_page
+        unique = self.unique
         query = Resource.get_query(info)
         if not page:
+            if unique:
+                return query.distinct(ResourceModel.name).all()
             return query.all()
 
         if page:
@@ -94,8 +97,11 @@ class DeleteResource(graphene.Mutation):
 
 class Query(graphene.ObjectType):
 
-    all_resources = graphene.Field(PaginatedResource, page=graphene.Int(),
-                                   per_page=graphene.Int())
+    all_resources = graphene.Field(
+        PaginatedResource,
+        page=graphene.Int(),
+        per_page=graphene.Int(),
+        unique=graphene.Boolean())
     get_resources_by_room_id = graphene.List(lambda: Resource,
                                              room_id=graphene.Int())
 

--- a/fixtures/room_resource/get_room_resource_fixtures.py
+++ b/fixtures/room_resource/get_room_resource_fixtures.py
@@ -81,3 +81,24 @@ get_room_resources_by_room_id_error = '''
 '''
 
 get_room_resources_by_room_id_error_response = "Room has no resource yet"
+
+filter_unique_resources = '''
+query {
+  allResources(unique: true){
+   resources{
+        name
+        }
+    }
+}
+    '''
+filter_unique_resources_response = {
+    "data": {
+        "allResources": {
+            "resources": [
+                {
+                    "name": "Markers"
+                }
+            ]
+        }
+    }
+}

--- a/helpers/pagination/paginate.py
+++ b/helpers/pagination/paginate.py
@@ -11,6 +11,7 @@ class Paginate(graphene.ObjectType):
     def __init__(self, **kwargs):
         self.page = kwargs.pop('page', None)
         self.per_page = kwargs.pop('per_page', None)
+        self.unique = kwargs.pop('unique', None)
         self.query_total
         self.pages
         self.filter_data = {}

--- a/tests/test_room_resource/test_get_resource_list.py
+++ b/tests/test_room_resource/test_get_resource_list.py
@@ -6,9 +6,11 @@ from tests.base import BaseTestCase
 from fixtures.room_resource.get_room_resource_fixtures import (
     resource_query, resource_query_response, get_room_resources_by_room_id,
     get_room_resources_by_room_id_response, get_room_resources_by_room_id_error,
-    get_room_resources_by_room_id_error_response
+    get_room_resources_by_room_id_error_response,
+    filter_unique_resources, filter_unique_resources_response
 )
 from helpers.database import db_session
+from fixtures.token.token_fixture import (user_api_token)
 
 sys.path.append(os.getcwd())
 
@@ -41,3 +43,10 @@ class TestGetRoomResource(BaseTestCase):
         expected_responese = get_room_resources_by_room_id_response
 
         self.assertEqual(execute_query, expected_responese)
+
+    def test_get_unique_resources(self):
+        api_headers = {'token': user_api_token}
+        response = self.app_test.post(
+            '/mrm?query='+filter_unique_resources, headers=api_headers)
+        actual_response = json.loads(response.data)
+        self.assertEquals(actual_response, filter_unique_resources_response)


### PR DESCRIPTION
### What does this PR do?
This PR enables querying for unique instances of resources

#### How should this be manually tested?

- Run the server

- Test the queries at localhost:5000/mrm

- Run getRoomsInALocation query

#### What are the relevant pivotal tracker stories?
#159817747
#### Screenshots (if appropriate)

When no value is passed
![image](https://user-images.githubusercontent.com/32728156/44208791-2722d680-a16a-11e8-9244-c06629f75366.png)

When a user set Unique to true
![image](https://user-images.githubusercontent.com/32728156/44208861-5a656580-a16a-11e8-9b9d-81b98e82f47e.png)

