### PR TITLE
#161179201 Fixes Room Creation making block ID required for Nairobi Office only

### DIFF
--- a/fixtures/helpers/decorators_fixtures.py
+++ b/fixtures/helpers/decorators_fixtures.py
@@ -36,7 +36,6 @@ room_mutation_query = '''
           capacity: 1,
           officeId: 1
           floorId: 1,
-          blockId: 1,
           imageUrl: "http://url.com") {
             room {
                 name

--- a/fixtures/room/create_room_in_block_fixtures.py
+++ b/fixtures/room/create_room_in_block_fixtures.py
@@ -1,38 +1,6 @@
-room_valid_blockId_mutation = '''
-    mutation {
-        createRoom(
-            name: "aso", roomType: "Meeting", capacity: 4, floorId: 1,
-            blockId: 1
-            officeId: 1
-            calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
-            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
-            room {
-                name
-                roomType
-                capacity
-                floorId
-                floor{
-                    blockId}
-            }
-        }
-    }
-'''
-expected_room_valid_blockId_mutation_response = {
-    "data": {
-        "createRoom": {
-            "room": {
-                "name": "aso",
-                "roomType": "Meeting",
-                "capacity": 4,
-                "floorId": 1,
-                "floor": {
-                     "blockId": 1
-                     }
-                     }
-                     }
-        }}
 
-room_invalid_blockId_mutation = '''
+
+room_blockId_not_required_mutation = '''
     mutation {
         createRoom(
             name: "aso", roomType: "Meeting", capacity: 4, floorId: 1,

--- a/helpers/auth/validator.py
+++ b/helpers/auth/validator.py
@@ -16,6 +16,15 @@ def assert_wing_is_required(office, kwargs):
             raise AttributeError("wing_id is not required for this office")
 
 
+def assert_block_id_is_required(office, kwargs):
+    if re.match('^(st\s?catherines?)$', office, re.IGNORECASE):
+        if not kwargs.get('block_id'):
+            raise AttributeError("block_id is required for this office")
+    else:
+        if kwargs.get('block_id'):
+            raise AttributeError("Block ID is not required for this office")
+
+
 def verify_email(email):
     return bool(re.match('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$',
                          email))

--- a/helpers/auth/verify_ids_for_room.py
+++ b/helpers/auth/verify_ids_for_room.py
@@ -1,6 +1,7 @@
 from api.office.models import Office
 from api.floor.models import Floor
 from api.wing.models import Wing
+from api.block.models import Block
 
 
 def verify_ids(office_id, kwargs):
@@ -15,3 +16,15 @@ def verify_ids(office_id, kwargs):
     wing_id = kwargs.get('wing_id')
     if wing_id and not Wing.query.filter_by(id=wing_id).first():
         raise AttributeError("Wing Id does not exist")
+
+
+def validate_block(office_id, kwargs):
+    block_id = kwargs.get("block_id")
+    get_floor = Floor.query.filter_by(id=kwargs.get('floor_id')).first()
+    if block_id:
+        exact_block = Block.query.filter_by(id=block_id, office_id=office_id).first()  # noqa: E501
+        if not exact_block:
+            raise AttributeError("Block with such id does not exist")
+        # checks if the floor exists in the given block
+        if get_floor.block_id != block_id:
+            raise AttributeError("Floor does not exist in this Block")

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -11,8 +11,8 @@ from fixtures.room.create_room_fixtures import (
     room_mutation_query_duplicate_name,
     room_mutation_query_duplicate_name_response)   # noqa : E501
 from fixtures.room.create_room_in_block_fixtures import (
-    room_valid_blockId_mutation, room_invalid_blockId_mutation,
-    expected_room_valid_blockId_mutation_response)
+    room_blockId_not_required_mutation
+    )
 
 sys.path.append(os.getcwd())
 
@@ -80,22 +80,12 @@ class TestCreateRoom(BaseTestCase):
             room_mutation_query_duplicate_name_response
         )
 
-    def test_room_creation_with_valid_blockId(self):
+    def test_room_creation_when_blockId_not_required(self):
         """
-        Test room creation with  invalid officeId
-        """
-        CommonTestCases.admin_token_assert_equal(
-            self,
-            room_valid_blockId_mutation,
-            expected_room_valid_blockId_mutation_response
-        )
-
-    def test_room_creation_with_invalid_blockId(self):
-        """
-        Test room creation with  invalid wingId
+        Test room creation with Block ID not required
         """
         CommonTestCases.admin_token_assert_in(
             self,
-            room_invalid_blockId_mutation,
-            "Block with such id does not exist in this office"
+            room_blockId_not_required_mutation,
+            "Block ID is not required for this office"
         )


### PR DESCRIPTION
### What does this PR do?
Allows Admins to create rooms in Kampala and Lagos Offices without passing a `Block ID`. But it required for the Nairobi Office

#### How should this be manually tested?

- Run the server.
- Test the query at localhost:5000/mrm.

#### What are the relevant pivotal tracker stories?
 #161179201
#### Screenshots (if appropriate)
I disabled the admin's location to able to test for Lagos and Nairobi

Creating a room in Kampala Office without a `Block ID`
![image](https://user-images.githubusercontent.com/32728156/46874166-2a240580-ce41-11e8-8801-59cac2dda1d0.png)

Creating a room in Kampala Office with a `Block ID`
![image](https://user-images.githubusercontent.com/32728156/46874296-80914400-ce41-11e8-8293-caa39c5824c3.png)

Creating a room in Nairobi Office without a `Block ID`
![image](https://user-images.githubusercontent.com/32728156/46874390-ba624a80-ce41-11e8-87e2-34a0afd843f4.png)

Creating a room in Nairobi Office with a `Block ID`
![image](https://user-images.githubusercontent.com/32728156/46874474-e978bc00-ce41-11e8-9ac0-453bf8b51e23.png)

Creating a room in Lagos Office with a `Wing ID` but no `Block ID`
![image](https://user-images.githubusercontent.com/32728156/46874585-25ac1c80-ce42-11e8-93d4-b118862dc110.png)

