### PR TITLE
#160993422 Fix change of user role mutation

### DIFF
--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -101,8 +101,8 @@ class ChangeUserRole(graphene.Mutation):
         user_role = UsersRole.query.filter_by(user_id=exact_user.id).first()
         new_role = kwargs.pop('role_id')
         user_role.role_id = new_role
-        user_role.save()
-        return ChangeUserRole(user=exact_user)
+        with SaveContextManager(user_role, 'Role id', new_role):
+            return ChangeUserRole(user=exact_user)
 
 
 class Mutation(graphene.ObjectType):

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -114,3 +114,43 @@ query_user_email_response = {
         }
     }
 }
+
+change_user_role_mutation = '''
+mutation{
+    changeUserRole(email:"peter.walugembe@andela.com", roleId: 1){
+        user{
+            name
+            roles{
+                role
+            }
+        }
+    }
+}
+'''
+
+change_user_role_mutation_response = {
+    "data": {
+        "changeUserRole": {
+            "user": {
+                "name": "Peter Walugembe",
+                "roles": [
+                    {
+                        "role": "Admin"
+                    }
+                ]
+            }
+        }
+    }
+}
+
+change_user_role_to_non_existence_role_mutation = '''
+mutation{
+    changeUserRole(email:"peter.walugembe@andela.com", roleId: 10){
+        user{
+            name
+        }
+    }
+}
+'''
+
+change_user_role_to_non_existing_role_mutation_response = "Role id 10 does not exist"  # noqa: E501

--- a/helpers/auth/error_handler.py
+++ b/helpers/auth/error_handler.py
@@ -13,9 +13,15 @@ class SaveContextManager():
     def __enter__(self):
         try:
             self.model_obj.save()
-        except exc.IntegrityError:
-            return ErrorHandler.check_conflict(
-                self, self.entity_name, self.entity)
+        except exc.IntegrityError as err:
+            res = 'Database integrity error'
+            if "duplicate key value violates unique constraint" in str(err):
+                res = ErrorHandler.check_conflict(
+                    self, self.entity_name, self.entity)
+            elif "violates foreign key constraint" in str(err):
+                res = ErrorHandler.foreign_key_conflict(
+                    self, self.entity_name, self.entity)
+            return res
         except exc.DBAPIError:
             return ErrorHandler.db_connection(self)
 

--- a/helpers/auth/validator.py
+++ b/helpers/auth/validator.py
@@ -29,6 +29,11 @@ class ErrorHandler():
         raise GraphQLError(
             '{} {} already exists'.format(entity_name, entity))
 
+    def foreign_key_conflict(self, entity_name, entity):
+        # Database foreign key error
+        raise GraphQLError(
+            '{} {} does not exists'.format(entity_name, entity))
+
     def db_connection(self):
         # Database connection error
         raise GraphQLError('Error: Could not connect to Db')

--- a/tests/test_user/test_change_user_role.py
+++ b/tests/test_user/test_change_user_role.py
@@ -1,0 +1,30 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.user.user_fixture import (
+    change_user_role_mutation, change_user_role_mutation_response,
+    change_user_role_to_non_existence_role_mutation,
+    change_user_role_to_non_existing_role_mutation_response
+)
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestChangeUserRole(BaseTestCase):
+
+    def test_change_user_role(self):
+        """
+        Testing change of user role
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, change_user_role_mutation, change_user_role_mutation_response
+        )
+
+    def test_change_user_role_with_non_existing_role_id(self):
+        """
+        Testing change of user role with non existing role_id
+        """
+        CommonTestCases.admin_token_assert_in(
+            self, change_user_role_to_non_existence_role_mutation,
+            change_user_role_to_non_existing_role_mutation_response
+            )


### PR DESCRIPTION
### What does this PR do?

- This PR fix error in the change user role mutation when a role id that does not exist is passed as an argument.

#### How should this be manually tested?
- Run the server.
- Test the query at localhost:5000/mrm.
- Run `changeUserRole` mutation with `email` and `roleId` as arguments.

### What are the relevant pivotal tracker stories?

#160993422

#### Screenshots

###### Change user role with a non-existing role id.
![image](https://user-images.githubusercontent.com/22454909/46585922-f4b59b80-ca7f-11e8-9ed8-b355036ee372.png)

###### Change user role with an existing role id 
![image](https://user-images.githubusercontent.com/22454909/46585944-2890c100-ca80-11e8-96cf-82f261423926.png)
