### PR TITLE
#160949212 Fix Backend Tests to Remove Duplication

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -14,10 +14,11 @@ from api.role.models import Role
 from api.user_role.models import UsersRole
 from api.devices.models import Devices
 from api.office.models import Office
-from fixtures.token.token_fixture import user_api_token
+from fixtures.token.token_fixture import user_api_token, admin_api_token
 
 import sys
 import os
+import json
 
 
 sys.path.append(os.getcwd())
@@ -84,6 +85,69 @@ class BaseTestCase(TestCase):
         with app.app_context():
             db_session.remove()
             Base.metadata.drop_all(bind=engine)
+
+
+class CommonTestCases(BaseTestCase):
+    """Common test cases throught the code.
+    This code is used to reduce duplication
+    :params
+        - admin_token_assert_equal
+        - admin_token_assert_in
+        - user_token_assert_equal
+        - user_token_assert_in
+    """
+
+    def admin_token_assert_equal(self, query, expected_response):
+        """
+        Make a request with admin token and use assertEquals
+        to compare the values
+
+        :params
+            - query, expected_response
+        """
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
+        response = self.app_test.post(
+            '/mrm?query=' + query, headers=headers)
+        actual_response = json.loads(response.data)
+        self.assertEquals(actual_response, expected_response)
+
+    def admin_token_assert_in(self, query, expected_response):
+        """
+        Make a request with admin token and use assertIn
+        to compare the values
+
+        :params
+            - query, expected_response
+        """
+        headers = {"Authorization": "Bearer" + " " + admin_api_token}
+        response = self.app_test.post('/mrm?query=' + query, headers=headers)
+        self.assertIn(expected_response, str(response.data))
+
+    def user_token_assert_equal(self, query, expected_response):
+        """
+        Make a request with user token and use assertEquals
+        to compare the values
+
+        :params
+            - query, expected_response
+        """
+        headers = {"Authorization": "Bearer" + " " + user_api_token}
+        response = self.app_test.post(
+            '/mrm?query=' + query, headers=headers)
+        actual_response = json.loads(response.data)
+        self.assertEquals(actual_response, expected_response)
+
+    def user_token_assert_in(self, query, expected_response):
+        """
+        Make a request with user token and use assertIn
+        to compare the values
+
+        :params
+            - query, expected_response
+        """
+        headers = {"Authorization": "Bearer" + " " + user_api_token}
+        response = self.app_test.post('/mrm?query=' + query, headers=headers)
+        self.assertIn(expected_response, str(response.data))
 
 
 def change_user_role_helper(func):

--- a/tests/test_office/test_create_office.py
+++ b/tests/test_office/test_create_office.py
@@ -1,12 +1,13 @@
 import sys
 import os
-import json
 
-from tests.base import BaseTestCase
-from fixtures.token.token_fixture import admin_api_token
-from fixtures.office.office_fixtures import (office_mutation_query, office_mutation_response, office_mutation_query_Different_Location,  # noqa : E501
-office_mutation_query_non_existant_ID, office_mutation_query_duplicate_name,
-office_mutation_query_duplicate_name_responce)
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.office.office_fixtures import (
+    office_mutation_query, office_mutation_response,
+    office_mutation_query_Different_Location,
+    office_mutation_query_non_existant_ID,
+    office_mutation_query_duplicate_name,
+    office_mutation_query_duplicate_name_responce)
 
 sys.path.append(os.getcwd())
 
@@ -17,40 +18,38 @@ class TestCreateOffice(BaseTestCase):
         """
         Testing for office creation
         """
