### PR TITLE
#160447638 Analytics for total monthly meetings duration

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -7,9 +7,8 @@ from api.room.models import Room as RoomModel
 from api.office.models import Office
 from api.block.models import Block
 from api.floor.models import Floor
-from api.location.models import Location as LocationModel
 from helpers.calendar.events import RoomSchedules
-from helpers.calendar.analytics import RoomAnalytics, RoomStatistics, RoomDailyDurations  # noqa: E501
+from helpers.calendar.analytics import RoomAnalytics, RoomStatistics  # noqa: E501
 from utilities.utility import validate_empty_fields, update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.auth.admin_roles import admin_roles
@@ -17,7 +16,7 @@ from helpers.auth.verify_ids_for_room import verify_ids
 from helpers.auth.validator import assert_wing_is_required
 from helpers.auth.validator import ErrorHandler
 from helpers.auth.add_office import verify_attributes
-from helpers.room_filter.room_filter import room_filter, room_join_office, room_join_location  # noqa: E501
+from helpers.room_filter.room_filter import room_filter, room_join_office  # noqa: E501
 from helpers.pagination.paginate import Paginate, validate_page
 
 
@@ -28,7 +27,7 @@ class Room(SQLAlchemyObjectType):
 
 class Analytics(graphene.ObjectType):
     analytics = graphene.List(RoomStatistics)
-    dailyDurationaAnalytics = graphene.List(RoomDailyDurations)
+    MeetingsDurationaAnalytics = graphene.List(RoomStatistics)
 
 
 class Calendar(graphene.ObjectType):
@@ -185,6 +184,13 @@ class Query(graphene.ObjectType):
         day_start=graphene.String(),
     )
 
+    monthly_durations_of_meetings = graphene.Field(
+        Analytics,
+        location_id=graphene.Int(),
+        month=graphene.String(),
+        year=graphene.Int(),
+    )
+
     analytics_for_room_least_used_per_week = graphene.Field(
         Analytics,
         location_id=graphene.Int(),
@@ -310,11 +316,14 @@ class Query(graphene.ObjectType):
     @Auth.user_roles('Admin')
     def resolve_daily_durations_of_meetings(self, info, location_id, day_start):  # noqa: E501
         query = Room.get_query(info)
-        new_query = room_join_location(query)
-        room_list = new_query.filter(LocationModel.id == location_id).all()
-        results = RoomAnalytics.get_daily_meetings_details(self, room_list, day_start)  # noqa: E501
+        results = RoomAnalytics.get_daily_meetings_details(self, query, location_id, day_start)  # noqa: E501
+        return Analytics(MeetingsDurationaAnalytics=results)
 
-        return Analytics(dailyDurationaAnalytics=results)
+    @Auth.user_roles('Admin')
+    def resolve_monthly_durations_of_meetings(self, info, month, year, location_id):  # noqa: E501
+        query = Room.get_query(info)
+        results = RoomAnalytics.get_meeting_duration_of_room_per_month(self, query, month, year, location_id)  # noqa
+        return Analytics(MeetingsDurationaAnalytics=results)
 
     @Auth.user_roles('Admin')
     def resolve_analytics_for_least_used_room_per_month(self, info, month, year, location_id):  # noqa: E501

--- a/fixtures/room/room_analytics_daily_duration_fixtures.py
+++ b/fixtures/room/room_analytics_daily_duration_fixtures.py
@@ -2,8 +2,8 @@ null = None
 
 get_daily_meetings_total_duration_query = '''
 query {
-    dailyDurationsOfMeetings(locationId:1, dayStart:"sep 10 2018"){
-        dailyDurationaAnalytics{
+    dailyDurationsOfMeetings(locationId:1, dayStart: "sep 10 2018"){
+        MeetingsDurationaAnalytics{
             roomName
             count
             totalDuration
@@ -19,7 +19,7 @@ query {
 get_daily_meetings_total_duration_response = {
     "data": {
         "dailyDurationsOfMeetings": {
-            "dailyDurationaAnalytics": [
+            "MeetingsDurationaAnalytics": [
                 {
                     "roomName": "Entebbe",
                     "count": 0,

--- a/fixtures/room/room_monthly_meeting_duration_fixtures.py
+++ b/fixtures/room/room_monthly_meeting_duration_fixtures.py
@@ -1,0 +1,31 @@
+get_monthly_meetings_total_duration_query = '''
+    {
+        monthlyDurationsOfMeetings(month:"Jul", year:2018, locationId:1)
+        {
+            MeetingsDurationaAnalytics {
+                roomName
+                count
+                totalDuration
+                events{
+                    durationInMinutes
+                    numberOfMeetings
+                }
+            }
+        }
+    }
+'''
+
+get_monthly_meetings_total_duration_response = {
+        "data": {
+            "monthlyDurationsOfMeetings": {
+                "MeetingsDurationaAnalytics": [
+                    {
+                        "roomName": "Entebbe",
+                        "totalDuration": 0,
+                        "count": 0,
+                        "events": []
+                    }
+                ]
+            }
+        }
+    }

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -22,6 +22,10 @@ from fixtures.room.room_analytics_fixtures import (
     get_most_used_room_without_event_response
 
 )
+from fixtures.room.room_monthly_meeting_duration_fixtures import (
+    get_monthly_meetings_total_duration_query,
+    get_monthly_meetings_total_duration_response
+)
 
 
 class QueryRoomsAnalytics(BaseTestCase):
@@ -94,4 +98,11 @@ class QueryRoomsAnalytics(BaseTestCase):
             self,
             get_most_used_room_without_event_query,
             get_most_used_room_without_event_response
+        )
+
+    def test_total_monthly_meeting_durations(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_monthly_meetings_total_duration_query,
+            get_monthly_meetings_total_duration_response
         )


### PR DESCRIPTION
#### What does this PR do?
 Enable admin to know the total meeting duration for each room within a specific month.
#### How should this be manually tested?
- Clone this branch in your local machine, Run the server
- Test the queries at localhost:5000/mrm
- Run `monthlyDurationsOfMeetings` query with `locationId`, `month` and `year` as the keyword arguments as shown in the screen shot below.
#### What are the relevant pivotal tracker stories?
[#160447638](https://www.pivotaltracker.com/story/show/160447638)
#### Screenshots 
     When an admin runs the query with locationId, year and month.
<img width="1440" alt="screen shot 2018-10-03 at 15 57 31" src="https://user-images.githubusercontent.com/28715887/46412017-ebe26400-c725-11e8-8c20-3dac31034a75.png">

