### PR TITLE
#160447342 Analytics for least used room per day

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -225,6 +225,12 @@ class Query(graphene.ObjectType):
         year=graphene.Int(),
     )
 
+    analytics_for_least_used_room_per_day = graphene.Field(
+        Analytics,
+        location_id=graphene.Int(),
+        day=graphene.String(),
+    )
+
     def check_valid_calendar_id(self, query, calendar_id):
         check_calendar_id = query.filter(
             RoomModel.calendar_id == calendar_id
@@ -304,6 +310,7 @@ class Query(graphene.ObjectType):
         )
         return room_most_used_per_week
 
+    @Auth.user_roles('Admin')
     def resolve_analytics_for_meetings_per_room(self, info, location_id, day_start, day_end):  # noqa: E501
         query = Room.get_query(info)
         meeting_summary = RoomAnalytics.get_meetings_per_room(
@@ -330,6 +337,16 @@ class Query(graphene.ObjectType):
         query = Room.get_query(info)
         room_analytics = RoomAnalytics.get_least_used_room_per_month(
             self, query, month, year, location_id)
+        return Analytics(
+            analytics=room_analytics
+        )
+
+    @Auth.user_roles('Admin')
+    def resolve_analytics_for_least_used_room_per_day(self, info, day, location_id):  # noqa: E501
+        query = Room.get_query(info)
+        room_analytics = RoomAnalytics.get_least_used_room_day(
+            self, query, day, location_id
+        )
         return Analytics(
             analytics=room_analytics
         )

--- a/fixtures/room/room_analytics_fixtures.py
+++ b/fixtures/room/room_analytics_fixtures.py
@@ -373,3 +373,31 @@ get_most_used_room_without_event_response = {
         }
     }
 }
+
+analytics_for_least_used_room_day = '''
+{
+    analyticsForLeastUsedRoomPerDay(locationId:1 day:"Jul 11 2018"){
+        analytics{
+            roomName
+            count
+            events{
+                durationInMinutes
+                numberOfMeetings
+            }
+            }
+        }
+    }
+'''
+
+analytics_for_least_used_room_day_response = {
+    "data": {
+        "analyticsForLeastUsedRoomPerDay": {
+            "analytics": [
+                {
+                    "roomName": "Entebbe",
+                    "count": 0,
+                    "events": null}
+            ]
+        }
+    }
+}

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -170,22 +170,13 @@ class RoomAnalytics(Credentials):
             room_events_count=room_events_count
         )
 
-    def get_least_used_room_week(self, query, location_id, week_start, week_end):  # noqa: E501
-        """ Get analytics for least used room per week
-         :params
-            - calendar_id, location_id
-            - week_start, week_end(Time range)
-        """
-        week_start = RoomAnalytics.convert_date(self, week_start)
-        week_end = RoomAnalytics.convert_date(self, week_end)
+    def get_least_used_rooms(self, rooms_available, time_start, time_end):
 
-        rooms_available = RoomAnalytics.get_calendar_id_name(
-            self, query, location_id)
         res = []
         number_of_least_events = float('inf')
         for room in rooms_available:
             calendar_events = RoomAnalytics.get_all_events_in_a_room(
-                self, room['calendar_id'], week_start, week_end)
+                self, room['calendar_id'], time_start, time_end)
             output = []
             if not calendar_events:
                 output.append({'RoomName': room['name'], 'has_events': False})
@@ -200,6 +191,29 @@ class RoomAnalytics(Credentials):
         analytics = RoomAnalytics.get_room_statistics(
             self, number_of_least_events, res)
         return analytics
+
+    def get_least_used_room_day(self, query, day, location_id):
+        """ Get event stats for all rooms in a specified day
+            :params
+                - location_id, day
+        """
+        day_start, day_end = RoomAnalytics.get_start_end_day_dates(self, day)
+        rooms_available = RoomAnalytics.get_calendar_id_name(
+            self, query, location_id)
+        return RoomAnalytics.get_least_used_rooms(self, rooms_available, day_start, day_end)  # noqa: E501
+
+    def get_least_used_room_week(self, query, location_id, week_start, week_end):  # noqa: E501
+        """ Get analytics for least used room per week
+         :params
+            - calendar_id, location_id
+            - week_start, week_end(Time range)
+        """
+        week_start = RoomAnalytics.convert_date(self, week_start)
+        week_end = RoomAnalytics.convert_date(self, week_end)
+
+        rooms_available = RoomAnalytics.get_calendar_id_name(
+            self, query, location_id)
+        return RoomAnalytics.get_least_used_rooms(self, rooms_available, week_start, week_end)  # noqa: E501
 
     def get_most_used_room_per_month(self, query, month, year, location_id):
         """ Get analytics for the MOST used room(s) per morth in a location

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -16,6 +16,8 @@ from fixtures.room.room_analytics_fixtures import (
     get_least_used_room_per_month_response,
     get_least_used_room_per_month_invalid_location,
     response_least_used_room_per_month_invalid_location,
+    analytics_for_least_used_room_day,
+    analytics_for_least_used_room_day_response,
     get_most_used_room_per_week_query,
     get_most_used_room_per_week_response,
     get_most_used_room_without_event_query,
@@ -106,3 +108,10 @@ class QueryRoomsAnalytics(BaseTestCase):
             get_monthly_meetings_total_duration_query,
             get_monthly_meetings_total_duration_response
         )
+
+    def test_analytics_for_least_used_room_day(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            analytics_for_least_used_room_day,
+            analytics_for_least_used_room_day_response
+            )


### PR DESCRIPTION
### What does this PR do?

- This PR enables admins see the least used room per day.

#### How should this be manually tested?
- Run the server.
- Test the query at localhost:5000/mrm.
- Run `analyticsForLeastUsedRoomPerDay` query with `locationId` and `day`  as the arguments.

### What are the relevant pivotal tracker stories?

#160447342


#### Screenshots
###### least used room on Jul 10 2018
<img width="1013" alt="least used room per day" src="https://user-images.githubusercontent.com/6715848/46421243-674e1080-c73a-11e8-9e3a-9ff1e200fce4.png">
