### PR TITLE
#161481601 add event listener for calendar id during room creation

### DIFF
--- a/api/room/models.py
+++ b/api/room/models.py
@@ -1,11 +1,13 @@
-from sqlalchemy import (Column, String, Integer, ForeignKey)
+from sqlalchemy import (Column, String, Integer, ForeignKey, event)
 from sqlalchemy.orm import relationship
+from graphql import GraphQLError
 
-from helpers.database import Base
+from helpers.database import Base, db_session
 from utilities.utility import Utility
 from api.floor.models import Floor  # noqa: F401
 from api.wing.models import Wing  # noqa: F401
 from api.events.models import Events  # noqa: F401
+from helpers.auth.validator import verify_calendar_id
 
 
 class Room(Base, Utility):
@@ -21,3 +23,12 @@ class Room(Base, Utility):
     floor = relationship('Floor')
     resources = relationship('Resource', cascade="all, delete-orphan")
     events = relationship('Events', cascade="all, delete-orphan")
+
+
+@event.listens_for(Room, 'before_insert')
+def receive_before_insert(mapper, connection, target):
+    @event.listens_for(db_session, "after_flush", once=True)
+    def receive_after_flush(session, context):
+        if not verify_calendar_id(target.calendar_id):
+            raise GraphQLError("Room calendar Id is invalid")
+        pass

--- a/fixtures/helpers/decorators_fixtures.py
+++ b/fixtures/helpers/decorators_fixtures.py
@@ -31,7 +31,7 @@ room_mutation_query = '''
     mutation {
         createRoom(
           name: "Syne",
-          calendarId: "id-w09e9slkj"
+          calendarId: "andela.com_3836323338323230343935@resource.calendar.google.com",  # noqa: E501
           roomType: "Meeting",
           capacity: 1,
           officeId: 1
@@ -53,7 +53,7 @@ user_role_401_msg = b'{"errors":[{"message":"You are not authorized to perform t
 
 query_string = '/mrm?query='+room_mutation_query
 
-query_string_response = b'{"data":{"createRoom":{"room":{"name":"Syne","roomType":"Meeting","capacity":1,"floorId":1,"calendarId":"id-w09e9slkj","imageUrl":"http://url.com"}}}}'  # noqa: E501
+query_string_response = b'{"data":{"createRoom":{"room":{"name":"Syne","roomType":"Meeting","capacity":1,"floorId":1,"calendarId":"andela.com_3836323338323230343935@resource.calendar.google.com","imageUrl":"http://url.com"}}}}'  # noqa: E501
 
 expired_token = jwt.encode(expired, SECRET_KEY)
 

--- a/fixtures/room/create_room_fixtures.py
+++ b/fixtures/room/create_room_fixtures.py
@@ -160,6 +160,38 @@ room_invalid_wingId_mutation = '''
     }
 '''
 
+room_invalid_calendar_id_mutation_query = '''
+    mutation {
+        createRoom(
+            name: "Kigali", roomType: "Meeting", capacity: 6, floorId: 1, officeId: 1,
+            calendarId:"andela.com_38363233383232303439@resource.calendar.google.com",
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            room {
+                name
+            }
+        }
+    }
+'''
+
+room_invalid_calendar_id_mutation_response = {
+    "errors": [
+        {
+            "message": "Room calendar Id is invalid",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 9
+                }
+            ],
+            "path": [
+                "createRoom"
+                ]
+        }
+    ],
+    "data": {
+        "createRoom": null
+    }
+}
 
 rooms_query = '''
 query {
@@ -172,7 +204,8 @@ query {
         }
     }
 }
-    '''
+'''
+
 db_rooms_query = '''
     {
     rooms{

--- a/helpers/auth/validator.py
+++ b/helpers/auth/validator.py
@@ -1,5 +1,6 @@
 import re
 from graphql import GraphQLError
+from helpers.calendar.credentials import Credentials
 
 
 def check_office_name(office_name):
@@ -28,6 +29,15 @@ def assert_block_id_is_required(office, kwargs):
 def verify_email(email):
     return bool(re.match('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$',  # noqa
                          email))
+
+
+def verify_calendar_id(calendar_id):
+    service = Credentials.set_api_credentials(Credentials)
+    try:
+        service.events().list(calendarId=calendar_id).execute()
+        return True
+    except Exception:
+        return False
 
 
 class ErrorHandler():

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -9,7 +9,9 @@ from fixtures.room.create_room_fixtures import (
     room_name_empty_mutation, room_invalid_officeId_mutation,
     room_invalid_floorId_mutation, room_invalid_wingId_mutation,
     room_mutation_query_duplicate_name,
-    room_mutation_query_duplicate_name_response)   # noqa : E501
+    room_mutation_query_duplicate_name_response,
+    room_invalid_calendar_id_mutation_query,
+    room_invalid_calendar_id_mutation_response)
 from fixtures.room.create_room_in_block_fixtures import (
     room_blockId_not_required_mutation
     )
@@ -88,4 +90,14 @@ class TestCreateRoom(BaseTestCase):
             self,
             room_blockId_not_required_mutation,
             "Block ID is not required for this office"
+        )
+
+    def test_room_creation_with_invalid_calendar_id(self):
+        """
+        Test room creation with Block ID not required
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            room_invalid_calendar_id_mutation_query,
+            room_invalid_calendar_id_mutation_response
         )

--- a/tests/test_rooms/test_room_model.py
+++ b/tests/test_rooms/test_room_model.py
@@ -15,7 +15,7 @@ class TestRoomModel(BaseTestCase):
         object_count = Room.query.count()
 
         room = Room(name='Jinja', room_type='meeting', capacity=5, floor_id=1,
-                    calendar_id='andela.com_3835468272423230343935@resource.calendar.google.com',  # noqa: E501
+                    calendar_id='andela.com_3836323338323230343935@resource.calendar.google.com',  # noqa: E501
                     image_url="https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg")  # noqa: E501
         room.save()
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds an event listener for calendar Ids to ensure only rooms with valid calendar Ids are save in the database when creating a room.

#### How should this be manually tested?
- Run the server.    
- Test the queries at `localhost:5000/mrm`
- Run the `createRoom mutation` with an invalid calendar id.  

#### What are the relevant pivotal tracker stories?
#161481601

#### Screenshots 
##### Snapshot of a response when an invalid calendar id is used
![image](https://user-images.githubusercontent.com/22454909/47565163-370c2300-d930-11e8-8cf2-c65713d7333c.png)

