### PR TITLE
#160447363 Analytics for least used room per month

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -209,6 +209,13 @@ class Query(graphene.ObjectType):
         day_end=graphene.String(),
     )
 
+    analytics_for_least_used_room_per_month = graphene.Field(
+        Analytics,
+        location_id=graphene.Int(),
+        month=graphene.String(),
+        year=graphene.Int(),
+    )
+
     def check_valid_calendar_id(self, query, calendar_id):
         check_calendar_id = query.filter(
             RoomModel.calendar_id == calendar_id
@@ -294,6 +301,15 @@ class Query(graphene.ObjectType):
         results = RoomAnalytics.get_daily_meetings_details(self, room_list, day_start)  # noqa: E501
 
         return Analytics(dailyDurationaAnalytics=results)
+
+    @Auth.user_roles('Admin')
+    def resolve_analytics_for_least_used_room_per_month(self, info, month, year, location_id):  # noqa: E501
+        query = Room.get_query(info)
+        room_analytics = RoomAnalytics.get_least_used_room_per_month(
+            self, query, month, year, location_id)
+        return Analytics(
+            analytics=room_analytics
+        )
 
 
 class Mutation(graphene.ObjectType):

--- a/fixtures/room/room_analytics_fixtures.py
+++ b/fixtures/room/room_analytics_fixtures.py
@@ -141,13 +141,36 @@ get_least_used_room_without_event_response = {
 }
 
 get_room_usage_analytics = '''
-{
+    {
     analyticsForMeetingsPerRoom(locationId:1,
-    dayStart:"Sep 11 2018" dayEnd:"sep 12 2018"){
-        analytics{
-            roomName
-            count
+        dayStart:"Sep 11 2018" dayEnd:"sep 12 2018"){
+            analytics{
+                roomName
+                count
+            }
         }
+    }
+'''
+
+get_least_used_room_per_month = '''
+    {
+        analyticsForLeastUsedRoomPerMonth(month:"Jul", year:2018, locationId:1)
+        {
+            analytics {
+                roomName
+                count
+            }
+        }
+    }
+'''
+get_least_used_room_per_month = '''
+    {
+        analyticsForLeastUsedRoomPerMonth(month:"Jul", year:2018, locationId:1)
+        {
+            analytics {
+                roomName
+                count
+            }
         }
     }
 '''
@@ -156,6 +179,32 @@ get_room_usage_anaytics_respone = {
     "data": {
         "analyticsForMeetingsPerRoom": {
             "analytics": [{'roomName': 'Entebbe', 'count': 2}]
+                    }
+    }
+}
+
+get_least_used_room_per_month_response = {
+    'data': {
+        'analyticsForLeastUsedRoomPerMonth': {
+            'analytics': [
+                {
+                    'roomName': 'Entebbe',
+                    'count': 0
+                }
+            ]
+        }
+    }
+}
+
+get_least_used_room_per_month_response = {
+    'data': {
+        'analyticsForLeastUsedRoomPerMonth': {
+            'analytics': [
+                {
+                    'roomName': 'Entebbe',
+                    'count': 0
+                }
+            ]
         }
     }
 }
@@ -168,6 +217,18 @@ get_room_usage_analytics_invalid_location = '''
            roomName
            count
            }
+        }
+    }
+'''
+
+get_least_used_room_per_month_invalid_location = '''
+    {
+        analyticsForLeastUsedRoomPerMonth(month:"Jul", year:2018, locationId:99)
+        {
+            analytics {
+                roomName
+                count
+            }
         }
     }
 '''
@@ -186,3 +247,21 @@ get_room_usage_analytics_invalid_location_response = {
                 'analyticsForMeetingsPerRoom': None
             }
 }
+
+response_least_used_room_per_month_invalid_location = {
+    "errors": [
+        {
+            "message": "No rooms in this location",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 9
+                }
+            ],
+            "path": ["analyticsForLeastUsedRoomPerMonth"]
+        }
+    ],
+    "data": {
+        "analyticsForLeastUsedRoomPerMonth": null
+        }
+    }

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -134,6 +134,41 @@ class RoomAnalytics(Credentials):
                 result.append(output)
         return result
 
+    def get_monthly_rooms_events(self, query, month, year, location_id):
+        """ Get event stats for all rooms in a specified month
+         :params
+            - location_id, month, year
+        """
+        date = month + ' 1 ' + str(year)
+        startdate = RoomAnalytics.convert_date(self, date)
+        date_after_month = (datetime.strptime(date, '%b %d %Y') + relativedelta(months=1)).isoformat() + 'Z'  # noqa: E501
+
+        rooms_available = RoomAnalytics.get_calendar_id_name(
+            self, query, location_id)
+        room_events_count = []
+        events_in_all_rooms = []
+        for room in rooms_available:
+            calendar_events = RoomAnalytics.get_all_events_in_a_room(
+                self, room['calendar_id'], startdate, date_after_month)
+            output = []
+            if not calendar_events:
+                output.append({'RoomName': room['name'], 'has_events': False})
+                room_with_no_events = 0
+                room_events_count.append(room_with_no_events)
+
+            else:
+                for event in calendar_events:
+                    if event.get('attendees'):
+                        event_details = RoomAnalytics.get_event_details(
+                            self, event, room['calendar_id'])
+                        output.append(event_details)
+                room_events_count.append(len(output))
+            events_in_all_rooms.append(output)
+        return dict(
+            events_in_all_rooms=events_in_all_rooms,
+            room_events_count=room_events_count
+        )
+
     def get_least_used_room_week(self, query, location_id, week_start, week_end):  # noqa: E501
         """ Get analytics for least used room per week
          :params
@@ -166,39 +201,31 @@ class RoomAnalytics(Credentials):
         return analytics
 
     def get_most_used_room_per_month(self, query, month, year, location_id):
-        """ Get analytics for the most used room(s) per morth in a location
+        """ Get analytics for the MOST used room(s) per morth in a location
          :params
             - month, year, location_id
         """