-
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+office_mutation_query, headers=headers)
-        expected_response = office_mutation_response
-        actual_response = json.loads(response.data)
-        self.assertEqual(expected_response, actual_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            office_mutation_query,
+            office_mutation_response
+        )
 
     def test_create_office_different_location(self):
         """
         Test creating office in different location
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+office_mutation_query_Different_Location,
-            headers=headers)
-        self.assertIn("You are not authorized to make changes in", str(response.data))  # noqa : E501
+        CommonTestCases.admin_token_assert_in(
+            self,
+            office_mutation_query_Different_Location,
+            "You are not authorized to make changes in"
+        )
 
     def test_office_creation_with_non_existant_ID(self):
         """
         Testing for office creation with non existant ID
         """
-
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+office_mutation_query_non_existant_ID, headers=headers)  # noqa : E501
-        self.assertIn("Location not found", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            office_mutation_query_non_existant_ID,
+            "Location not found"
+        )
 
     def test_office_creation_with_an_already_existent_name(self):
         """
         Testing for office creation with an already existing office name
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+office_mutation_query_duplicate_name, headers=headers)  # noqa : E501
-        actual_response = json.loads(response.data)  # noqa: E501
-        self.assertEquals(actual_response, office_mutation_query_duplicate_name_responce)  # noqa: E501
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            office_mutation_query_duplicate_name,
+            office_mutation_query_duplicate_name_responce
+        )

--- a/tests/test_office/test_delete_office.py
+++ b/tests/test_office/test_delete_office.py
@@ -1,27 +1,30 @@
 import json
 
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 
-from fixtures.office.office_fixtures import (delete_office_mutation,
-                                             delete_office_mutation_response,
-                                             delete_non_existent_office_mutation,  # noqa: E501
-                                             delete_unauthorised_location_mutation)  # noqa: E501
+from fixtures.office.office_fixtures import (
+    delete_office_mutation,
+    delete_office_mutation_response,
+    delete_non_existent_office_mutation,
+    delete_unauthorised_location_mutation
+)
 from fixtures.token.token_fixture import admin_api_token
 
 
 class TestDeleteOffice(BaseTestCase):
     def test_delete_office(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+delete_office_mutation,
-                                      headers=headers)
-        actual_response = json.loads(response.data)
-        self.assertEquals(delete_office_mutation_response, actual_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_office_mutation,
+            delete_office_mutation_response
+        )
 
     def test_delete_non_existent_office(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+delete_non_existent_office_mutation,  # noqa: E501
-                                      headers=headers)
-        self.assertIn("Office not found", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_non_existent_office_mutation,
+            "Office not found"
+        )
 
     def test_delete_unautorised_location(self):
         headers = {"Authorization": "Bearer" + " " + admin_api_token}

--- a/tests/test_office/test_get_office_by_name.py
+++ b/tests/test_office/test_get_office_by_name.py
@@ -1,9 +1,7 @@
 import sys
 import os
-import json
 
-from tests.base import BaseTestCase
-from fixtures.token.token_fixture import user_api_token
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.office.office_fixtures import (
     get_office_by_name,
     get_office_by_name_response)
@@ -13,8 +11,8 @@ sys.path.append(os.getcwd())
 
 class GetOfficeByName(BaseTestCase):
     def test_get_office_by_name(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        get_office_query = self.app_test.post(
-            '/mrm?query='+get_office_by_name, headers=headers)
-        actual_response = json.loads(get_office_query.data)
-        self.assertEquals(actual_response, get_office_by_name_response)
+        CommonTestCases.user_token_assert_equal(
+            self,
+            get_office_by_name,
+            get_office_by_name_response
+        )

--- a/tests/test_office/test_update_office.py
+++ b/tests/test_office/test_update_office.py
@@ -1,9 +1,7 @@
 import sys
 import os
-import json
 
-from tests.base import BaseTestCase
-from fixtures.token.token_fixture import admin_api_token
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.office.update_office_fixture import (
     update_office_in_another_location_query,
     update_office_with_wrong_ID_query,
@@ -20,32 +18,38 @@ class TestUpdateOffice(BaseTestCase):
         """
         Test updating an existing office
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+update_office_query, headers=headers)  # noqa: E501
-        expected_response = office_mutation_response
-        actual_response = json.loads(response.data)
-        self.assertEqual(expected_response, actual_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_office_query,
+            office_mutation_response
+        )
 
     def test_updating_non_existant_office(self):
         """
         Test updating a non existing office
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+update_office_with_wrong_ID_query, headers=headers)  # noqa: E501
-        self.assertIn("Office not found", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_office_with_wrong_ID_query,
+            "Office not found"
+        )
 
     def test_updating_office_name_with_an_existing_name(self):
         """
         Test updating office name with an already existing name
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+update_office_with_same_Name_query, headers=headers)  # noqa: E501
-        self.assertIn("Action Failed", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_office_with_same_Name_query,
+            "Action Failed"
+        )
 
     def test_updating_office_in_another_location(self):
         """
         Test updating office in another location
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+update_office_in_another_location_query, headers=headers)  # noqa: E501
-        self.assertIn("You are not authorized to make changes in", str(response.data))  # noqa: E501
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_office_in_another_location_query,
+            "You are not authorized to make changes in"
+        )

