### PR TITLE
#160447415 Analytics for most used room(s) per week

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -194,6 +194,12 @@ class Query(graphene.ObjectType):
         week_start=graphene.String(),
         week_end=graphene.String(),
     )
+    analytics_for_room_most_used_per_week = graphene.Field(
+        Analytics,
+        location_id=graphene.Int(),
+        week_start=graphene.String(),
+        week_end=graphene.String(),
+    )
 
     most_used_room_per_month_analytics = graphene.Field(
         Analytics,
@@ -283,6 +289,17 @@ class Query(graphene.ObjectType):
         return Analytics(
             analytics=room_analytics
         )
+
+    @Auth.user_roles('Admin')
+    def resolve_analytics_for_room_most_used_per_week(self, info, location_id, week_start, week_end):  # noqa: E501
+        query = Room.get_query(info)
+        room_analytics = RoomAnalytics.get_most_used_room_week(
+            self, query, location_id, week_start, week_end
+        )
+        room_most_used_per_week = Analytics(
+            analytics=room_analytics
+        )
+        return room_most_used_per_week
 
     def resolve_analytics_for_meetings_per_room(self, info, location_id, day_start, day_end):  # noqa: E501
         query = Room.get_query(info)

--- a/fixtures/room/room_analytics_fixtures.py
+++ b/fixtures/room/room_analytics_fixtures.py
@@ -35,6 +35,68 @@ get_least_used_room_per_week_query = '''
         }
     }
 '''
+most_used_room_in_a_month_analytics_invalid_location_response = {
+        "errors": [
+            {
+                "message": "No rooms in this location",
+                "locations": [
+                    {
+                        "line": 3,
+                        "column": 9
+                    }
+                ],
+                "path": [
+                    "mostUsedRoomPerMonthAnalytics"
+                ]
+            }
+        ],
+        "data": {
+            "mostUsedRoomPerMonthAnalytics": null
+        }
+    }
+get_most_used_room_in_a_month_analytics_query = '''
+    {
+        mostUsedRoomPerMonthAnalytics(month:"Jul", year:2018, locationId:1)
+        {
+            analytics {
+                roomName
+                count
+            }
+        }
+    }
+'''
+get_most_used_room_in_a_month_analytics_response = {
+        "data": {
+            "mostUsedRoomPerMonthAnalytics": {
+                "analytics": [
+                    {
+                        "roomName": "Entebbe",
+                        "count": 0
+                    }
+                ]
+            }
+        }
+    }
+get_least_used_room_per_week_query = '''
+    {
+        analyticsForRoomLeastUsedPerWeek(
+            locationId: 1,
+            weekStart: "Sep 8 2018"
+            weekEnd: "Sep 15 2018"
+        )
+        {
+            analytics {
+                roomName
+                count
+                hasEvents
+                events {
+                    durationInMinutes
+                    numberOfMeetings
+                }
+            }
+        }
+    }
+'''
 
 most_used_room_in_a_month_analytics_invalid_location_response = {
         "errors": [
@@ -56,30 +118,6 @@ most_used_room_in_a_month_analytics_invalid_location_response = {
         }
     }
 
-get_most_used_room_in_a_month_analytics_query = '''
-    {
-        mostUsedRoomPerMonthAnalytics(month:"Jul", year:2018, locationId:1)
-        {
-            analytics {
-                roomName
-                count
-            }
-        }
-    }
-'''
-
-get_most_used_room_in_a_month_analytics_response = {
-        "data": {
-            "mostUsedRoomPerMonthAnalytics": {
-                "analytics": [
-                    {
-                        "roomName": "Entebbe",
-                        "count": 0
-                    }
-                ]
-            }
-        }
-    }
 
 get_least_used_room_per_week_response = {
     "data": {
@@ -139,6 +177,27 @@ get_least_used_room_without_event_response = {
         }
     }
 }
+
+get_most_used_room_per_week_query = '''
+     {
+        analyticsForRoomMostUsedPerWeek(
+            locationId: 1,
+            weekStart: "Aug 8 2018"
+            weekEnd: "Aug 12 2018"
+        )
+        {
+            analytics {
+                roomName
+                count
+                hasEvents
+                events {
+                    durationInMinutes
+                    numberOfMeetings
+                }
+            }
+        }
+    }
+'''
 
 get_room_usage_analytics = '''
     {
@@ -208,6 +267,20 @@ get_least_used_room_per_month_response = {
         }
     }
 }
+get_most_used_room_per_week_response = {
+   "data": {
+        "analyticsForRoomMostUsedPerWeek": {
+            "analytics": [
+                {
+                    "roomName": "Entebbe",
+                    "count": 0,
+                    "hasEvents": False,
+                    "events": null
+                }
+            ]
+        }
+    }
+}
 
 get_room_usage_analytics_invalid_location = '''
 {
@@ -223,11 +296,32 @@ get_room_usage_analytics_invalid_location = '''
 
 get_least_used_room_per_month_invalid_location = '''
     {
-        analyticsForLeastUsedRoomPerMonth(month:"Jul", year:2018, locationId:99)
+        analyticsForLeastUsedRoomPerMonth(month:"Jul", year:2018,
+        locationId:99)
         {
             analytics {
                 roomName
                 count
+            }
+        }
+    }
+'''
+get_most_used_room_without_event_query = '''
+    {
+        analyticsForRoomMostUsedPerWeek(
+            locationId: 1,
+            weekStart: "Aug 8 2018"
+            weekEnd: "Aug 12 2018"
+        )
+        {
+            analytics {
+                roomName
+                count
+                hasEvents
+                events {
+                    durationInMinutes
+                    numberOfMeetings
+                }
             }
         }
     }
@@ -265,3 +359,17 @@ response_least_used_room_per_month_invalid_location = {
         "analyticsForLeastUsedRoomPerMonth": null
         }
     }
+
+get_most_used_room_without_event_response = {
+    "data": {
+        "analyticsForRoomMostUsedPerWeek": {
+            "analytics": [
+                {
+                    "roomName": "Entebbe",
+                    "count": 0,
+                    "hasEvents": False,
+                    "events": null}
+            ]
+        }
+    }
+}

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -63,7 +63,8 @@ class RoomAnalytics(Credentials):
             - location_id
         """
         exact_query = room_join_location(query)
-        rooms_in_locations = exact_query.filter(LocationModel.id == location_id)
+        rooms_in_locations = exact_query.filter(
+            LocationModel.id == location_id)
         if not rooms_in_locations.all():
             raise GraphQLError("No rooms in this location")
         result = [{'name': room.name, 'calendar_id': room.calendar_id}

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -232,12 +232,10 @@ class RoomAnalytics(Credentials):
     def get_meetings_per_room(self, query, location_id, timeMin, timeMax):
         day_start = RoomAnalytics.convert_date(self, timeMin)
         day_end = RoomAnalytics.convert_date(self, timeMax)
-
         rooms_available = RoomAnalytics.get_calendar_id_name(
             self, query, location_id)
         res = []
         for room in rooms_available:
-
             calendar_events = RoomAnalytics.get_all_events_in_a_room(
                 self, room['calendar_id'], day_start, day_end)
             room_details = RoomStatistics(room_name=room["name"], count=len(calendar_events))  # noqa: E501
@@ -279,3 +277,34 @@ class RoomAnalytics(Credentials):
             result.append(output)
 
         return result
+
+    def get_most_used_room_week(self, query, location_id, week_start, week_end):  # noqa: E501
+        """ Get analytics for most used room per week
+         :params
+            - calendar_id, location_id
+            - week_start, week_end(Time range)
+        """
+        week_start = RoomAnalytics.convert_date(self, week_start)
+        week_end = RoomAnalytics.convert_date(self, week_end)
+        rooms_available = RoomAnalytics.get_calendar_id_name(
+            self, query, location_id)
+        res = []
+        number_of_most_events = 0
+        for room in rooms_available:
+            calendar_events = RoomAnalytics.get_all_events_in_a_room(
+                self, room['calendar_id'], week_start, week_end)
+            output = []
+            if not calendar_events:
+                output.append({'RoomName': room['name'], 'has_events': False})
+                number_of_most_events = 0
+            else:
+                for event in calendar_events:
+                    event_details = RoomAnalytics.get_event_details(
+                        self, event, room['calendar_id'])
+                    output.append(event_details)
+                if len(output) > number_of_most_events:
+                    number_of_most_events = len(output)
+            res.append(output)
+        analytics = RoomAnalytics.get_room_statistics(
+            self, number_of_most_events, res)
+        return analytics

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -18,7 +18,11 @@ from fixtures.room.room_analytics_fixtures import (
     get_least_used_room_per_month,
     get_least_used_room_per_month_response,
     get_least_used_room_per_month_invalid_location,
-    response_least_used_room_per_month_invalid_location
+    response_least_used_room_per_month_invalid_location,
+    get_most_used_room_per_week_query,
+    get_most_used_room_per_week_response,
+    get_most_used_room_without_event_query,
+    get_most_used_room_without_event_response
 
 )
 
@@ -90,4 +94,20 @@ class QueryRoomsAnalytics(BaseTestCase):
             headers=headers)
         actual_response = json.loads(response.data)
         expected_response = response_least_used_room_per_month_invalid_location
+        self.assertEquals(actual_response, expected_response)
+
+    def test_analytics_for_most_used_room_weekly(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
+        analytics_query = self.app_test.post(
+            '/mrm?query=' + get_most_used_room_per_week_query, headers=headers)  # noqa: E501
+        actual_response = json.loads(analytics_query.data)
+        expected_response = get_most_used_room_per_week_response
+        self.assertEquals(actual_response, expected_response)
+
+    def test_analytics_for_most_used_room_without_event_weekly(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
+        analytics_query = self.app_test.post(
+            '/mrm?query=' + get_most_used_room_without_event_query, headers=headers)  # noqa: E501
+        actual_response = json.loads(analytics_query.data)
+        expected_response = get_most_used_room_without_event_response
         self.assertEquals(actual_response, expected_response)


### PR DESCRIPTION
#### What does this PR do?
 Enable admin to know the most used room(s) per week i.e meeting room(s) with the highest bookings
#### How should this be manually tested?
- Clone this branch in your local machine, Run the server
- Test the queries at localhost:5000/mrm
- Run `analyticsForRoomMostUsedPerWeek` query with `locationId` and the duration range of one week as the keyword arguments as shown in the screen shot below.
#### What are the relevant pivotal tracker stories?
[#160447415](https://www.pivotaltracker.com/story/show/160447415)
#### Screenshots 
     When an admin runs the query with `locationId`.
<img width="1440" alt="screen shot 2018-09-25 at 19 23 04" src="https://user-images.githubusercontent.com/28715887/46131827-4a4ea480-c245-11e8-939b-51fbeea26f9c.png">
     When there are no events is a period.
<img width="1440" alt="screen shot 2018-09-28 at 11 18 20" src="https://user-images.githubusercontent.com/28715887/46199825-b221ef80-c318-11e8-9a30-39c5ba9bdcc4.png">



