### PR TITLE
#160491334 Generate ratio of check-ins to booked meetings

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -71,12 +71,6 @@ class Query(graphene.ObjectType):
 
     analytics_ratios = graphene.Field(
         CheckinsToBookingsRatio,
-        start_date=graphene.String(),
-        end_date=graphene.String(),
-    )
-
-    analytics_ratios = graphene.Field(
-        CheckinsToBookingsRatio,
         start_date=graphene.String(required=True),
         end_date=graphene.String(),
     )


### PR DESCRIPTION
#### What does this PR do?
- Updates events model and Enables an admin to obtain the ratio of check-ins to booked meetings

#### How should this be manually tested?
- First,  Run migrations to update Events model. 
- Run the server
- Test the mutation at `localhost:5000/mrm`
- Run `eventCheckin` mutation to have a checkin record in the db to facilitate analytics ratio.
- Run `analyticsRatios` query with `start_date` and `end_date` as the parameters

#### What are the relevant pivotal tracker stories?
[#160491334](https://www.pivotaltracker.com/story/show/160491334)

#### Screenshots
1. EventCheckin mutation
<img width="1183" alt="screen shot 2018-11-02 at 13 56 13" src="https://user-images.githubusercontent.com/20478530/47911770-67f7d500-dea7-11e8-87aa-5caff8a53e4a.png">

2. Checkins to bookings ratio query
<img width="1182" alt="ratio" src="https://user-images.githubusercontent.com/20478530/47785221-20434300-dd19-11e8-977e-a07ee03d17b2.png">

