### PR TITLE
#161054985 Export analytics report as JPEG 

### DIFF
--- a/api/analytics/analytic_report.py
+++ b/api/analytics/analytic_report.py
@@ -102,3 +102,16 @@ class AnalyticsReport():
 
         summary = WriteFile.wrte_csv(self, combined_report, 'Analytics_report.csv')  # noqa: E501
         return summary
+
+    def get_jpeg_analytics_report(self, query, start_time, end_time):
+        '''
+        Convert analytics for 5 least and most used rooms into a jpeg
+        '''
+        report_df = AnalyticsReport.generate_combined_analytics_report(
+            self, query, start_time, end_time)
+
+        df1 = report_df['Most Used Rooms']
+        df2 = report_df['Least Used Rooms']
+        report_jpeg = WriteFile.analytics_report_image(self, df1, df2, outputfile="report.jpeg", format="jpeg")  # noqa: E501
+
+        return report_jpeg

--- a/api/analytics/analytics_request.py
+++ b/api/analytics/analytics_request.py
@@ -52,6 +52,9 @@ class AnalyticsRequest():
         if file_type == 'CSV':
             response = AnalyticsReport.get_csv_analytics_report(
                 self, query, start_date, end_date)
+        elif file_type == 'JPEG':
+            response = AnalyticsReport.get_jpeg_analytics_report(
+                self, query, start_date, end_date)
         else:
             response = AnalyticsReport.get_json_analytics_report(
                 self, query, start_date, end_date)

--- a/api/analytics/write_files.py
+++ b/api/analytics/write_files.py
@@ -1,5 +1,7 @@
-
 from flask import make_response
+import imgkit
+import os
+import cv2
 
 
 class WriteFile():
@@ -20,4 +22,64 @@ class WriteFile():
         response = make_response(response)
         response.headers['Content-Disposition'] = 'attachment; filename={}'.format(file_name)  # noqa: E501
         response.mimetype = 'text/csv'
+        return response
+
+    def analytics_report_image(self, df1, df2, outputfile="report.jpeg", format="jpeg"):  # noqa: E501
+        '''
+        Returning a DataFrame as a JPEG image.
+        '''
+        css = """
+            <style type=\"text/css\">
+            table {
+            width: 640px;
+            border-collapse:
+            collapse;
+            border-spacing: 0;
+            margin-left:5%
+            }
+
+            td, th {
+            border: 1px solid transparent; /* No more visible border */
+            height: 40px;
+            text-align: left;
+            }
+
+            th {
+            font-weight: bold;
+            }
+
+            td {
+            background: #FAFAFA;
+            padding-left:3%
+            }
+
+            table tr:nth-child(odd) td{
+            background-color: white;
+            }
+
+            h3 {
+            margin-left:3% !important;
+            }
+            </style>
+            """
+        fn = "file.html"
+        try:
+            os.remove(fn)
+        except:  # noqa: E722
+            None
+
+        text_file = open(fn, "a")
+        text_file.write(css)
+        text_file.write('<br><br><h3>Most Booked Rooms</h3>' + df1.to_html(index=False) + '<br><br><h3>Least Booked Rooms</h3>' + df2.to_html(index=False) + '<br><br>')  # noqa: E501
+        text_file.close()
+
+        imgkitoptions = {"format": format}
+        imgkit.from_file(fn, "templates/report_template.jpeg", options=imgkitoptions)  # noqa: E501
+        os.remove(fn)
+        im_gray = cv2.imread('templates/report_template.jpeg')
+        img_str = cv2.imencode('.jpg', im_gray)[1].tostring()
+        response = make_response(img_str)
+        cd = 'attachment; filename=report.jpeg'
+        response.headers['Content-Disposition'] = cd
+        response.mimetype = 'image/jpeg'
         return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,13 @@ Flask-GraphQL==1.4.1
 google-api-python-client==1.6.7
 graphene-sqlalchemy==2.0.0
 graphene==2.1
+imgkit==1.0.1
 MarkupSafe==1.0
 more-itertools==4.1.0
 numpy==1.15.2
+opencv-python==3.4.3.18
 pandas==0.23.4
+Pillow==5.3.0
 psycopg2-binary==2.7.4
 py==1.5.3
 pytest==3.5.0


### PR DESCRIPTION
#### What does this PR do?
-  Exports room analytics report as JPEG

#### How should this be manually tested?
- Run the server
- Ensure to install wkhtmltoimage and  wkhtmltopdf by running the command: `brew install Caskroom/cask/wkhtmltopdf` on your terminal.
- Test the mutation at `localhost:5000/analytics`
- Make a POST request using json input containing: `timeMin`, `timeMax`, `fileType`: "JPEG"
- Download the file generated and view.


#### What are the relevant pivotal tracker stories?
[#161054985](https://www.pivotaltracker.com/story/show/161054985)

#### Screenshots
1. Request and Output
<img width="1191" alt="request and responce" src="https://user-images.githubusercontent.com/20478530/47713567-a729ea00-dc4b-11e8-965a-e3939a87e0fc.png">

2. Downloaded Image
<img width="1127" alt="downloaded image" src="https://user-images.githubusercontent.com/20478530/47713561-a4c79000-dc4b-11e8-85e2-32fc17ad9cc4.png">

3. Response when no file format is specified
<img width="1134" alt="json" src="https://user-images.githubusercontent.com/20478530/47713665-e5270e00-dc4b-11e8-9b6d-a2810deb5b1b.png">

