### PR TITLE
#160514243 Add query for offices

### DIFF
--- a/fixtures/office/office_fixtures.py
+++ b/fixtures/office/office_fixtures.py
@@ -160,3 +160,77 @@ mutation{
     }
 }
 '''
+
+paginated_offices_query = '''
+query {
+    allOffices(page:1, perPage:2){
+        offices{
+            name
+            id
+        }
+        hasNext
+        hasPrevious
+        pages
+    }
+}
+'''
+offices_query_response = {
+    "data": {
+        "allOffices": {
+            "offices": [
+                {
+                    "name": "St. Catherines",
+                    "id": "1"
+                },
+                {
+                    "name": "dojo",
+                    "id": "2"
+                }
+            ],
+            "hasNext": False,
+            "hasPrevious": False,
+            "pages": 1
+        }
+    }
+}
+
+offices_query = '''
+query {
+    allOffices{
+        offices{
+            name
+            id
+        }
+    }
+}
+'''
+all_offices_query_response = {
+    "data": {
+        "allOffices": {
+            "offices": [
+                {
+                    "name": "St. Catherines",
+                    "id": "1"
+                },
+                {
+                    "name": "dojo",
+                    "id": "2"
+                }
+            ]
+        }
+    }
+}
+
+paginated_offices_non_existing_page_query = '''
+query {
+    allOffices(page:2, perPage:2){
+        offices{
+            name
+            id
+        }
+        hasNext
+        hasPrevious
+        pages
+    }
+}
+'''

--- a/tests/test_office/test_query_offices.py
+++ b/tests/test_office/test_query_offices.py
@@ -1,0 +1,29 @@
+import json
+
+from tests.base import BaseTestCase
+from fixtures.office.office_fixtures import (
+    paginated_offices_query,
+    offices_query_response,
+    offices_query,
+    all_offices_query_response,
+    paginated_offices_non_existing_page_query
+    )
+
+
+class QueryOffice(BaseTestCase):
+
+    def test_paginate_office_query(self):
+        response = self.app_test.post('/mrm?query='+paginated_offices_query)
+        paginate_query = json.loads(response.data)
+        expected_response = offices_query_response
+        self.assertEqual(paginate_query, expected_response)
+
+    def test_office_query(self):
+        response = self.app_test.post('/mrm?query='+offices_query)
+        paginate_query = json.loads(response.data)
+        expected_response = all_offices_query_response
+        self.assertEqual(paginate_query, expected_response)
+
+    def test_office_non_existing_page_paginated_query(self):
+        response = self.app_test.post('/mrm?query='+paginated_offices_non_existing_page_query)  # noqa: E501
+        self.assertIn("No more offices", str(response.data))


### PR DESCRIPTION

### What does this PR do?
The PR ensure Users can query for Offices

#### How should this be manually tested?
Run the server

Test the queries at localhost:5000/mrm

#### What are the relevant pivotal tracker stories?
[Delivers #160514243]
#### Screenshots (if appropriate)
All Offices
![image](https://user-images.githubusercontent.com/32728156/45585767-b3075a00-b8f2-11e8-9e4a-59cac5a8a371.png)

All Offices paginated
![image](https://user-images.githubusercontent.com/32728156/45585769-bac6fe80-b8f2-11e8-821a-7181da4ed777.png)
