### PR TITLE
#161279850 users should be able to set email notification preferences.

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -27,8 +27,8 @@ class Query(
     api.devices.schema.Query,
     api.office.schema.Query,
     api.wing.schema.Query,
-    api.notification.schema.Query,
-    utilities.calendar_ids_cleanup.Query
+    utilities.calendar_ids_cleanup.Query,
+    api.notification.schema.Query
 ):
     pass
 


### PR DESCRIPTION
**What does this PR do?**

Enables a user to set his/her device health email notification preference to either True or False.

**How should this be tested?**

- Run migrations.
- Run the server.
- Run the `getUserNotificationSettings` query with `userId` as the argument.
- Run the `updateNotification` mutation with `deviceHealthNotification` as the argument.

**What are the relevant pivotal tracker stories?**
[#161279850](https://www.pivotaltracker.com/story/show/161279850)

**Screenshots**

1. _Query for a non-existing user_

![image](https://user-images.githubusercontent.com/28927645/47350144-dd9cbd80-d6bd-11e8-997e-1e27ad57770a.png)

2. _Query for an existing user_

![image](https://user-images.githubusercontent.com/28927645/47350213-0a50d500-d6be-11e8-8f4f-a99f0149ee7d.png)

3. _Mutuation for a user_

![image](https://user-images.githubusercontent.com/28927645/47357706-307f7080-d6d0-11e8-8a58-c52eddf6e886.png)



