### PR TITLE
#161506663 fix analytics response

### DIFF
--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -131,4 +131,4 @@ class CommonAnalytics(Credentials):
                                         has_events=True
                                         )
                 result.append(output)
-            return result
+        return result


### PR DESCRIPTION
### What does this PR do?

Fix analytics mutation that returns an empty list instead of the correct analytics requested

#### How should this be manually tested?
- Run the server.    
- Test the queries at `localhost:5000/mrm`
- Run the analytics mutations for most and least used rooms  

#### What are the relevant pivotal tracker stories?
#161506663

#### Screenshots 
##### Snapshot before the fix
![image](https://user-images.githubusercontent.com/22454909/47568815-c1598480-d93a-11e8-99cc-adbce893ead5.png)

##### Snapshot after the fix
![image](https://user-images.githubusercontent.com/22454909/47568824-c8809280-d93a-11e8-8818-c22647a9f544.png)