--- a/tests/test_room_resource/test_create_room_resource.py
+++ b/tests/test_room_resource/test_create_room_resource.py
@@ -1,12 +1,9 @@
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room_resource.room_resource_fixtures import (
     resource_mutation_query,
     resource_mutation_0_room_id,
     resource_mutation_empty_name
 )
-from fixtures.token.token_fixture import (user_api_token, admin_api_token)
-
-# from api.room.models import Room
 
 import sys
 import os
@@ -16,29 +13,29 @@ sys.path.append(os.getcwd())
 class TestCreateRoomResource(BaseTestCase):
 
     def test_resource_creation_mutation_when_not_admin(self):
-
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        response = self.app_test.post('/mrm?query='+resource_mutation_query,
-                                      headers=headers)
-        self.assertIn("You are not authorized to perform this action",
-                      str(response.data))
+        CommonTestCases.user_token_assert_in(
+            self,
+            resource_mutation_query,
+            "You are not authorized to perform this action"
+        )
 
     def test_room_resource_creation_when_admin(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+resource_mutation_query,
-                                      headers=headers)
-        self.assertIn("Speakers", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            resource_mutation_query,
+            "Speakers"
+        )
 
     def test_room_resource_creation_name_error(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-                                    '/mrm?query='+resource_mutation_empty_name,
-                                    headers=headers)
-        self.assertIn("name is required", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            resource_mutation_empty_name,
+            "name is required"
+        )
 
     def test_room_resource_creation_room_id_error(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-                                    '/mrm?query='+resource_mutation_0_room_id,
-                                    headers=headers)
-        self.assertIn("Room not found", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            resource_mutation_0_room_id,
+            "Room not found"
+        )

--- a/tests/test_room_resource/test_delete_resource.py
+++ b/tests/test_room_resource/test_delete_resource.py
@@ -1,11 +1,10 @@
 import sys
 import os
 
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room_resource.delete_room_resource import (  # noqa: F401
   delete_resource, expected_query_after_delete, delete_non_existant_resource)  # noqa: E501
 from helpers.database import db_session  # noqa: F401
-from fixtures.token.token_fixture import (admin_api_token, user_api_token)
 
 
 sys.path.append(os.getcwd())
@@ -14,22 +13,22 @@ sys.path.append(os.getcwd())
 class TestDeleteRoomResource(BaseTestCase):
 
     def test_deleteresource_mutation_when_not_admin(self):
-
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        response = self.app_test.post('/mrm?query='+delete_resource,
-                                      headers=headers)
-        self.assertIn("You are not authorized to perform this action",
-                      str(response.data))
+        CommonTestCases.user_token_assert_in(
+            self,
+            delete_resource,
+            "You are not authorized to perform this action"
+        )
 
     def test_deleteresource_mutation_when_admin(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+delete_resource,
-                                      headers=headers)
-        self.assertIn("Markers", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_resource,
+            "Markers"
+        )
 
     def test_non_existant_deleteresource_mutation(self):
-
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+delete_non_existant_resource,  # noqa: E501
-                                      headers=headers)
-        self.assertIn("Resource not found", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_non_existant_resource,
+            "Resource not found"
+        )

