### PR TITLE
#160193993 Add error handling for Roles and Users

### DIFF
--- a/api/role/schema.py
+++ b/api/role/schema.py
@@ -2,6 +2,7 @@ import graphene
 
 from graphene_sqlalchemy import (SQLAlchemyObjectType)
 from api.role.models import Role as RoleModel
+from helpers.auth.error_handler import SaveContextManager
 
 
 class Role(SQLAlchemyObjectType):
@@ -18,9 +19,8 @@ class CreateRole(graphene.Mutation):
 
     def mutate(self, info, **kwargs):
         role = RoleModel(**kwargs)
-        role.save()
-
-        return CreateRole(role=role)
+        with SaveContextManager(role, kwargs.get('role'), 'Role'):
+            return CreateRole(role=role)
 
 
 class Query(graphene.ObjectType):

--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -8,6 +8,7 @@ from helpers.auth.user_details import get_user_from_db
 from helpers.auth.authentication import Auth
 from helpers.auth.validator import verify_email
 from helpers.pagination.paginate import Paginate, validate_page
+from helpers.auth.error_handler import SaveContextManager
 
 
 class User(SQLAlchemyObjectType):
@@ -27,9 +28,8 @@ class CreateUser(graphene.Mutation):
 
     def mutate(self, info, **kwargs):
         user = UserModel(**kwargs)
-        user.save()
-
-        return CreateUser(user=user)
+        with SaveContextManager(user, kwargs.get('email'), 'User email'):
+            return CreateUser(user=user)
 
 
 class PaginatedUsers(Paginate):

