### PR TITLE
#160447468 Analytics of the most used room in a month

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -188,6 +188,13 @@ class Query(graphene.ObjectType):
         week_end=graphene.String(),
     )
 
+    most_used_room_per_month_analytics = graphene.Field(
+        Analytics,
+        location_id=graphene.Int(),
+        month=graphene.String(),
+        year=graphene.Int(),
+    )
+
     def check_valid_calendar_id(self, query, calendar_id):
         check_calendar_id = query.filter(
             RoomModel.calendar_id == calendar_id
@@ -243,6 +250,15 @@ class Query(graphene.ObjectType):
         room_analytics = RoomAnalytics.get_least_used_room_week(
             self, query, location_id, week_start, week_end
         )
+        return Analytics(
+            analytics=room_analytics
+        )
+
+    @Auth.user_roles('Admin')
+    def resolve_most_used_room_per_month_analytics(self, info, month, year, location_id):  # noqa: E501
+        query = Room.get_query(info)
+        room_analytics = RoomAnalytics.get_most_used_room_per_month(
+            self, query, month, year, location_id)
         return Analytics(
             analytics=room_analytics
         )

--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -8,6 +8,7 @@ from api.office.models import Office
 from api.block.models import Block
 from api.floor.models import Floor
 from helpers.calendar.events import RoomSchedules
+from helpers.calendar.analytics import RoomAnalytics, RoomStatistics
 from utilities.utility import validate_empty_fields, update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.auth.admin_roles import admin_roles
@@ -22,6 +23,10 @@ from helpers.pagination.paginate import Paginate, validate_page
 class Room(SQLAlchemyObjectType):
     class Meta:
         model = RoomModel
+
+
+class Analytics(graphene.ObjectType):
+    analytics = graphene.List(RoomStatistics)
 
 
 class Calendar(graphene.ObjectType):
@@ -176,6 +181,20 @@ class Query(graphene.ObjectType):
         days=graphene.Int(),
     )
 
+    analytics_for_room_least_used_per_week = graphene.Field(
+        Analytics,
+        location_id=graphene.Int(),
+        week_start=graphene.String(),
+        week_end=graphene.String(),
+    )
+
+    def check_valid_calendar_id(self, query, calendar_id):
+        check_calendar_id = query.filter(
+            RoomModel.calendar_id == calendar_id
+        ).first()
+        if not check_calendar_id:
+            raise GraphQLError("CalendarId given not assigned to any room on converge")  # noqa: E501
+
     def resolve_all_rooms(self, info, **kwargs):
         response = PaginatedRooms(**kwargs)
         return response
@@ -198,11 +217,7 @@ class Query(graphene.ObjectType):
 
     def resolve_room_occupants(self, info, calendar_id, days):
         query = Room.get_query(info)
