### PR TITLE
#161623168 Enable a query for notifications without a userId parameter

### DIFF
--- a/fixtures/notification/notification_fixture.py
+++ b/fixtures/notification/notification_fixture.py
@@ -2,43 +2,12 @@ null = None
 true = True
 false = False
 
-non_existent_user_notification_settings_query = '''
-{
-getUserNotificationSettings (userId:100){
-    id,
-    userId,
-    deviceHealthNotification,
-    meetingUpdateNotification
-}
-}
-'''
-
-non_existent_user_notification_settings_response = {
-    "errors": [
-        {
-            "message": "User not found",
-            "locations": [
-                {
-                    "line": 2,
-                    "column": 2
-                }
-            ],
-            "path": [
-                "getUserNotificationSettings"
-            ]
-        }
-    ],
-    "data": {
-        "getUserNotificationSettings": null
-    }
-}
-
 # when run for the first time for a user not already in the notifications table,
 # the user is automatically added and the field is populated with the
 # default value (True).
-missing_user_notification_table_query = '''
+user_notification_query = '''
 {
-getUserNotificationSettings (userId:1){
+getUserNotificationSettings{
     id,
     userId,
     deviceHealthNotification,
@@ -47,7 +16,7 @@ getUserNotificationSettings (userId:1){
 }
 '''
 
-missing_user_notification_table_response = {
+user_notification_response = {
     "data": {
         "getUserNotificationSettings": [
             {
@@ -58,30 +27,6 @@ missing_user_notification_table_response = {
             }
         ]
         }
-}
-
-existing_user_notification_table_query = '''
-{
-getUserNotificationSettings (userId:1){
-    id,
-    userId,
-    deviceHealthNotification,
-    meetingUpdateNotification
-}
-}
-'''
-
-existing_user_notification_table_response = {
-    "data": {
-        "getUserNotificationSettings": [
-            {
-                "id": "1",
-                "userId": 1,
-                "deviceHealthNotification": true,
-                "meetingUpdateNotification": true
-            }
-        ]
-    }
 }
 
 # when run for the first time for a user not already in the notifications table,
@@ -107,7 +52,7 @@ update_user_notification_settings_response = {
         "updateNotification": {
             "notification": {
                 "id": "1",
-                "userId": 2,
+                "userId": 1,
                 "deviceHealthNotification": true,
                 "meetingUpdateNotification": false
             }

--- a/tests/test_notification/test_query_notification.py
+++ b/tests/test_notification/test_query_notification.py
@@ -1,11 +1,7 @@
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.notification.notification_fixture import (
-    non_existent_user_notification_settings_query,
-    non_existent_user_notification_settings_response,
-    missing_user_notification_table_query,
-    missing_user_notification_table_response,
-    existing_user_notification_table_query,
-    existing_user_notification_table_response,
+    user_notification_query,
+    user_notification_response,
     update_user_notification_settings_query,
     update_user_notification_settings_response)
 
@@ -15,33 +11,19 @@ sys.path.append(os.getcwd())
 
 
 class TestNotification(BaseTestCase):
-    def test_non_existent_user_notification_settings(self):
 
-        CommonTestCases.user_token_assert_equal(
+    def test_get_user_notification_(self):
+
+        CommonTestCases.admin_token_assert_equal(
             self,
-            non_existent_user_notification_settings_query,
-            non_existent_user_notification_settings_response,
-        )
-
-    def test_missing_user_notification_table(self):
-
-        CommonTestCases.user_token_assert_equal(
-            self,
-            missing_user_notification_table_query,
-            missing_user_notification_table_response,
+            user_notification_query,
+            user_notification_response,
         )
 
     def test_update_user_notification_settings(self):
 
-        CommonTestCases.user_token_assert_equal(
+        CommonTestCases.admin_token_assert_equal(
             self,
             update_user_notification_settings_query,
             update_user_notification_settings_response,
-        )
-
-    def test_existing_user_notification_table(self):
-        CommonTestCases.user_token_assert_equal(
-            self,
-            existing_user_notification_table_query,
-            existing_user_notification_table_response,
         )


### PR DESCRIPTION
#### What does this PR do?
Allows a the front end to send a query without the UserId parameter

#### Description of Task to be completed?
- Remove the userId field from the query
- Retrieve the userId using the token
- Refactor tests and fixtures

#### How should this be manually tested?
- Run server `http://127.0.0.1:5000/mrm`
- Run the `getUserNotificationSettings` without a userId
- It should return the user notification settings

#### What are the relevant pivotal tracker stories?
[#161623168](https://www.pivotaltracker.com/story/show/161623168)

#### Screenshots
<img width="1064" alt="screenshot 2018-10-31 at 18 06 29" src="https://user-images.githubusercontent.com/33119403/47800203-dcfacb80-dd3c-11e8-811a-3b8481b03b31.png">

