### PR TITLE
#160235195 Update Create Room Mutation to include Block_id and Wing_id

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -5,6 +5,8 @@ from graphql import GraphQLError
 
 from api.room.models import Room as RoomModel
 from api.office.models import Office
+from api.block.models import Block
+from api.floor.models import Floor
 from helpers.calendar.events import RoomSchedules
 from utilities.utility import validate_empty_fields, update_entity_fields
 from helpers.auth.authentication import Auth
@@ -41,29 +43,40 @@ class CreateRoom(graphene.Mutation):
         calendar_id = graphene.String()
         office_id = graphene.Int(required=True)
         wing_id = graphene.Int()
+        block_id = graphene.Int()
     room = graphene.Field(Room)
 
     @Auth.user_roles('Admin')
     def mutate(self, info, office_id, **kwargs):
         verify_attributes(kwargs)
-        verify_ids(kwargs, office_id)
+        verify_ids(office_id, kwargs)
         get_office = Office.query.filter_by(id=office_id).first()
         if not get_office:
             raise GraphQLError("No Office Found")
 
-        admin_roles.create_rooms_update_delete_office(office_id)
-        query = Room.get_query(info)
-        exact_query = room_join_office(query)
-        result = exact_query.filter(
-            Office.id == office_id, RoomModel.name == kwargs.get('name'))
-        if result.count() > 0:
-            ErrorHandler.check_conflict(self, kwargs['name'], 'Room')
-
-        assert_wing_is_required(get_office.name, kwargs)
-        room = RoomModel(**kwargs)
-        room.save()
-
-        return CreateRoom(room=room)
+        if 'block_id' in kwargs:
+            exact_block = Block.query.filter_by(id=kwargs['block_id']).first()
+            if not exact_block:
+                raise GraphQLError("Block with such id does not exist")
+            floor = Floor.query.filter_by(id=kwargs['floor_id']).first()
+            if floor.block_id == kwargs['block_id']:
+                admin_roles.create_rooms_update_delete_office(office_id)
+                query = Room.get_query(info)
+                exact_query = room_join_office(query)
+                result = exact_query.filter(
+                    Office.id == office_id,
+                    RoomModel.name == kwargs.get('name'))
+                if result.count() > 0:
+                    ErrorHandler.check_conflict(self, kwargs['name'], 'Room')
+                assert_wing_is_required(get_office.name, kwargs)
+                kwargs.pop('block_id')
+                room = RoomModel(**kwargs)
+                room.save()
+                return CreateRoom(room=room)
+            raise GraphQLError(
+                "Floor with such id does not exist in this block")
+        raise GraphQLError(
+            "Block id is required")
 
 
 class PaginatedRooms(Paginate):