-        check_calendar_id = query.filter(
-            RoomModel.calendar_id == calendar_id
-        ).first()
-        if not check_calendar_id:
-            raise GraphQLError("Invalid CalendarId")
+        Query.check_valid_calendar_id(self, query, calendar_id)
         room_occupants = RoomSchedules.get_room_schedules(
             self,
             calendar_id,
@@ -213,17 +228,23 @@ class Query(graphene.ObjectType):
 
     def resolve_room_schedule(self, info, calendar_id, days):
         query = Room.get_query(info)
-        check_calendar_id = query.filter(
-            RoomModel.calendar_id == calendar_id
-        ).first()
-        if not check_calendar_id:
-            raise GraphQLError("CalendarId given not assigned to any room on converge")  # noqa: E501
+        Query.check_valid_calendar_id(self, query, calendar_id)
         room_schedule = RoomSchedules.get_room_schedules(
             self,
             calendar_id,
             days)
         return Calendar(
             events=room_schedule[1]
+        )
+
+    @Auth.user_roles('Admin')
+    def resolve_analytics_for_room_least_used_per_week(self, info, location_id, week_start, week_end):  # noqa: E501
+        query = Room.get_query(info)
+        room_analytics = RoomAnalytics.get_least_used_room_week(
+            self, query, location_id, week_start, week_end
+        )
+        return Analytics(
+            analytics=room_analytics
         )
 
 

--- a/fixtures/room/room_analytics_fixtures.py
+++ b/fixtures/room/room_analytics_fixtures.py
@@ -1,0 +1,80 @@
+null = None
+get_least_used_room_per_week_query = '''
+    {
+        analyticsForRoomLeastUsedPerWeek(
+            locationId: 1,
+            weekStart: "Sep 8 2018"
+            weekEnd: "Sep 15 2018"
+        )
+        {
+            analytics {
+                roomName
+                count
+                hasEvents
+                events {
+                    durationInMinutes
+                    numberOfMeetings
+                }
+            }
+        }
+    }
+'''
+
+get_least_used_room_per_week_response = {
+    "data": {
+        "analyticsForRoomLeastUsedPerWeek": {
+            "analytics": [
+                {
+                    "roomName": "Nairobi - 2nd Floor Block A Khartoum (1)",
+                    "count": 5,
+                    "hasEvents": True,
+                    "events": [{
+                        "durationInMinutes": 30,
+                        "numberOfMeetings": 1
+                    },
+                        {
+                        "durationInMinutes": 25,
+                        "numberOfMeetings": 4
+                    }
+                    ]
+                }
+            ]
+        }
+    }
+}
+
+get_least_used_room_without_event_query = '''
+    {
+        analyticsForRoomLeastUsedPerWeek(
+            locationId: 1,
+            weekStart: "Aug 8 2018"
+            weekEnd: "Aug 12 2018"
+        )
+        {
+            analytics {
+                roomName
+                count
+                hasEvents
+                events {
+                    durationInMinutes
+                    numberOfMeetings
+                }
+            }
+        }
+    }
+'''
+
+get_least_used_room_without_event_response = {
+    "data": {
+        "analyticsForRoomLeastUsedPerWeek": {
+            "analytics": [
+                {
+                    "roomName": "Entebbe",
+                    "count": 0,
+                    "hasEvents": False,
+                    "events": null
+                }
+            ]
+        }
+    }
+}

--- a/fixtures/room/room_analytics_fixtures.py
+++ b/fixtures/room/room_analytics_fixtures.py
@@ -1,4 +1,20 @@
 null = None
+
+most_used_room_in_a_month_analytics_invalid_location_query = '''
+    {
+        mostUsedRoomPerMonthAnalytics(month:"Dec", year:2018, locationId:19)
+        {
+            analytics {
+                roomName
+                count
+                events {
+                    durationInMinutes
+                    numberOfMeetings
+                }
+            }
+        }
+    }
+'''
 get_least_used_room_per_week_query = '''
     {
         analyticsForRoomLeastUsedPerWeek(
@@ -19,6 +35,51 @@ get_least_used_room_per_week_query = '''
         }
     }
 '''
+
+most_used_room_in_a_month_analytics_invalid_location_response = {
+        "errors": [
+            {
+                "message": "No rooms in this location",
+                "locations": [
+                    {
+                        "line": 3,
+                        "column": 9
+                    }
+                ],
+                "path": [
+                    "mostUsedRoomPerMonthAnalytics"
+                ]
+            }
+        ],
+        "data": {
+            "mostUsedRoomPerMonthAnalytics": null
+        }
+    }
+
+get_most_used_room_in_a_month_analytics_query = '''
+    {
+        mostUsedRoomPerMonthAnalytics(month:"Dec", year:2018, locationId:1)
+        {
+            analytics {
+                roomName
+                count
+            }
+        }
+    }
+'''
+
+get_most_used_room_in_a_month_analytics_response = {
+        "data": {
+            "mostUsedRoomPerMonthAnalytics": {
+                "analytics": [
+                    {
+                        "roomName": "Nairobi - 2nd Floor Block A Khartoum (1)",
+                        "count": 21
+                    }
+                ]
+            }
+        }
+    }
 
 get_least_used_room_per_week_response = {
     "data": {

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -1,0 +1,150 @@
+from datetime import datetime
+import dateutil.parser
+from graphql import GraphQLError
+import graphene
+from collections import Counter
+
+from .credentials import Credentials
+from api.location.models import Location as LocationModel
+from ..room_filter.room_filter import room_join_location
+
+
+class EventsDuration(graphene.ObjectType):
+    duration_in_minutes = graphene.Int()
+    number_of_meetings = graphene.Int()
+
+
+class RoomStatistics(graphene.ObjectType):
+    room_name = graphene.String()
+    count = graphene.Int()
+    events = graphene.List(EventsDuration)
+    has_events = graphene.Boolean()
+
+
+class RoomAnalytics(Credentials):
+    """Get room analytics
+       :methods
+           get_least_used_room_week
+    """
+
+    def convert_date(self, date):
+        return datetime.strptime(date, '%b %d %Y').isoformat() + 'Z'
+
+    def get_time_duration_for_event(self, start_time, end_time):
+        """ Calculate duration range of an event
+         :params
+            - start_time
+            - end_time
+        """
+        start_time = dateutil.parser.parse(start_time)
+        end_time = dateutil.parser.parse(end_time)
+        event_duration = end_time - start_time
+        return event_duration.seconds / 60
+
+    def get_calendar_id_name(self, query, location_id):
+        """ Get all room(name, calendar_id) in a location
+         :params
+            - location_id
+        """
+        exact_query = room_join_location(query)
+        rooms_in_locations = exact_query.filter(LocationModel.id == location_id)
+        if not rooms_in_locations.all():
+            raise GraphQLError("No rooms in this location")
+        result = [{'name': room.name, 'calendar_id': room.calendar_id}
+                  for room in rooms_in_locations.all()]
+        return result
+
+    def get_all_events_in_a_room(self, calendar_id, min_limit, max_limit):
+        """ Get all events in a room
+         :params
+            - calendar_id - for specific room
+            - min_limit, max_limit(Time range)
+        """
+        service = Credentials.set_api_credentials(self)
+        events_result = service.events().list(
+            calendarId=calendar_id, timeMin=min_limit, timeMax=max_limit,
+            singleEvents=True, orderBy='startTime').execute()
+        calendar_events = events_result.get('items', [])
+        return calendar_events
+
+    def get_event_details(self, event, calendar_id):
+        """ Filter details of an event
+         :params
+            - event
+        """
+        event_details = {}
+        if event.get('attendees'):
+            for resource in event.get('attendees'):
+                if resource.get('resource') and resource.get('email') == calendar_id:  # noqa: E501
+                    event_details["minutes"] = RoomAnalytics.get_time_duration_for_event(  # noqa: E501
+                        self, event['start'].get(
+                            'dateTime'), event['end'].get('dateTime')
+                    )
+                    event_details["roomName"] = resource.get(
+                        'displayName') or None
+                    event_details["summary"] = event.get("summary")
+        return event_details
+
+    def get_room_statistics(self, number_of_events_in_room, all_details):
+        """ Get summary statistics for room
+         :params
+            - number_of_events_in_room
+            - all_details(List of list of events in a room)
+        """
+        result = []
+        for room_details in all_details:
+            if number_of_events_in_room == 0:
+                for detail in room_details:
+                    if 'has_events' in detail.keys():
+                        output = RoomStatistics(
+                            room_name=detail['RoomName'],
+                            has_events=detail['has_events'],
+                            count=0)
+                        result.append(output)
+            elif len(room_details) == number_of_events_in_room:
+                events_count = Counter(detail['minutes']
+                                       for detail in room_details if detail)
+                duration_of_events_in_room = [
+                    EventsDuration(
+                        duration_in_minutes=event_duration,
+                        number_of_meetings=events_count[event_duration])
+                    for index, event_duration in enumerate(events_count)
+                ]
+                output = RoomStatistics(room_name=room_details[0]['roomName'],
+                                        count=number_of_events_in_room,
+                                        events=duration_of_events_in_room,
+                                        has_events=True
+                                        )
+                result.append(output)
+        return result
+
+    def get_least_used_room_week(self, query, location_id, week_start, week_end):  # noqa: E501
+        """ Get analytics for least used room per week
+         :params
+            - calendar_id, location_id
+            - week_start, week_end(Time range)
+        """
+        week_start = RoomAnalytics.convert_date(self, week_start)
+        week_end = RoomAnalytics.convert_date(self, week_end)
+
+        rooms_available = RoomAnalytics.get_calendar_id_name(
+            self, query, location_id)
+        res = []
+        number_of_least_events = float('inf')
+        for room in rooms_available:
+            calendar_events = RoomAnalytics.get_all_events_in_a_room(
+                self, room['calendar_id'], week_start, week_end)
+            output = []
+            if not calendar_events:
+                output.append({'RoomName': room['name'], 'has_events': False})
+                number_of_least_events = 0
+            for event in calendar_events:
+                if event.get('attendees'):
+                    event_details = RoomAnalytics.get_event_details(self, event, room['calendar_id'])  # noqa: E501
+                    output.append(event_details)
+            if len(output) < number_of_least_events:
+                number_of_least_events = len(output)
+            res.append(output)
+        analytics = RoomAnalytics.get_room_statistics(
+            self, number_of_least_events, res)
+        return analytics

--- a/tests/base.py
+++ b/tests/base.py
@@ -61,7 +61,7 @@ class BaseTestCase(TestCase):
                         room_type='meeting',
                         capacity=6,
                         floor_id=floor.id,
-                        calendar_id='andela.com_3835468272423230343935@resource.calendar.google.com',  # noqa: E501
+                        calendar_id='andela.com_3630363835303531343031@resource.calendar.google.com',  # noqa: E501
                         image_url="https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg")  # noqa: E501
             room.save()
             resource = Resource(name='Markers',

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -3,6 +3,10 @@ import json
 from tests.base import BaseTestCase
 from fixtures.token.token_fixture import (admin_api_token)
 from fixtures.room.room_analytics_fixtures import (
+    get_most_used_room_in_a_month_analytics_query,
+    get_most_used_room_in_a_month_analytics_response,
+    most_used_room_in_a_month_analytics_invalid_location_query,
+    most_used_room_in_a_month_analytics_invalid_location_response,
     get_least_used_room_per_week_query,
     get_least_used_room_per_week_response,
     get_least_used_room_without_event_query,
@@ -13,7 +17,21 @@ from fixtures.room.room_analytics_fixtures import (
 
 class QueryRoomsAnalytics(BaseTestCase):
 
-    api_headers = {'token': admin_api_token}
+    api_headers = {"Authorization": "Bearer" + " " + admin_api_token}
+
+    def test_most_used_room_in_a_month_analytics(self):
+        response = self.app_test.post(
+            '/mrm?query=' + get_most_used_room_in_a_month_analytics_query, headers=self.api_headers)  # noqa: E501
+        actual_response = json.loads(response.data)
+        expected_response = get_most_used_room_in_a_month_analytics_response
+        self.assertEquals(actual_response, expected_response)
+
+    def test_most_used_room_in_a_month_invalid_location_analytics(self):
+        response = self.app_test.post(
+            '/mrm?query=' + most_used_room_in_a_month_analytics_invalid_location_query, headers=self.api_headers)  # noqa: E501
+        actual_response = json.loads(response.data)
+        expected_response = most_used_room_in_a_month_analytics_invalid_location_response  # noqa: E501
+        self.assertEquals(actual_response, expected_response)
 
     def test_analytics_for_least_used_room_weekly(self):
         analytics_query = self.app_test.post(

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -1,0 +1,30 @@
+import json
+
+from tests.base import BaseTestCase
+from fixtures.token.token_fixture import (admin_api_token)
+from fixtures.room.room_analytics_fixtures import (
+    get_least_used_room_per_week_query,
+    get_least_used_room_per_week_response,
+    get_least_used_room_without_event_query,
+    get_least_used_room_without_event_response
+
+)
+
+
+class QueryRoomsAnalytics(BaseTestCase):
+
+    api_headers = {'token': admin_api_token}
+
+    def test_analytics_for_least_used_room_weekly(self):
+        analytics_query = self.app_test.post(
+            '/mrm?query=' + get_least_used_room_per_week_query, headers=self.api_headers)  # noqa: E501
+        actual_response = json.loads(analytics_query.data)
+        expected_response = get_least_used_room_per_week_response
+        self.assertEquals(actual_response, expected_response)
+
+    def test_analytics_for_least_used_room_without_event_weekly(self):
+        analytics_query = self.app_test.post(
+            '/mrm?query=' + get_least_used_room_without_event_query, headers=self.api_headers)  # noqa: E501
+        actual_response = json.loads(analytics_query.data)
+        expected_response = get_least_used_room_without_event_response
+        self.assertEquals(actual_response, expected_response)


### PR DESCRIPTION
#### What does this PR do?
- Handles Analytics of the most used room in a month

#### How should this be manually tested?
- Run the server
- Test query at `localhost:5000/mrm`
- Run `mostUsedRoomPerMonthAnalytics` query using parameters: `month`, `year` and `locationId`

#### What are the relevant pivotal tracker stories?
[#160447468](https://www.pivotaltracker.com/story/show/160447468)

#### Screenshots
- Analytics for most used room in Location1 - Kenya
<img width="1099" alt="screen shot 2018-09-26 at 14 34 07" src="https://user-images.githubusercontent.com/20478530/46077407-757bba00-c199-11e8-852c-8f75216bb38f.png">

- Analytics for most used room in Location2 - Uganda
<img width="1190" alt="screen shot 2018-09-26 at 14 37 47" src="https://user-images.githubusercontent.com/20478530/46077513-cab7cb80-c199-11e8-9971-ece1261a7c87.png">

- Response when month selected has no events booked
<img width="975" alt="screen shot 2018-09-26 at 17 42 03" src="https://user-images.githubusercontent.com/20478530/46087779-b97bb880-c1b3-11e8-9b14-28e1a4b7ca51.png">


