### PR TITLE
#160193943 Fix room creation duplication error.

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -62,9 +62,9 @@ class CreateRoom(graphene.Mutation):
             raise GraphQLError("No Office Found")
 
         if 'block_id' in kwargs:
-            exact_block = Block.query.filter_by(id=kwargs['block_id']).first()
+            exact_block = Block.query.filter_by(id=kwargs['block_id'], office_id=office_id).first()  # noqa: E501
             if not exact_block:
-                raise GraphQLError("Block with such id does not exist")
+                raise GraphQLError("Block with such id does not exist in this office")  # noqa: E501
             floor = Floor.query.filter_by(id=kwargs['floor_id']).first()
             if floor.block_id == kwargs['block_id']:
                 admin_roles.create_rooms_update_delete_office(office_id)

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -112,6 +112,6 @@ class TestCreateRoom(BaseTestCase):
         response = self.app_test.post(
             '/mrm?query='+room_invalid_blockId_mutation, headers=headers)
         actual_response = json.loads(response.data)
-        expected_response = "Block with such id does not exist"
+        expected_response = "Block with such id does not exist in this office"
         self.assertEquals(
             actual_response["errors"][0]["message"], expected_response)


### PR DESCRIPTION
#### What does this PR do?
-  Fixes room creation duplication error that arises in Kampala and Lagos offices.

#### How should this be manually tested?
- Run the server
- Test the mutation at `localhost:5000/mrm`
- Run `createRoom` mutation using an existing room name in any location

#### What are the relevant pivotal tracker stories?
[#160193943](https://www.pivotaltracker.com/story/show/160193943)

#### Screenshots
First creation
<img width="1222" alt="screen shot 2018-10-04 at 17 03 46" src="https://user-images.githubusercontent.com/20478530/46480461-f79f5a80-c7f9-11e8-8d3f-c3fbcad45d21.png">

Duplicate creation
<img width="1227" alt="screen shot 2018-10-04 at 17 03 59" src="https://user-images.githubusercontent.com/20478530/46480494-05ed7680-c7fa-11e8-84bc-0fd8332acc9f.png">

Creation of a room in a non-existent block
<img width="1211" alt="screen shot 2018-10-04 at 17 26 55" src="https://user-images.githubusercontent.com/20478530/46480955-ee62bd80-c7fa-11e8-9e61-5eb2711640fc.png">
