### PR TITLE
#160445644 Analytics for meetings per room.

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -195,6 +195,13 @@ class Query(graphene.ObjectType):
         year=graphene.Int(),
     )
 
+    analytics_for_meetings_per_room = graphene.Field(
+        Analytics,
+        location_id=graphene.Int(),
+        day_start=graphene.String(),
+        day_end=graphene.String(),
+    )
+
     def check_valid_calendar_id(self, query, calendar_id):
         check_calendar_id = query.filter(
             RoomModel.calendar_id == calendar_id
@@ -261,6 +268,15 @@ class Query(graphene.ObjectType):
             self, query, month, year, location_id)
         return Analytics(
             analytics=room_analytics
+        )
+
+    def resolve_analytics_for_meetings_per_room(self, info, location_id, day_start, day_end):  # noqa: E501
+        query = Room.get_query(info)
+        meeting_summary = RoomAnalytics.get_meetings_per_room(
+            self, query, location_id, day_start, day_end
+        )
+        return Analytics(
+            analytics=meeting_summary
         )
 
 

--- a/fixtures/room/room_analytics_fixtures.py
+++ b/fixtures/room/room_analytics_fixtures.py
@@ -58,7 +58,7 @@ most_used_room_in_a_month_analytics_invalid_location_response = {
 
 get_most_used_room_in_a_month_analytics_query = '''
     {
-        mostUsedRoomPerMonthAnalytics(month:"Dec", year:2018, locationId:1)
+        mostUsedRoomPerMonthAnalytics(month:"Jul", year:2018, locationId:1)
         {
             analytics {
                 roomName
@@ -73,8 +73,8 @@ get_most_used_room_in_a_month_analytics_response = {
             "mostUsedRoomPerMonthAnalytics": {
                 "analytics": [
                     {
-                        "roomName": "Nairobi - 2nd Floor Block A Khartoum (1)",
-                        "count": 21
+                        "roomName": "Entebbe",
+                        "count": 0
                     }
                 ]
             }
@@ -138,4 +138,51 @@ get_least_used_room_without_event_response = {
             ]
         }
     }
+}
+
+get_room_usage_analytics = '''
+{
+    analyticsForMeetingsPerRoom(locationId:1,
+    dayStart:"Sep 11 2018" dayEnd:"sep 12 2018"){
+        analytics{
+            roomName
+            count
+        }
+        }
+    }
+'''
+
+get_room_usage_anaytics_respone = {
+    "data": {
+        "analyticsForMeetingsPerRoom": {
+            "analytics": [{'roomName': 'Entebbe', 'count': 2}]
+        }
+    }
+}
+
+get_room_usage_analytics_invalid_location = '''
+{
+    analyticsForMeetingsPerRoom(locationId:20,
+    dayStart:"Sep 11 2018" dayEnd:"sep 12 2018"){
+        analytics{
+           roomName
+           count
+           }
+        }
+    }
+'''
+
+get_room_usage_analytics_invalid_location_response = {
+    'errors':
+    [
+        {
+            'message': 'No rooms in this location',
+            'locations': [{'line': 3, 'column': 5}],
+            'path': ['analyticsForMeetingsPerRoom']
+        }
+    ],
+        'data':
+            {
+                'analyticsForMeetingsPerRoom': None
+            }
 }

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -27,7 +27,6 @@ class RoomAnalytics(Credentials):
        :methods
            get_least_used_room_week
     """
-
     def convert_date(self, date):
         return datetime.strptime(date, '%b %d %Y').isoformat() + 'Z'
 

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -184,3 +184,18 @@ class RoomAnalytics(Credentials):
         analytics = RoomAnalytics.get_room_statistics(
             self, rooms_with_max_events, res)
         return analytics
+
+    def get_meetings_per_room(self, query, location_id, timeMin, timeMax):
+        day_start = RoomAnalytics.convert_date(self, timeMin)
+        day_end = RoomAnalytics.convert_date(self, timeMax)
+
+        rooms_available = RoomAnalytics.get_calendar_id_name(
+            self, query, location_id)
+        res = []
+        for room in rooms_available:
+
+            calendar_events = RoomAnalytics.get_all_events_in_a_room(
+                self, room['calendar_id'], day_start, day_end)
+            room_details = RoomStatistics(room_name=room["name"], count=len(calendar_events))  # noqa: E501
+            res.append(room_details)
+        return res

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -10,7 +10,11 @@ from fixtures.room.room_analytics_fixtures import (
     get_least_used_room_per_week_query,
     get_least_used_room_per_week_response,
     get_least_used_room_without_event_query,
-    get_least_used_room_without_event_response
+    get_least_used_room_without_event_response,
+    get_room_usage_analytics,
+    get_room_usage_anaytics_respone,
+    get_room_usage_analytics_invalid_location,
+    get_room_usage_analytics_invalid_location_response,
 
 )
 
@@ -47,4 +51,21 @@ class QueryRoomsAnalytics(BaseTestCase):
             '/mrm?query=' + get_least_used_room_without_event_query, headers=headers)  # noqa: E501
         actual_response = json.loads(analytics_query.data)
         expected_response = get_least_used_room_without_event_response
+        self.assertEquals(actual_response, expected_response)
+
+    def test_room_usage_analytics(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
+        response = self.app_test.post(
+            '/mrm?query='+get_room_usage_analytics, headers=headers)
+        actual_response = json.loads(response.data)
+        expected_response = get_room_usage_anaytics_respone
+        self.assertEquals(actual_response, expected_response)
+
+    def test_room_usage_analytics_invalid_location(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
+        response = self.app_test.post(
+            '/mrm?query='+get_room_usage_analytics_invalid_location,
+            headers=headers)
+        actual_response = json.loads(response.data)
+        expected_response = get_room_usage_analytics_invalid_location_response
         self.assertEquals(actual_response, expected_response)


### PR DESCRIPTION
### What does this PR do?

- This PR enables admins see the statistics of meetings per room i.e count of all meetings per room.

#### How should this be manually tested?
- Run the server.
- Test the query at localhost:5000/mrm.
- Run `analyticsForMeetingsPerRoom` query with `locationId`, `dayStart`, and `dayEnd`  as the arguments.

### What are the relevant pivotal tracker stories?

#160445644

#### Screenshots

###### Getting room analytics from Nairobi Office.
<img width="1091" alt="nai update" src="https://user-images.githubusercontent.com/6715848/45967777-acd25580-c037-11e8-8306-7075a974ab23.png">


###### Getting room analytics from Lagos Office.
<img width="1098" alt="lagos update" src="https://user-images.githubusercontent.com/6715848/45967792-b491fa00-c037-11e8-9a94-9300068f3db7.png">


###### Getting room analytics from Kampala Office.
<img width="1089" alt="kampala update" src="https://user-images.githubusercontent.com/6715848/45967835-d68b7c80-c037-11e8-86a5-19fbf2dc50d3.png">