-        date = month + ' 1 ' + str(year)
-        startdate = RoomAnalytics.convert_date(self, date)
-        date_after_month = (datetime.strptime(date, '%b %d %Y') + relativedelta(months=1)).isoformat() + 'Z'  # noqa: E501
-
-        rooms_available = RoomAnalytics.get_calendar_id_name(
-            self, query, location_id)
-        rooms = []
-        res = []
-        for room in rooms_available:
-            calendar_events = RoomAnalytics.get_all_events_in_a_room(
-                self, room['calendar_id'], startdate, date_after_month)
-            output = []
-            if not calendar_events:
-                output.append({'RoomName': room['name'], 'has_events': False})
-                rooms_with_max_events = 0
-                rooms.append(rooms_with_max_events)
-
-            else:
-                for event in calendar_events:
-                    if event.get('attendees'):
-                        event_details = RoomAnalytics.get_event_details(
-                            self, event, room['calendar_id'])
-                        output.append(event_details)
-                rooms.append(len(output))
-            res.append(output)
-        rooms_with_max_events = max(rooms)
+        get_monthly_events = RoomAnalytics.get_monthly_rooms_events(
+            self, query, month, year, location_id)
+        rooms_with_max_events = max(get_monthly_events['room_events_count'])
+        res = get_monthly_events['events_in_all_rooms']
 
         analytics = RoomAnalytics.get_room_statistics(
             self, rooms_with_max_events, res)
+        return analytics
+
+    def get_least_used_room_per_month(self, query, month, year, location_id):
+        """ Get analytics for the LEAST used room(s) per morth in a location
+         :params
+            - month, year, location_id
+        """
+        get_monthly_events = RoomAnalytics.get_monthly_rooms_events(
+            self, query, month, year, location_id)
+        rooms_with_min_events = min(get_monthly_events['room_events_count'])
+        res = get_monthly_events['events_in_all_rooms']
+
+        analytics = RoomAnalytics.get_room_statistics(
+            self, rooms_with_min_events, res)
         return analytics
 
     def get_meetings_per_room(self, query, location_id, timeMin, timeMax):

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -15,6 +15,10 @@ from fixtures.room.room_analytics_fixtures import (
     get_room_usage_anaytics_respone,
     get_room_usage_analytics_invalid_location,
     get_room_usage_analytics_invalid_location_response,
+    get_least_used_room_per_month,
+    get_least_used_room_per_month_response,
+    get_least_used_room_per_month_invalid_location,
+    response_least_used_room_per_month_invalid_location
 
 )
 
@@ -68,4 +72,22 @@ class QueryRoomsAnalytics(BaseTestCase):
             headers=headers)
         actual_response = json.loads(response.data)
         expected_response = get_room_usage_analytics_invalid_location_response
+        self.assertEquals(actual_response, expected_response)
+
+    def test_analytics_for_least_used_room_monthly(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
+        response = self.app_test.post(
+            '/mrm?query=' + get_least_used_room_per_month,
+            headers=headers)
+        actual_response = json.loads(response.data)
+        expected_response = get_least_used_room_per_month_response
+        self.assertEquals(actual_response, expected_response)
+
+    def test_analytics_for_least_used_room_monthly_invalid_location(self):
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
+        response = self.app_test.post(
+            '/mrm?query=' + get_least_used_room_per_month_invalid_location,
+            headers=headers)
+        actual_response = json.loads(response.data)
+        expected_response = response_least_used_room_per_month_invalid_location
         self.assertEquals(actual_response, expected_response)


### PR DESCRIPTION
#### What does this PR do?
This PR enables admins to see the statistics of the least used room per month

**How should this be manually tested?**
- Run the server.
- Test the query at `localhost:5000/mrm`
- Run `analyticsForLeastUsedRoomPerMonth` query with `locationId`, `month`(First 3 letters), and `year` as the arguments.


#### What are the relevant pivotal tracker stories?
[#160447363](https://www.pivotaltracker.com/story/show/160447363)

**Screenshots**
<img width="1186" alt="screen shot 2018-09-28 at 22 59 48" src="https://user-images.githubusercontent.com/33119403/46231436-92b8b000-c374-11e8-9ae5-feceaa084c45.png">
