### PR TITLE
#160445879 Analytics for the least used room per week

### DIFF
--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -76,7 +76,6 @@ class RoomAnalytics(Credentials):
         event_details = {}
         if event.get('attendees'):
             for resource in event.get('attendees'):
-
                 if resource.get('resource') and resource.get('email') == calendar_id:  # noqa: E501
                     event_details["minutes"] = RoomAnalytics.get_time_duration_for_event(  # noqa: E501
                         self, event['start'].get(
@@ -105,7 +104,7 @@ class RoomAnalytics(Credentials):
                         result.append(output)
             elif len(room_details) == number_of_events_in_room and 'has_events' not in room_details[0].keys():  # noqa: E501
                 events_count = Counter(detail['minutes']
-                                       for detail in room_details if 'minutes' in detail.keys())  # noqa: E501
+                                       for detail in room_details if detail)
                 duration_of_events_in_room = [
                     EventsDuration(
                         duration_in_minutes=event_duration,

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -17,32 +17,34 @@ from fixtures.room.room_analytics_fixtures import (
 
 class QueryRoomsAnalytics(BaseTestCase):
 
-    api_headers = {"Authorization": "Bearer" + " " + admin_api_token}
-
     def test_most_used_room_in_a_month_analytics(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
         response = self.app_test.post(
-            '/mrm?query=' + get_most_used_room_in_a_month_analytics_query, headers=self.api_headers)  # noqa: E501
+            '/mrm?query=' + get_most_used_room_in_a_month_analytics_query, headers=headers)  # noqa: E501
         actual_response = json.loads(response.data)
         expected_response = get_most_used_room_in_a_month_analytics_response
         self.assertEquals(actual_response, expected_response)
 
     def test_most_used_room_in_a_month_invalid_location_analytics(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
         response = self.app_test.post(
-            '/mrm?query=' + most_used_room_in_a_month_analytics_invalid_location_query, headers=self.api_headers)  # noqa: E501
+            '/mrm?query=' + most_used_room_in_a_month_analytics_invalid_location_query, headers=headers)  # noqa: E501
         actual_response = json.loads(response.data)
         expected_response = most_used_room_in_a_month_analytics_invalid_location_response  # noqa: E501
         self.assertEquals(actual_response, expected_response)
 
     def test_analytics_for_least_used_room_weekly(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
         analytics_query = self.app_test.post(
-            '/mrm?query=' + get_least_used_room_per_week_query, headers=self.api_headers)  # noqa: E501
+            '/mrm?query=' + get_least_used_room_per_week_query, headers=headers)  # noqa: E501
         actual_response = json.loads(analytics_query.data)
         expected_response = get_least_used_room_per_week_response
         self.assertEquals(actual_response, expected_response)
 
     def test_analytics_for_least_used_room_without_event_weekly(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
         analytics_query = self.app_test.post(
-            '/mrm?query=' + get_least_used_room_without_event_query, headers=self.api_headers)  # noqa: E501
+            '/mrm?query=' + get_least_used_room_without_event_query, headers=headers)  # noqa: E501
         actual_response = json.loads(analytics_query.data)
         expected_response = get_least_used_room_without_event_response
         self.assertEquals(actual_response, expected_response)


### PR DESCRIPTION
#### What does this PR do?
This PR handle analytics for the least used room per week

#### How should this be manually tested?
- Run the server.    
- Test the queries at `localhost:5000/mrm`
- Run `analyticsForRoomLeastUsedPerWeek` query with following params.  
    - `locationId`
    - `weekStart`
    - `weekEnd`

#### What are the relevant pivotal tracker stories?
[Analytics for the least used room per week](https://www.pivotaltracker.com/n/projects/2154921/stories/160445879)

#### Screenshots 
##### Snapshot of a period where all rooms have events booked
![image](https://user-images.githubusercontent.com/22454909/46005539-201eaa80-c0be-11e8-8d9a-2d1c669ea33c.png)

##### Snapshot of a period where some rooms have no events booked
![image](https://user-images.githubusercontent.com/22454909/46005599-46dce100-c0be-11e8-9ada-3e1c1019004c.png)
