### PR TITLE
#159960430 get office by name

### DIFF
--- a/api/office/schema.py
+++ b/api/office/schema.py
@@ -1,8 +1,10 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
+from graphql import GraphQLError
 
 from api.office.models import Office as OfficeModel
 from helpers.auth.authentication import Auth
+from helpers.room_filter.room_filter import office_join_location, lagos_office_join_location  # noqa: E501
 
 
 class Office(SQLAlchemyObjectType):
@@ -21,6 +23,29 @@ class CreateOffice(graphene.Mutation):
         office = OfficeModel(**kwargs)
         office.save()
         return CreateOffice(office=office)
+
+
+class Query(graphene.ObjectType):
+    get_office_by_name = graphene.List(
+        Office,
+        name=graphene.String()
+    )
+
+    def resolve_get_office_by_name(self, info, name):
+        query = Office.get_query(info)
+        check_office = query.filter(OfficeModel.name == name).first()
+        if not check_office:
+            raise GraphQLError("Office Not found")
+
+        if name == "Epic tower":
+            exact_query = lagos_office_join_location(query)
+            result = exact_query.filter(OfficeModel.name == name)
+            return result.all()
+
+        else:
+            exact_query = office_join_location(query)
+            result = exact_query.filter(OfficeModel.name == name)
+            return result.all()
 
 
 class Mutation(graphene.ObjectType):

--- a/api/wing/schema.py
+++ b/api/wing/schema.py
@@ -1,0 +1,18 @@
+import graphene
+
+from graphene_sqlalchemy import (SQLAlchemyObjectType)
+
+from api.wing.models import Wing as WingModel
+
+
+class Wing(SQLAlchemyObjectType):
+    class Meta:
+        model = WingModel
+
+
+class Query(graphene.ObjectType):
+    all_wings = graphene.List(Wing)
+
+    def resolve_all_wings(self, info):
+        query = Wing.get_query(info)
+        return query.all()

--- a/fixtures/office/office_fixtures.py
+++ b/fixtures/office/office_fixtures.py
@@ -29,3 +29,42 @@ office_mutation_response = {
         }
     }
 }
+
+get_office_by_name = '''
+query{
+    getOfficeByName(name:"St. Catherines"){
+        name
+        id
+        blocks{
+            name
+            floors{
+                name
+                id
+                rooms{
+                name
+                  id
+                    }
+                    }
+                    }
+                }
+        }
+'''
+
+get_office_by_name_response = {
+    'data': {
+        'getOfficeByName': [{
+            'name': 'St. Catherines',
+            'id': '1',
+            'blocks': [{
+                'name': 'EC',
+                'floors': [{
+                    'name': '3rd',
+                    'id': '1',
+                    'rooms': [{
+                       'name': 'Entebbe',
+                       'id': '1'}]
+                }]
+            }]
+        }]
+    }
+    }

--- a/helpers/auth/validator.py
+++ b/helpers/auth/validator.py
@@ -2,7 +2,7 @@ import re
 
 
 def check_office_name(office_name):
-    return bool(re.match('^(epic\s?towers?||the\s?crest)$',
+    return bool(re.match('^(epic\s?towers?||the\s?crest)$',  # noqa: E501
                          office_name, re.IGNORECASE))
 
 

--- a/helpers/room_filter/room_filter.py
+++ b/helpers/room_filter/room_filter.py
@@ -4,6 +4,7 @@ from api.floor.models import Floor
 from api.block.models import Block
 from api.office.models import Office
 from api.location.models import Location
+from api.wing.models import Wing
 
 
 def resource_join_location(query):
@@ -35,6 +36,21 @@ def room_join_location(query):
     query_office = query_block.join(Office)
     query_location = query_office.join(Location)
     return query_location
+
+
+def office_join_location(query):
+    query_floor = query.join(Floor.rooms)
+    query_block = query_floor.join(Block)
+    query_office = query_block.join(Office)
+    query_location = query_office.join(Location)
+    return query_location
+
+
+def lagos_office_join_location(query):
+    query_block = query.join(Block)
+    query_floor = query_block.join(Floor)
+    query_wing = query_floor.join(Wing)
+    return query_wing
 
 
 def room_filter(query, filter_data):

--- a/schema.py
+++ b/schema.py
@@ -9,6 +9,7 @@ import api.user.schema
 import api.user_role.schema
 import api.devices.schema
 import api.office.schema
+import api.wing.schema
 
 
 class Query(
@@ -21,6 +22,8 @@ class Query(
     api.user.schema.Query,
     api.user_role.schema.Query,
     api.devices.schema.Query,
+    api.office.schema.Query,
+    api.wing.schema.Query
 ):
     pass
 

--- a/tests/test_office/test_get_office_by_name.py
+++ b/tests/test_office/test_get_office_by_name.py
@@ -1,0 +1,20 @@
+import sys
+import os
+import json
+
+from tests.base import BaseTestCase
+from fixtures.token.token_fixture import user_api_token
+from fixtures.office.office_fixtures import (
+    get_office_by_name,
+    get_office_by_name_response)
+
+sys.path.append(os.getcwd())
+
+
+class GetOfficeByName(BaseTestCase):
+    def test_get_office_by_name(self):
+        api_headers = {'token': user_api_token}
+        get_office_query = self.app_test.post(
+            '/mrm?query='+get_office_by_name, headers=api_headers)
+        actual_response = json.loads(get_office_query.data)
+        self.assertEquals(actual_response, get_office_by_name_response)


### PR DESCRIPTION
### What does this PR do?

- This PR allows a user to get room by name.

#### How should this be manually tested?
- Run the server.
- Test the queries at localhost:5000/mrm
- Run `getOfficeByName` query with specified office name as the argument.
- `Epic tower` office should be able to populate `wings` within a floor from the query.
- `St. Catherine` and `The crest` offices should be able to populate `blocks` and `floors` from the query.

### What are the relevant pivotal tracker stories?

#159960430

#### Screenshots

###### St. Catherine office
<img width="907" alt="dojo" src="https://user-images.githubusercontent.com/6715848/44655495-fb231300-a9fd-11e8-8f49-8c6aba1f36ab.png">

###### The Crest Office
<img width="918" alt="the crest" src="https://user-images.githubusercontent.com/6715848/44655504-037b4e00-a9fe-11e8-9289-072b6c54efcd.png">

###### Epic Tower Office
<img width="921" alt="epic tower" src="https://user-images.githubusercontent.com/6715848/44655512-0bd38900-a9fe-11e8-8bc8-82e4434ec1f7.png">