--- a/tests/test_room_resource/test_update_room_resource.py
+++ b/tests/test_room_resource/test_update_room_resource.py
@@ -1,10 +1,8 @@
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room_resource.update_resource_fixtures import (
     update_room_resource_query,
     non_existant_resource_id_query
 )
-from fixtures.token.token_fixture import (admin_api_token, user_api_token)
-
 
 import os
 import sys
@@ -14,27 +12,22 @@ sys.path.append(os.getcwd())
 class TestUpdateRoomResorce(BaseTestCase):
 
     def test_deleteresource_mutation_when_not_admin(self):
-
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        response = self.app_test.post(
-            '/mrm?query=' +
+        CommonTestCases.user_token_assert_in(
+            self,
             update_room_resource_query,
-            headers=headers)
-        self.assertIn("You are not authorized to perform this action",
-                      str(response.data))
+            "You are not authorized to perform this action"
+        )
 
     def test_updateresource_mutation_when_admin(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query=' +
+        CommonTestCases.admin_token_assert_in(
+            self,
             update_room_resource_query,
-            headers=headers)
-        self.assertIn("Markers", str(response.data))
+            "Markers"
+        )
 
     def test_updateresource_mutation_when_id_doesnt_exist(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query=' +
+        CommonTestCases.admin_token_assert_in(
+            self,
             non_existant_resource_id_query,
-            headers=headers)
-        self.assertIn("Resource not found", str(response.data))
+            "Resource not found"
+        )

--- a/tests/test_rooms/test_analytics_total_daily_durations.py
+++ b/tests/test_rooms/test_analytics_total_daily_durations.py
@@ -1,6 +1,4 @@
-import json
-from tests.base import BaseTestCase
-from fixtures.token.token_fixture import admin_api_token
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room.room_analytics_daily_duration_fixtures import (
     get_daily_meetings_total_duration_query,
     get_daily_meetings_total_duration_response
@@ -13,8 +11,8 @@ class TotalDailyDurations(BaseTestCase):
         """
         Tests getting total durations for daily meetings
         """
-
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+get_daily_meetings_total_duration_query, headers=headers)  # noqa: E501
-        actual_response = json.loads(response.data)
-        self.assertEquals(actual_response, get_daily_meetings_total_duration_response)  # noqa: E501
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_daily_meetings_total_duration_query,
+            get_daily_meetings_total_duration_response
+        )

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -1,7 +1,6 @@
 import sys
 import os
