### PR TITLE
#160845129 Add cascade effect on  delete office

### DIFF
--- a/api/block/models.py
+++ b/api/block/models.py
@@ -12,4 +12,4 @@ class Block(Base, Utility):
     name = Column(String, nullable=False)
     office_id = Column(Integer, ForeignKey('offices.id'))
     offices = relationship('Office')
-    floors = relationship('Floor')
+    floors = relationship('Floor', cascade="all, delete-orphan")

--- a/api/floor/models.py
+++ b/api/floor/models.py
@@ -12,5 +12,5 @@ class Floor(Base, Utility):
     name = Column(String, nullable=False)
     block_id = Column(Integer, ForeignKey('blocks.id'))
     block = relationship('Block')
-    rooms = relationship('Room')
-    wings = relationship('Wing')
+    rooms = relationship('Room', cascade="all, delete-orphan")
+    wings = relationship('Wing', cascade="all, delete-orphan")

--- a/api/office/models.py
+++ b/api/office/models.py
@@ -15,7 +15,7 @@ class Office(Base, Utility):
     name = Column(String, nullable=True, unique=True)
     location_id = Column(Integer, ForeignKey('locations.id'))
     location = relationship('Location')
-    blocks = relationship('Block')
+    blocks = relationship('Block', cascade="all, delete-orphan")
 
 
 @event.listens_for(Office, 'after_insert')

--- a/api/room/models.py
+++ b/api/room/models.py
@@ -18,4 +18,4 @@ class Room(Base, Utility):
     floor_id = Column(Integer, ForeignKey('floors.id'))
     wing_id = Column(Integer, ForeignKey('wings.id'))
     floor = relationship('Floor')
-    resources = relationship('Resource')
+    resources = relationship('Resource', cascade="all, delete-orphan")

--- a/api/room_resource/models.py
+++ b/api/room_resource/models.py
@@ -13,7 +13,7 @@ class Resource(Base, Utility):
     quantity = Column(Integer, nullable=False)
     room_id = Column(Integer, ForeignKey('rooms.id'))
     room = relationship('Room')
-    devices = relationship('Devices')
+    devices = relationship('Devices', cascade="all, delete-orphan")
 
     def __init__(self, **kwargs):
         validate_empty_fields(**kwargs)

--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -21,7 +21,7 @@ expected_response_devices = {
                                             "resourceId": 1,
                                             "lastSeen": "2018-06-08T11:17:58.785136",  # noqa: E501
                                             "dateAdded": "2018-06-08T11:17:58.785136",  # noqa: E501
-                                            "name": "Samsung ",
+                                            "name": "Samsung",
                                             "location": "Nairobi"
                                             }
                                             ]

--- a/fixtures/office/office_fixtures.py
+++ b/fixtures/office/office_fixtures.py
@@ -110,34 +110,90 @@ office_mutation_query_duplicate_name = '''
 '''
 
 office_mutation_query_duplicate_name_responce = {
-        "errors": [
-            {
-                "message": "St. Catherines Office already exists",
-                "locations": [
-                    {
-                        "line": 3,
-                        "column": 9
-                    }
-                ],
-                "path": [
-                    "createOffice"
-                ]
-            }
-        ],
-        "data": {
-            "createOffice": null
+    "errors": [
+        {
+            "message": "St. Catherines Office already exists",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 9
+                }
+            ],
+            "path": [
+                "createOffice"
+            ]
         }
+    ],
+    "data": {
+        "createOffice": null
     }
+}
 
 delete_office_mutation = '''
 mutation{
     deleteOffice(officeId: 1){
         office{
             name
+            blocks{
+                name
+                floors{
+                    name
+                    rooms{
+                        name
+                        roomType
+                        capacity
+                        resources{
+                            name
+                            quantity
+                            devices{
+                                name
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }
 '''
+
+delete_office_mutation_response = {
+    "data": {
+        "deleteOffice": {
+            "office": {
+                "name": "St. Catherines",
+                "blocks": [
+                    {
+                        "name": "EC",
+                        "floors": [
+                            {
+                                "name": "3rd",
+                                "rooms": [
+                                    {
+                                        "name": "Entebbe",
+                                        "roomType": "meeting",
+                                        "capacity": 6,
+                                        "resources": [
+                                            {
+                                                "name": "Markers",
+                                                "quantity": 3,
+                                                "devices": [
+                                                    {
+                                                        "name": "Samsung"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}
 
 delete_non_existent_office_mutation = '''
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -72,7 +72,7 @@ class BaseTestCase(TestCase):
                 resource_id=resource.id,
                 last_seen="2018-06-08T11:17:58.785136",
                 date_added="2018-06-08T11:17:58.785136",
-                name="Samsung ",
+                name="Samsung",
                 location="Nairobi",
                 device_type="External Display"
             )

--- a/tests/test_office/test_delete_office.py
+++ b/tests/test_office/test_delete_office.py
@@ -3,8 +3,9 @@ import json
 from tests.base import BaseTestCase
 
 from fixtures.office.office_fixtures import (delete_office_mutation,
-delete_non_existent_office_mutation,
-delete_unauthorised_location_mutation)  # noqa: E501
+                                             delete_office_mutation_response,
+                                             delete_non_existent_office_mutation,  # noqa: E501
+                                             delete_unauthorised_location_mutation)  # noqa: E501
 from fixtures.token.token_fixture import admin_api_token
 
 
@@ -13,7 +14,8 @@ class TestDeleteOffice(BaseTestCase):
         headers = {"Authorization": "Bearer" + " " + admin_api_token}
         response = self.app_test.post('/mrm?query='+delete_office_mutation,
                                       headers=headers)
-        self.assertIn("St. Catherines", str(response.data))
+        actual_response = json.loads(response.data)
+        self.assertEquals(delete_office_mutation_response, actual_response)
 
     def test_delete_non_existent_office(self):
         headers = {"Authorization": "Bearer" + " " + admin_api_token}


### PR DESCRIPTION
### What does this PR do?

- This PR adds the cascade effect on delete office to ensure all data related to an office is deleted when an office is deleted.

#### How should this be manually tested?
- Run the server.
- Test the query at localhost:5000/mrm.
- Run `deleteOffice` mutation with `officeId` as an argument.

### What are the relevant pivotal tracker stories?

#160845129

#### Screenshots

###### Deleting an office with one block
![image](https://user-images.githubusercontent.com/22454909/46289774-ac374300-c592-11e8-9c9f-88d579dbd845.png)


###### Deleting an office with more than one block
![image](https://user-images.githubusercontent.com/22454909/46289797-c1ac6d00-c592-11e8-98d8-6a9d6c2f593d.png)