--- a/fixtures/role/role_fixtures.py
+++ b/fixtures/role/role_fixtures.py
@@ -1,3 +1,5 @@
+null = None
+
 role_mutation_query = '''
 mutation {
   createRole(role:"DevOps"){
@@ -9,13 +11,33 @@ mutation {
 '''
 
 role_mutation_response = {
-  "data": {
-    "createRole": {
-      "role": {
-        "role": "DevOps"
-      }
+    "data": {
+        "createRole": {
+            "role": {
+                "role": "DevOps"
+            }
+        }
     }
-  }
+}
+
+role_duplication_mutation_response = {
+    "errors": [
+        {
+            "message": "DevOps Role already exists",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 3
+                }
+            ],
+            "path": [
+                "createRole"
+            ]
+        }
+    ],
+    "data": {
+        "createRole": null
+    }
 }
 
 role_query = '''
@@ -27,16 +49,16 @@ query {
 '''
 
 role_query_response = {
-  "data": {
-    "roles": [
-      {
-        "role": "Admin"
-      },
-      {
-        "role": "Ops"
-      }
-    ]
-  }
+    "data": {
+        "roles": [
+            {
+                "role": "Admin"
+            },
+            {
+                "role": "Ops"
+            }
+        ]
+    }
 }
 
 query_role_by_role = '''
@@ -48,9 +70,9 @@ query_role_by_role = '''
 '''
 
 query_role_by_role_response = {
-  "data": {
-    "role": {
-      "role": "Ops"
+    "data": {
+        "role": {
+            "role": "Ops"
+        }
     }
-  }
 }

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -1,3 +1,5 @@
+null = None
+
 user_mutation_query = '''
 mutation {
   createUser(email: "mrm@andela.com", location: "Lagos",
@@ -14,16 +16,36 @@ mutation {
 '''
 
 user_mutation_response = {
-  "data": {
-    "createUser": {
-      "user": {
-        "email": "mrm@andela.com",
-        "location": "Lagos",
-        "name": "this user",
-        "picture": "www.andela.com/user"
-      }
+    "data": {
+        "createUser": {
+            "user": {
+                "email": "mrm@andela.com",
+                "location": "Lagos",
+                "name": "this user",
+                "picture": "www.andela.com/user"
+            }
+        }
     }
-  }
+}
+
+user_duplication_mutation_response = {
+    "errors": [
+        {
+            "message": "mrm@andela.com User email already exists",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 3
+                }
+            ],
+            "path": [
+                "createUser"
+            ]
+        }
+    ],
+    "data": {
+        "createUser": null
+    }
 }
 
 user_query = '''
@@ -38,20 +60,20 @@ query {
 '''
 
 user_query_response = {
-  "data": {
-    "users": {
-      "users": [
-        {
-          "email": "peter.walugembe@andela.com",
-          "location": "Kampala"
-        },
-        {
-          "email": "mrm@andela.com",
-          "location": "Lagos"
-        },
-      ]
+    "data": {
+        "users": {
+            "users": [
+                {
+                    "email": "peter.walugembe@andela.com",
+                    "location": "Kampala"
+                },
+                {
+                    "email": "mrm@andela.com",
+                    "location": "Lagos"
+                },
+            ]
+        }
     }
-  }
 }
 
 paginated_users_query = '''
@@ -69,19 +91,19 @@ query {
 '''
 
 paginated_users_response = {
-  "data": {
-    "users": {
-      "users": [
-        {
-          "email": "peter.walugembe@andela.com",
-          "location": "Kampala"
+    "data": {
+        "users": {
+            "users": [
+                {
+                    "email": "peter.walugembe@andela.com",
+                    "location": "Kampala"
+                }
+            ],
+            "hasNext": False,
+            "hasPrevious": False,
+            "pages": 1
         }
-      ],
-      "hasNext": False,
-      "hasPrevious": False,
-      "pages": 1
     }
-  }
 }
 
 query_user_by_email = '''
@@ -94,10 +116,10 @@ query_user_by_email = '''
 '''
 
 query_user_email_response = {
-  "data": {
-    "user": {
-      "email": "mrm@andela.com",
-      "location": "Lagos"
+    "data": {
+        "user": {
+            "email": "mrm@andela.com",
+            "location": "Lagos"
+        }
     }
-  }
 }

--- a/helpers/auth/error_handler.py
+++ b/helpers/auth/error_handler.py
@@ -1,0 +1,23 @@
+from sqlalchemy import exc
+from helpers.auth.validator import ErrorHandler
+
+
+class SaveContextManager():
+    '''Manage sqlalchemy exceptions.'''
+
+    def __init__(self, model_obj, entity_name, entity):
+        self.model_obj = model_obj
+        self.entity_name = entity_name
+        self.entity = entity
+
+    def __enter__(self):
+        try:
+            self.model_obj.save()
+        except exc.IntegrityError:
+            return ErrorHandler.check_conflict(
+                self, self.entity_name, self.entity)
+        except exc.DBAPIError:
+            return ErrorHandler.db_connection(self)
+
+    def __exit__(self, type, value, traceback):
+        return False

--- a/helpers/auth/validator.py
+++ b/helpers/auth/validator.py
@@ -1,4 +1,5 @@
 import re
+from graphql import GraphQLError
 
 
 def check_office_name(office_name):
@@ -17,4 +18,17 @@ def assert_wing_is_required(office, kwargs):
 
 def verify_email(email):
     return bool(re.match('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$',
-                email))
+                         email))
+
+
+class ErrorHandler():
+    '''Handles error'''
+
+    def check_conflict(self, entity_name, entity):
+        # Database integrity error
+        raise GraphQLError(
+            '{} {} already exists'.format(entity_name, entity))
+
+    def db_connection(self):
+        # Database connection error
+        raise GraphQLError('Error: Could not connect to Db')

--- a/tests/test_role/test_create_role.py
+++ b/tests/test_role/test_create_role.py
@@ -1,6 +1,7 @@
 from tests.base import BaseTestCase
 from fixtures.role.role_fixtures import (
-   role_mutation_query, role_mutation_response
+    role_mutation_query, role_mutation_response,
+    role_duplication_mutation_response
 )
 from helpers.database import db_session
 import sys
@@ -20,3 +21,16 @@ class TestCreateRole(BaseTestCase):
 
         expected_responese = role_mutation_response
         self.assertEqual(execute_query, expected_responese)
+
+    def test_role_duplication(self):
+        """
+        Testing for creation of an already existing role
+        """
+        self.client.execute(role_mutation_query,
+                            context_value={'session': db_session})
+        # Try to create a role twice
+        query_response = self.client.execute(
+            role_mutation_query, context_value={'session': db_session})
+
+        expected_responese = role_duplication_mutation_response
+        self.assertEqual(query_response, expected_responese)

--- a/tests/test_user/test_create_user.py
+++ b/tests/test_user/test_create_user.py
@@ -1,6 +1,7 @@
 from tests.base import BaseTestCase
 from fixtures.user.user_fixture import (
-    user_mutation_query, user_mutation_response
+    user_mutation_query, user_mutation_response,
+    user_duplication_mutation_response
 )
 from helpers.database import db_session
 
@@ -19,5 +20,19 @@ class TestCreateUser(BaseTestCase):
             user_mutation_query,
             context_value={'session': db_session})
 
-        expected_responese = user_mutation_response
-        self.assertEqual(execute_query, expected_responese)
+        expected_response = user_mutation_response
+        self.assertEqual(execute_query, expected_response)
+
+    def test_user_duplication(self):
+        """
+        Testing for creation of an already existing user
+        """
+        self.client.execute(user_mutation_query,
+                            context_value={'session': db_session})
+        # Try to create a user twice
+        query_response = self.client.execute(
+            user_mutation_query,
+            context_value={'session': db_session})
+
+        expected_response = user_duplication_mutation_response
+        self.assertEqual(query_response, expected_response)


### PR DESCRIPTION
#### What does this PR do?
This PR handle conflict/duplication error for already existing Roles and Users

#### How should this be manually tested?
- Run the server.    
- Test the queries at `localhost:5000/mrm`
- Run createUser mutation with an existing user email
- Run createRole mutation with an existing role name

#### What are the relevant pivotal tracker stories?
[Error handling](https://www.pivotaltracker.com/n/projects/2154921/stories/160193993)

#### Screenshots
##### createUser error snapshot
![image](https://user-images.githubusercontent.com/22454909/45021127-6fcb0280-b039-11e8-897f-631bd0a24262.png)

##### createRole error snapshot
![image](https://user-images.githubusercontent.com/22454909/45021256-c0426000-b039-11e8-9f48-a0666cb1f628.png)
