### PR TITLE
#160235030 Delete office mutation

### DIFF
--- a/api/office/schema.py
+++ b/api/office/schema.py
@@ -32,6 +32,24 @@ class CreateOffice(graphene.Mutation):
         return CreateOffice(office=office)
 
 
+class DeleteOffice(graphene.Mutation):
+
+    class Arguments:
+        office_id = graphene.Int(required=True)
+    office = graphene.Field(Office)
+
+    @Auth.user_roles('Admin')
+    def mutate(self, info, office_id, **kwargs):
+        query_office = Office.get_query(info)
+        exact_office = query_office.filter(OfficeModel.id == office_id).first()  # noqa: E501
+        if not exact_office:
+            raise GraphQLError("Office not found")
+
+        admin_roles.delete_office(office_id)
+        exact_office.delete()
+        return DeleteOffice(office=exact_office)
+
+
 class Query(graphene.ObjectType):
     get_office_by_name = graphene.List(
         Office,
@@ -57,3 +75,4 @@ class Query(graphene.ObjectType):
 
 class Mutation(graphene.ObjectType):
     create_office = CreateOffice.Field()
+    delete_office = DeleteOffice.Field()

--- a/fixtures/location/all_locations_fixtures.py
+++ b/fixtures/location/all_locations_fixtures.py
@@ -47,7 +47,12 @@ expected_query_all_locations = {
         {
             "name": "Nairobi",
             "abbreviation": "NBO",
-            "offices": []
+            "offices": [
+                {
+                    "name": "dojo",
+                    "blocks": []
+                }
+            ]
         }]
     }
 }

--- a/fixtures/office/office_fixtures.py
+++ b/fixtures/office/office_fixtures.py
@@ -98,3 +98,35 @@ office_mutation_query_non_existant_ID = '''
         }
     }
 '''
+
+delete_office_mutation = '''
+mutation{
+    deleteOffice(officeId: 1){
+        office{
+            name
+        }
+    }
+}
+'''
+
+delete_non_existent_office_mutation = '''
+
+mutation{
+    deleteOffice(officeId: 10){
+        office{
+            name
+        }
+    }
+}
+
+'''
+
+delete_unauthorised_location_mutation = '''
+mutation{
+    deleteOffice(officeId: 2){
+        office{
+            name
+        }
+    }
+}
+'''

--- a/helpers/auth/admin_roles.py
+++ b/helpers/auth/admin_roles.py
@@ -50,5 +50,12 @@ class Admin_roles():
         if admin_details.location != resource_location.name:
             raise GraphQLError("You are not authorized to make changes in " + resource_location.name)  # noqa: E501
 
+    def delete_office(self, office_id):
+        admin_details = get_user_from_db()
+        get_office = Office.query.filter_by(id=office_id).first()
+        location = Location.query.filter_by(id=get_office.location_id).first()
+        if admin_details.location != location.name:
+            raise GraphQLError("You are not authorized to delete an office in " + location.name)  # noqa: E501
+
 
 admin_roles = Admin_roles()

--- a/schema.py
+++ b/schema.py
@@ -36,7 +36,7 @@ class Mutation(
     api.user_role.schema.Mutation,
     api.devices.schema.Mutation,
     api.location.schema.Mutation,
-    api.office.schema.Mutation,
+    api.office.schema.Mutation
 ):
     pass
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -51,6 +51,8 @@ class BaseTestCase(TestCase):
             location_two.save()
             office = Office(name="St. Catherines", location_id=location.id)
             office.save()
+            office_two = Office(name="dojo", location_id=location_two.id)
+            office_two.save()
             block = Block(name='EC', office_id=office.id)
             block.save()
             floor = Floor(name='3rd', block_id=block.id)

--- a/tests/test_office/test_delete_office.py
+++ b/tests/test_office/test_delete_office.py
@@ -1,0 +1,26 @@
+from tests.base import BaseTestCase
+
+from fixtures.office.office_fixtures import (delete_office_mutation,
+delete_non_existent_office_mutation,
+delete_unauthorised_location_mutation)  # noqa: E501
+from fixtures.token.token_fixture import admin_api_token
+
+
+class TestDeleteOffice(BaseTestCase):
+    def test_delete_office(self):
+        api_headers = {'token': admin_api_token}
+        response = self.app_test.post('/mrm?query='+delete_office_mutation,
+                                      headers=api_headers)
+        self.assertIn("St. Catherines", str(response.data))
+
+    def test_delete_non_existent_office(self):
+        api_headers = {'token': admin_api_token}
+        response = self.app_test.post('/mrm?query='+delete_non_existent_office_mutation,  # noqa: E501
+                                      headers=api_headers)
+        self.assertIn("Office not found", str(response.data))
+
+    def test_delete_unautorised_location(self):
+        api_headers = {'token': admin_api_token}
+        response = self.app_test.post('mrm?query='+delete_unauthorised_location_mutation,  # noqa: E501
+                                      headers=api_headers)
+        self.assertIn("You are not authorized to delete an office in Nairobi", str(response.data))  # noqa: E501


### PR DESCRIPTION
### What does this PR do?

- This PR allows an admin to delete an office within his location.

#### How should this be manually tested?
- Run the server.
- Test the mutation at localhost:5000/mrm
- Run `deleteOffice` mutation with an `officeId` as the argument.

### What are the relevant pivotal tracker stories?

#160235030

#### Screenshots

###### deleting an office e.g the crest.
<img width="913" alt="success" src="https://user-images.githubusercontent.com/6715848/45018985-d9e0a900-b033-11e8-881e-decb83a93040.png">



###### When not authorised to delete.
<img width="1093" alt="notauthorised" src="https://user-images.githubusercontent.com/6715848/45019001-e36a1100-b033-11e8-929a-84cb1479ac01.png">



###### When office does not exist.
<img width="912" alt="officenotfound" src="https://user-images.githubusercontent.com/6715848/45019014-eebd3c80-b033-11e8-9950-433ff42d4fec.png">