-import json
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.token.token_fixture import admin_api_token
 from fixtures.helpers.decorators_fixtures import (
     query_string, query_string_response
@@ -35,83 +34,68 @@ class TestCreateRoom(BaseTestCase):
         """
         Test room creation with name field empty
         """
-
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+room_name_empty_mutation, headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = "name is required field"
-        self.assertEquals(
-            actual_response["errors"][0]["message"], expected_response)
+        CommonTestCases.admin_token_assert_in(
+            self,
+            room_name_empty_mutation,
+            "name is required field"
+        )
 
     def test_room_creation_with_invalid_officeId(self):
         """
         Test room creation with  invalid officeId
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-
-        response = self.app_test.post(
-            '/mrm?query='+room_invalid_officeId_mutation, headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = "Office Id does not exist"
-        self.assertEquals(
-            actual_response["errors"][0]["message"], expected_response)
+        CommonTestCases.admin_token_assert_in(
+            self,
+            room_invalid_officeId_mutation,
+            "Office Id does not exist"
+        )
 
     def test_room_creation_with_invalid_floorId(self):
         """
         Test room creation with  invalid floorId
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+room_invalid_floorId_mutation, headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = "Floor Id does not exist"
-        self.assertEquals(
-            actual_response["errors"][0]["message"], expected_response)
+        CommonTestCases.admin_token_assert_in(
+            self,
+            room_invalid_floorId_mutation,
+            "Floor Id does not exist"
+        )
 
     def test_room_creation_with_invalid_wingId(self):
         """
         Test room creation with  invalid wingId
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+room_invalid_wingId_mutation, headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = "Wing Id does not exist"
-        self.assertEquals(
-            actual_response["errors"][0]["message"], expected_response)
+        CommonTestCases.admin_token_assert_in(
+            self,
+            room_invalid_wingId_mutation,
+            "Wing Id does not exist"
+        )
 
     def test_room_creation_with_duplicate_name(self):
         """
         Test room creation with an already existing room name
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+room_mutation_query_duplicate_name, headers=headers)  # noqa : E501
-        expected_response = room_mutation_query_duplicate_name_response
-        actual_response = json.loads(response.data)
-        self.assertEqual(expected_response, actual_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            room_mutation_query_duplicate_name,
+            room_mutation_query_duplicate_name_response
+        )
 
     def test_room_creation_with_valid_blockId(self):
         """
         Test room creation with  invalid officeId
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+room_valid_blockId_mutation, headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = expected_room_valid_blockId_mutation_response
-        self.assertEquals(
-            actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            room_valid_blockId_mutation,
+            expected_room_valid_blockId_mutation_response
+        )
 
     def test_room_creation_with_invalid_blockId(self):
         """
         Test room creation with  invalid wingId
         """
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+room_invalid_blockId_mutation, headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = "Block with such id does not exist in this office"
-        self.assertEquals(
-            actual_response["errors"][0]["message"], expected_response)
+        CommonTestCases.admin_token_assert_in(
+            self,
+            room_invalid_blockId_mutation,
+            "Block with such id does not exist in this office"
+        )

--- a/tests/test_rooms/test_delete_room.py
+++ b/tests/test_rooms/test_delete_room.py
@@ -1,28 +1,29 @@
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 
 from fixtures.room.delete_room_fixtures import (
     delete_room_query,
     delete_room_query_non_existant_room_id,
 )
-from fixtures.token.token_fixture import (user_api_token, admin_api_token)
 
 
 class TestDeleteRoom(BaseTestCase):
     def test_delete_room_admin_user(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+delete_room_query,
-                                      headers=headers)
-        self.assertIn("Entebbe", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_room_query,
+            "Entebbe"
+        )
 
     def test_delete_room_non_admin_user(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        response = self.app_test.post('/mrm?query='+delete_room_query,
-                                      headers=headers)
-        self.assertIn("You are not authorized to perform this action",
-                      str(response.data))
+        CommonTestCases.user_token_assert_in(
+            self,
+            delete_room_query,
+            "You are not authorized to perform this action"
+        )
 
     def test_non_existant_room_id(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+delete_room_query_non_existant_room_id, # noqa : E501
-                                      headers=headers)
-        self.assertIn("Room not found", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_room_query_non_existant_room_id,
+            "Room not found"
+        )

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -1,7 +1,4 @@
-import json
-
-from tests.base import BaseTestCase
-from fixtures.token.token_fixture import (admin_api_token)
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room.room_analytics_fixtures import (
     get_most_used_room_in_a_month_analytics_query,
     get_most_used_room_in_a_month_analytics_response,
@@ -30,84 +27,71 @@ from fixtures.room.room_analytics_fixtures import (
 class QueryRoomsAnalytics(BaseTestCase):
 
     def test_most_used_room_in_a_month_analytics(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query=' + get_most_used_room_in_a_month_analytics_query, headers=headers)  # noqa: E501
-        actual_response = json.loads(response.data)
-        expected_response = get_most_used_room_in_a_month_analytics_response
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_most_used_room_in_a_month_analytics_query,
+            get_most_used_room_in_a_month_analytics_response
+        )
 
     def test_most_used_room_in_a_month_invalid_location_analytics(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query=' + most_used_room_in_a_month_analytics_invalid_location_query, headers=headers)  # noqa: E501
-        actual_response = json.loads(response.data)
-        expected_response = most_used_room_in_a_month_analytics_invalid_location_response  # noqa: E501
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            most_used_room_in_a_month_analytics_invalid_location_query,
+            most_used_room_in_a_month_analytics_invalid_location_response
+        )
 
     def test_analytics_for_least_used_room_weekly(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        analytics_query = self.app_test.post(
-            '/mrm?query=' + get_least_used_room_per_week_query, headers=headers)  # noqa: E501
-        actual_response = json.loads(analytics_query.data)
-        expected_response = get_least_used_room_per_week_response
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_least_used_room_per_week_query,
+            get_least_used_room_per_week_response
+        )
 
     def test_analytics_for_least_used_room_without_event_weekly(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        analytics_query = self.app_test.post(
-            '/mrm?query=' + get_least_used_room_without_event_query, headers=headers)  # noqa: E501
-        actual_response = json.loads(analytics_query.data)
-        expected_response = get_least_used_room_without_event_response
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_least_used_room_without_event_query,
+            get_least_used_room_without_event_response
+        )
 
     def test_room_usage_analytics(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+get_room_usage_analytics, headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = get_room_usage_anaytics_respone
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_room_usage_analytics,
+            get_room_usage_anaytics_respone
+        )
 
     def test_room_usage_analytics_invalid_location(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query='+get_room_usage_analytics_invalid_location,
-            headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = get_room_usage_analytics_invalid_location_response
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_room_usage_analytics_invalid_location,
+            get_room_usage_analytics_invalid_location_response
+        )
 
     def test_analytics_for_least_used_room_monthly(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query=' + get_least_used_room_per_month,
-            headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = get_least_used_room_per_month_response
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_least_used_room_per_month,
+            get_least_used_room_per_month_response
+        )
 
     def test_analytics_for_least_used_room_monthly_invalid_location(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post(
-            '/mrm?query=' + get_least_used_room_per_month_invalid_location,
-            headers=headers)
-        actual_response = json.loads(response.data)
-        expected_response = response_least_used_room_per_month_invalid_location
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_least_used_room_per_month_invalid_location,
+            response_least_used_room_per_month_invalid_location
+        )
 
     def test_analytics_for_most_used_room_weekly(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        analytics_query = self.app_test.post(
-            '/mrm?query=' + get_most_used_room_per_week_query, headers=headers)  # noqa: E501
-        actual_response = json.loads(analytics_query.data)
-        expected_response = get_most_used_room_per_week_response
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_most_used_room_per_week_query,
+            get_most_used_room_per_week_response
+        )
 
     def test_analytics_for_most_used_room_without_event_weekly(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        analytics_query = self.app_test.post(
-            '/mrm?query=' + get_most_used_room_without_event_query, headers=headers)  # noqa: E501
-        actual_response = json.loads(analytics_query.data)
-        expected_response = get_most_used_room_without_event_response
-        self.assertEquals(actual_response, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_most_used_room_without_event_query,
+            get_most_used_room_without_event_response
+        )

--- a/tests/test_rooms/test_room_filter.py
+++ b/tests/test_rooms/test_room_filter.py
@@ -1,8 +1,7 @@
 import sys
 import os
-import json
 
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room.filter_room_fixtures import (
     filter_rooms_by_capacity,
     filter_rooms_by_capacity_response,
@@ -27,101 +26,91 @@ from fixtures.room.filter_room_fixtures import (
     filter_rooms_response
 )
 
-from fixtures.token.token_fixture import (user_api_token)
-
 sys.path.append(os.getcwd())
 
 
 class RoomsFilter(BaseTestCase):
+
     def test_filter_room_by_capacity(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_capacity_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_capacity, headers=headers)
-        actual_response = json.loads(filter_room_by_capacity_query.data)
-        self.assertEquals(actual_response, filter_rooms_by_capacity_response)
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_capacity,
+            filter_rooms_by_capacity_response
+        )
 
     def test_filter_room_by_location(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_location_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_location, headers=headers)
-        actual_response = json.loads(filter_room_by_location_query.data)
-        self.assertEquals(actual_response, filter_rooms_by_location_response)
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_location,
+            filter_rooms_by_location_response
+        )
 
     def test_filter_room_by_resources(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_resources_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_resources, headers=headers)
-        actual_response = json.loads(filter_room_by_resources_query.data)
-        self.assertEquals(actual_response, filter_rooms_by_resources_response)
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_resources,
+            filter_rooms_by_resources_response
+        )
 
     def test_filter_room_by_location_capacity(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_location_capacity_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_location_capacity,
-            headers=headers)
-        actual_response = json.loads(filter_room_by_location_capacity_query.data)  # noqa: E501
-        self.assertEquals(actual_response, filter_rooms_by_location_capacity_response)  # noqa: E501
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_location_capacity,
+            filter_rooms_by_location_capacity_response
+        )
 
     def test_filter_room_by_resources_capacity(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_resources_capacity_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_resources_capacity,
-            headers=headers)
-        actual_response = json.loads(filter_room_by_resources_capacity_query.data)  # noqa: E501
-        self.assertEquals(actual_response, filter_rooms_by_resources_capacity_response)  # noqa: E501
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_resources_capacity,
+            filter_rooms_by_resources_capacity_response
+        )
 
     def test_filter_room_by_all(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_all = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_resources_location_capacity,
-            headers=headers)
-        actual_response = json.loads(filter_room_by_all.data)
-        self.assertEquals(actual_response, filter_rooms_by_resources_location_capacityresponse)  # noqa: E501
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_resources_location_capacity,
+            filter_rooms_by_resources_location_capacityresponse
+        )
 
     def test_filter_room_by_non_existant_data(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_nonexistant_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_non_existant_data,
-            headers=headers)
-        actual_response = json.loads(filter_room_by_nonexistant_query.data)
-        self.assertEquals(actual_response, filter_rooms_by_non_existant_datay_response)  # noqa: E501
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_non_existant_data,
+            filter_rooms_by_non_existant_datay_response
+        )
 
     def test_filter_room_by_resources_location(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_resources_capacity_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_resources_location,
-            headers=headers)
-        actual_response = json.loads(filter_room_by_resources_capacity_query.data)  # noqa: E501
-        self.assertEquals(actual_response, filter_rooms_by_resources_location_response)  # noqa: E501
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_resources_location,
+            filter_rooms_by_resources_location_response
+        )
 
     def test_filter_room_by_office(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_office_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_office,
-            headers=headers)
-        actual_response = json.loads(filter_room_by_office_query.data)
-        self.assertEquals(actual_response, filter_rooms_response)
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_office,
+            filter_rooms_response
+        )
 
     def test_filter_room_by_office_capacity(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_office_capacity_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_office_capacity,
-            headers=headers)
-        actual_response = json.loads(filter_room_by_office_capacity_query.data)
-        self.assertEquals(actual_response, filter_rooms_response)
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_office_capacity,
+            filter_rooms_response
+        )
 
     def test_filter_room_by_office_location(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_office_location_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_office_location,
-            headers=headers)
-        actual_response = json.loads(filter_room_by_office_location_query.data)
-        self.assertEquals(actual_response, filter_rooms_response)
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_office_location,
+            filter_rooms_response
+        )
 
     def test_filter_room_by_office_capacity_location(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        filter_room_by_office_capacity_location_query = self.app_test.post(
-            '/mrm?query='+filter_rooms_by_office_capacity_location,
-            headers=headers)
-        actual_response = json.loads(filter_room_by_office_capacity_location_query.data)  # noqa: E501
-        self.assertEquals(actual_response, filter_rooms_response)
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_office_capacity_location,
+            filter_rooms_response
+        )

--- a/tests/test_rooms/test_search_room_by_name.py
+++ b/tests/test_rooms/test_search_room_by_name.py
@@ -1,9 +1,8 @@
 import sys
 import os
-import json
 
 
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room.query_room_fixtures import (
     room_search_by_name,
     room_search_by_name_response,
@@ -13,33 +12,27 @@ from fixtures.room.query_room_fixtures import (
     room_search_by_invalid_name_response
 )
 
-from fixtures.token.token_fixture import (user_api_token)
-
 sys.path.append(os.getcwd())
 
 
 class SearchRoomsByName(BaseTestCase):
     def test_search_room_by_name(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        search_room_query = self.app_test.post(
-            '/mrm?query='+room_search_by_name, headers=headers)
-        actual_response = json.loads(search_room_query.data)
-        self.assertEquals(actual_response, room_search_by_name_response)
+        CommonTestCases.user_token_assert_equal(
+            self,
+            room_search_by_name,
+            room_search_by_name_response
+        )
 
     def test_search_room_by_empty_name(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        search_room_empty_query = self.app_test.post(
-            '/mrm?query='+room_search_by_empty_name, headers=headers)
-        actual_response = json.loads(search_room_empty_query.data)
-        expected_response = room_search_by_empty_name_response
-        self.assertEquals(
-            actual_response["errors"][0]['message'], expected_response)
+        CommonTestCases.user_token_assert_in(
+            self,
+            room_search_by_empty_name,
+            room_search_by_empty_name_response
+        )
 
     def test_search_room_by_invalid_name(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        search_room_by_invalid_name = self.app_test.post(
-            '/mrm?query='+room_search_by_invalid_name, headers=headers)
-        actual_response = json.loads(search_room_by_invalid_name.data)
-        expected_response = room_search_by_invalid_name_response
-        self.assertEquals(
-            actual_response["errors"][0]['message'], expected_response)
+        CommonTestCases.user_token_assert_in(
+            self,
+            room_search_by_invalid_name,
+            room_search_by_invalid_name_response
+        )

--- a/tests/test_rooms/test_update_room.py
+++ b/tests/test_rooms/test_update_room.py
@@ -1,6 +1,6 @@
 
 
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 
 from fixtures.room.room_update_fixtures import (
     query_update_all_fields,
@@ -8,38 +8,36 @@ from fixtures.room.room_update_fixtures import (
     query_room_id_non_existant,
     update_with_empty_field
 )
-from fixtures.token.token_fixture import (user_api_token, admin_api_token)
 
 
 class TestUpdateRoom(BaseTestCase):
 
     def test_resource_update_mutation_when_not_admin(self):
-        headers = {"Authorization": "Bearer" + " " + user_api_token}
-        response = self.app_test.post('/mrm?query='+query_update_all_fields,
-                                      headers=headers)
-        self.assertIn("You are not authorized to perform this action",
-                      str(response.data))
+        CommonTestCases.user_token_assert_in(
+            self,
+            query_update_all_fields,
+            "You are not authorized to perform this action")
 
     def test_if_all_fields_updated(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+query_update_all_fields,
-                                      headers=headers)
-        self.assertIn("Jinja", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            query_update_all_fields,
+            "Jinja")
 
     def test_for_error_if_id_not_supplied(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+query_without_room_id,
-                                      headers=headers)
-        self.assertIn("required positional argument", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            query_without_room_id,
+            "required positional argument")
 
     def test_for_error_if_room_id_is_non_existant_room(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+query_room_id_non_existant,
-                                      headers=headers)
-        self.assertIn("Room not found", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            query_room_id_non_existant,
+            "Room not found")
 
     def test_update_with_empty_field(self):
-        headers = {"Authorization": "Bearer" + " " + admin_api_token}
-        response = self.app_test.post('/mrm?query='+update_with_empty_field,
-                                      headers=headers)
-        self.assertIn("name is required field", str(response.data))
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_with_empty_field,
+            "name is required field")


### PR DESCRIPTION
#### What does this PR do?
- Creates a class for common test cases to allow the reuse of one code snippet.

#### Description of Task to be completed?
- Create a class that contains methods for the most used test cases
- Refactor tests to call these methods and pass their unique parameters for testing

#### How should this be manually tested?
- Change your `.env` file's app settings to `testing`
- Go to your terminal and enter the `mrm_api` folder
- Run `$ source .env`
- Run `$ tox`
- Wait for all tests to pass 

#### What are the relevant pivotal tracker stories?
[#160949212](https://www.pivotaltracker.com/story/show/160949212)