### PR TITLE
#160128227 Make temporary use of andela-learning project on Google Cloud Platform(GCP) for converge backend.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
       - run:
           name: Deploy to gcloud
-          command: gcloud beta compute instance-groups managed rolling-action replace mrm-staging-backend-instance-group --region europe-west1
+          command: gcloud beta compute instance-groups managed rolling-action replace mrm-staging-frontend-instance-group --zone europe-west1-b
 
 workflows:
   version: 2


### PR DESCRIPTION
**What does this PR do?**
This PR ensures the temporary use of andela-learning project on Google Cloud Platform

**Description of Task to be completed?**
Project should be deployed to `andela-learning` instead of `learning-map`

**What are the relevant pivotal tracker stories?**
#160128227