--- a/fixtures/helpers/decorators_fixtures.py
+++ b/fixtures/helpers/decorators_fixtures.py
@@ -36,6 +36,7 @@ room_mutation_query = '''
           capacity: 1,
           officeId: 1
           floorId: 1,
+          blockId: 1,
           imageUrl: "http://url.com") {
             room {
                 name

--- a/fixtures/room/create_room_fixtures.py
+++ b/fixtures/room/create_room_fixtures.py
@@ -214,6 +214,7 @@ room_mutation_query_duplicate_name = '''
     mutation {
         createRoom(
             name: "Entebbe", roomType: "Meeting", capacity: 4, floorId: 1, officeId: 1
+            blockId: 1
             calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
             imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") { # noqa: E501
             room {

--- a/fixtures/room/create_room_in_block_fixtures.py
+++ b/fixtures/room/create_room_in_block_fixtures.py
@@ -1,0 +1,52 @@
+room_valid_blockId_mutation = '''
+    mutation {
+        createRoom(
+            name: "aso", roomType: "Meeting", capacity: 4, floorId: 1,
+            blockId: 1
+            officeId: 1
+            calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            room {
+                name
+                roomType
+                capacity
+                floorId
+                floor{
+                    blockId}
+            }
+        }
+    }
+'''
+expected_room_valid_blockId_mutation_response = {
+    "data": {
+        "createRoom": {
+            "room": {
+                "name": "aso",
+                "roomType": "Meeting",
+                "capacity": 4,
+                "floorId": 1,
+                "floor": {
+                     "blockId": 1
+                     }
+                     }
+                     }
+        }}
+
+room_invalid_blockId_mutation = '''
+    mutation {
+        createRoom(
+            name: "aso", roomType: "Meeting", capacity: 4, floorId: 1,
+            blockId: 3
+            officeId: 1
+            calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            room {
+                name
+                roomType
+                capacity
+                floorId
+                imageUrl
+            }
+        }
+    }
+'''

--- a/helpers/auth/verify_ids_for_room.py
+++ b/helpers/auth/verify_ids_for_room.py
@@ -3,7 +3,7 @@ from api.floor.models import Floor
 from api.wing.models import Wing
 
 
-def verify_ids(kwargs, office_id):
+def verify_ids(office_id, kwargs):
     get_office = Office.query.filter_by(id=office_id).first()
     if not get_office:
         raise AttributeError("Office Id does not exist")

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -9,8 +9,11 @@ from fixtures.helpers.decorators_fixtures import (
 from fixtures.room.create_room_fixtures import (
     room_name_empty_mutation, room_invalid_officeId_mutation,
     room_invalid_floorId_mutation, room_invalid_wingId_mutation,
-    room_mutation_query_duplicate_name, room_mutation_query_duplicate_name_response)   # noqa : E501
-
+    room_mutation_query_duplicate_name,
+    room_mutation_query_duplicate_name_response)   # noqa : E501
+from fixtures.room.create_room_in_block_fixtures import (
+    room_valid_blockId_mutation, room_invalid_blockId_mutation,
+    expected_room_valid_blockId_mutation_response)
 
 sys.path.append(os.getcwd())
 
@@ -87,3 +90,27 @@ class TestCreateRoom(BaseTestCase):
         expected_response = room_mutation_query_duplicate_name_response
         actual_response = json.loads(response.data)
         self.assertEqual(expected_response, actual_response)
+
+    def test_room_creation_with_valid_blockId(self):
+        """
+        Test room creation with  invalid officeId
+        """
+        api_headers = {'token': admin_api_token}
+        response = self.app_test.post(
+            '/mrm?query='+room_valid_blockId_mutation, headers=api_headers)
+        actual_response = json.loads(response.data)
+        expected_response = expected_room_valid_blockId_mutation_response
+        self.assertEquals(
+            actual_response, expected_response)
+
+    def test_room_creation_with_invalid_blockId(self):
+        """
+        Test room creation with  invalid wingId
+        """
+        api_headers = {'token': admin_api_token}
+        response = self.app_test.post(
+            '/mrm?query='+room_invalid_blockId_mutation, headers=api_headers)
+        actual_response = json.loads(response.data)
+        expected_response = "Block with such id does not exist"
+        self.assertEquals(
+            actual_response["errors"][0]["message"], expected_response)


### PR DESCRIPTION
#### What does this PR do?
 Enable `createRoom` mutation for Nairobi to include `blockId`, and `createRoom` mutation for Lagos to include `wingId` when admin creates a meeting room
#### How should this be manually tested?
- Clone this branch in your local machine, Run the server
- Test the queries at localhost:5000/mrm
- Run `createRoom` mutation with `blockId` when the office is Nairobi or `wingId` when the office is Lagos in the keyword arguments
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/160127115
#### Screenshots 
     When an admin runs the mutation with block id.
<img width="1440" alt="screen shot 2018-09-06 at 11 07 44" src="https://user-images.githubusercontent.com/28715887/45143906-4212c480-b1c5-11e8-916e-3f2b74a1a927.png">
     When an admin runs the mutation with wing id.
<img width="1440" alt="screen shot 2018-09-06 at 12 22 43" src="https://user-images.githubusercontent.com/28715887/45148328-b3f00b80-b1cf-11e8-8400-1981627cfeed.png">

