### PR TITLE
#161615830 refactor analytics to use a date range

### DIFF
--- a/api/analytics/analytics_request.py
+++ b/api/analytics/analytics_request.py
@@ -14,14 +14,15 @@ class AnalyticsRequest():
            get_analytic_report
            get_analytic_report_pdf_file
     """
-
-    def validate_date(self, start_date, end_date):
+    def validate_date(self, request_data):
         '''
         Validate date params
         '''
+        if 'end_date' not in request_data:
+            request_data['end_date'] = None
         try:
-            start_date = CommonAnalytics.convert_date(self, start_date)
-            end_date = CommonAnalytics.convert_date(self, end_date)
+            start_date, end_date = CommonAnalytics.convert_dates(
+                self, request_data['start_date'], request_data['end_date'])  # noqa: E501
             return (start_date, end_date)
         except ValueError as err:
             raise JsonError(error=str(err), example='Sep 15 2018')
@@ -31,12 +32,12 @@ class AnalyticsRequest():
         Validate analytics report requests
         '''
         request_data = request.get_json()
-        if not all(param in request_data for param in ('start_date', 'end_date')):  # noqa: E501
+        if 'start_date' not in request_data:  # noqa: E501
             return jsonify(
-                {"Error": "Request must have start_date and end_date"}
+                {"Error": "Request must have a start_date"}
             ), 400
         start_date, end_date = AnalyticsRequest.validate_date(
-            self, request_data['start_date'], request_data['end_date'])
+            self, request_data)
         try:
             file_type = request_data['file_type'].upper()
         except (KeyError, AttributeError):

--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -3,7 +3,6 @@ from graphene_sqlalchemy import (SQLAlchemyObjectType)
 from graphql import GraphQLError
 from api.room.models import Room as RoomModel
 from api.office.models import Office
-from helpers.calendar.analytics import RoomStatistics  # noqa: E501
 from utilities.utility import validate_empty_fields, update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.auth.admin_roles import admin_roles
@@ -18,11 +17,6 @@ from helpers.pagination.paginate import Paginate, validate_page
 class Room(SQLAlchemyObjectType):
     class Meta:
         model = RoomModel
-
-
-class Analytics(graphene.ObjectType):
-    analytics = graphene.List(RoomStatistics)
-    MeetingsDurationaAnalytics = graphene.List(RoomStatistics)
 
 
 class Calendar(graphene.ObjectType):

--- a/fixtures/room/room_analytics_duration_fixtures.py
+++ b/fixtures/room/room_analytics_duration_fixtures.py
@@ -2,7 +2,7 @@ null = None
 
 get_daily_meetings_total_duration_query = '''
 query {
-    dailyDurationsOfMeetings(dayStart:"sep 10 2018"){
+    analyticsForMeetingsDurations(startDate:"sep 10 2018"){
         MeetingsDurationaAnalytics{
             roomName
             count
@@ -18,7 +18,7 @@ query {
 
 get_daily_meetings_total_duration_response = {
     "data": {
-        "dailyDurationsOfMeetings": {
+        "analyticsForMeetingsDurations": {
             "MeetingsDurationaAnalytics": [
                 {
                     "roomName": "Entebbe",
@@ -33,7 +33,7 @@ get_daily_meetings_total_duration_response = {
 
 get_weekly_meetings_total_duration_query = '''
 query {
-    weeklyDurationsOfMeetings(weekStart:"Jan 3 2018", weekEnd:"Jan 9 2018"){  # noqa: E501
+    analyticsForMeetingsDurations(startDate:"Jan 3 2018", endDate:"Jan 9 2018"){  # noqa: E501
         MeetingsDurationaAnalytics{
             roomName
             count
@@ -49,7 +49,7 @@ query {
 
 get_weekly_meetings_total_duration_response = {
     'data': {
-        'weeklyDurationsOfMeetings': {
+        'analyticsForMeetingsDurations': {
             'MeetingsDurationaAnalytics': [
                 {
                     'roomName': 'Entebbe',

--- a/fixtures/room/room_analytics_least_used_fixtures.py
+++ b/fixtures/room/room_analytics_least_used_fixtures.py
@@ -2,9 +2,9 @@ null = None
 
 get_least_used_room_per_week_query = '''
     {
-        analyticsForRoomLeastUsedPerWeek(
-            weekStart: "Sep 8 2018"
-            weekEnd: "Sep 15 2018"
+        analyticsForLeastUsedRooms(
+            startDate: "Sep 8 2018"
+            endDate: "Sep 15 2018"
         )
         {
             analytics {
@@ -20,29 +20,10 @@ get_least_used_room_per_week_query = '''
     }
 '''
 
-get_least_used_room_per_week_query = '''
-    {
-        analyticsForRoomLeastUsedPerWeek(
-            weekStart: "Sep 8 2018"
-            weekEnd: "Sep 15 2018"
-        )
-        {
-            analytics {
-                roomName
-                count
-                hasEvents
-                events {
-                    durationInMinutes
-                    numberOfMeetings
-                }
-            }
-        }
-    }
-'''
 
 get_least_used_room_per_week_response = {
     "data": {
-        "analyticsForRoomLeastUsedPerWeek": {
+        "analyticsForLeastUsedRooms": {
             "analytics": [
                 {
                     "roomName": "Nairobi - 2nd Floor Block A Khartoum (1)",
@@ -65,9 +46,9 @@ get_least_used_room_per_week_response = {
 
 get_least_used_room_without_event_query = '''
     {
-        analyticsForRoomLeastUsedPerWeek(
-            weekStart: "Aug 8 2018"
-            weekEnd: "Aug 12 2018"
+        analyticsForLeastUsedRooms(
+            startDate: "Aug 8 2018"
+            endDate: "Aug 12 2018"
         )
         {
             analytics {
@@ -85,7 +66,7 @@ get_least_used_room_without_event_query = '''
 
 get_least_used_room_without_event_response = {
     "data": {
-        "analyticsForRoomLeastUsedPerWeek": {
+        "analyticsForLeastUsedRooms": {
             "analytics": [
                 {
                     "roomName": "Entebbe",
@@ -101,7 +82,7 @@ get_least_used_room_without_event_response = {
 get_room_usage_analytics = '''
     {
     analyticsForMeetingsPerRoom(
-        dayStart:"Sep 11 2018" dayEnd:"sep 12 2018"){
+        startDate:"Sep 11 2018" endDate:"sep 12 2018"){
             analytics{
                 roomName
                 count
@@ -110,40 +91,29 @@ get_room_usage_analytics = '''
     }
 '''
 
-get_least_used_room_per_month = '''
-    {
-        analyticsForLeastUsedRoomPerMonth(month:"Jul", year:2018)
-        {
-            analytics {
-                roomName
-                count
-            }
-        }
-    }
-'''
-get_least_used_room_per_month = '''
-    {
-        analyticsForLeastUsedRoomPerMonth(month:"Jul", year:2018)
-        {
-            analytics {
-                roomName
-                count
-            }
-        }
-    }
-'''
-
-get_room_usage_anaytics_respone = {
+get_room_usage_anaytics_response = {
     "data": {
         "analyticsForMeetingsPerRoom": {
-            "analytics": [{'roomName': 'Entebbe', 'count': 2}]
+            "analytics": [{'roomName': 'Entebbe', 'count': 3}]
                     }
     }
 }
 
+get_least_used_room_per_month = '''
+    {
+        analyticsForLeastUsedRooms(startDate:"Jul 1 2018", endDate:"Jul 31 2018")  # noqa: E501
+        {
+            analytics {
+                roomName
+                count
+            }
+        }
+    }
+'''
+
 get_least_used_room_per_month_response = {
     'data': {
-        'analyticsForLeastUsedRoomPerMonth': {
+        'analyticsForLeastUsedRooms': {
             'analytics': [
                 {
                     'roomName': 'Entebbe',
@@ -154,22 +124,10 @@ get_least_used_room_per_month_response = {
     }
 }
 
-get_least_used_room_per_month_response = {
-    'data': {
-        'analyticsForLeastUsedRoomPerMonth': {
-            'analytics': [
-                {
-                    'roomName': 'Entebbe',
-                    'count': 0
-                }
-            ]
-        }
-    }
-}
 
 analytics_for_least_used_room_day = '''
 {
-    analyticsForLeastUsedRoomPerDay(day:"Jul 11 2018"){
+    analyticsForLeastUsedRooms(startDate:"Jul 11 2018"){
         analytics{
             roomName
             count
@@ -184,7 +142,7 @@ analytics_for_least_used_room_day = '''
 
 analytics_for_least_used_room_day_response = {
     "data": {
-        "analyticsForLeastUsedRoomPerDay": {
+        "analyticsForLeastUsedRooms": {
             "analytics": [
                 {
                     "roomName": "Entebbe",

--- a/fixtures/room/room_analytics_most_used_fixtures.py
+++ b/fixtures/room/room_analytics_most_used_fixtures.py
@@ -2,7 +2,7 @@ null = None
 
 get_most_used_room_in_a_month_analytics_query = '''
     {
-        mostUsedRoomPerMonthAnalytics(month:"Jul", year:2018)
+        analyticsForMostUsedRooms(startDate:"Jul 1 2018", endDate:"Jul 31 2018")
         {
             analytics {
                 roomName
@@ -13,7 +13,7 @@ get_most_used_room_in_a_month_analytics_query = '''
 '''
 get_most_used_room_in_a_month_analytics_response = {
         "data": {
-            "mostUsedRoomPerMonthAnalytics": {
+            "analyticsForMostUsedRooms": {
                 "analytics": [
                     {
                         "roomName": "Entebbe",
@@ -26,9 +26,9 @@ get_most_used_room_in_a_month_analytics_response = {
 
 get_most_used_room_per_week_query = '''
      {
-        analyticsForRoomMostUsedPerWeek(
-            weekStart: "Aug 8 2018"
-            weekEnd: "Aug 12 2018"
+        analyticsForMostUsedRooms(
+            startDate: "Aug 8 2018"
+            endDate: "Aug 12 2018"
         )
         {
             analytics {
@@ -45,7 +45,7 @@ get_most_used_room_per_week_query = '''
 '''
 get_most_used_room_per_week_response = {
    "data": {
-        "analyticsForRoomMostUsedPerWeek": {
+        "analyticsForMostUsedRooms": {
             "analytics": [
                 {
                     "roomName": "Entebbe",
@@ -60,9 +60,9 @@ get_most_used_room_per_week_response = {
 
 get_most_used_room_without_event_query = '''
     {
-        analyticsForRoomMostUsedPerWeek(
-            weekStart: "Aug 8 2018"
-            weekEnd: "Aug 12 2018"
+        analyticsForMostUsedRooms(
+            startDate: "Aug 8 2018"
+            endDate: "Aug 12 2018"
         )
         {
             analytics {
@@ -80,7 +80,7 @@ get_most_used_room_without_event_query = '''
 
 get_most_used_room_without_event_response = {
     "data": {
-        "analyticsForRoomMostUsedPerWeek": {
+        "analyticsForMostUsedRooms": {
             "analytics": [
                 {
                     "roomName": "Entebbe",

--- a/fixtures/room/room_monthly_meeting_duration_fixtures.py
+++ b/fixtures/room/room_monthly_meeting_duration_fixtures.py
@@ -1,6 +1,6 @@
 get_monthly_meetings_total_duration_query = '''
     {
-        monthlyDurationsOfMeetings(month:"Jul", year:2018)
+        analyticsForMeetingsDurations(startDate:"Jul 1 2018", endDate:"Jul 31 2018")  # noqa: E501
         {
             MeetingsDurationaAnalytics {
                 roomName
@@ -17,7 +17,7 @@ get_monthly_meetings_total_duration_query = '''
 
 get_monthly_meetings_total_duration_response = {
         "data": {
-            "monthlyDurationsOfMeetings": {
+            "analyticsForMeetingsDurations": {
                 "MeetingsDurationaAnalytics": [
                     {
                         "roomName": "Entebbe",

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -25,23 +25,16 @@ class RoomStatistics(graphene.ObjectType):
 
 class CommonAnalytics(Credentials):
 
-    def convert_date(self, date):
-        return datetime.strptime(date, '%b %d %Y').isoformat() + 'Z'
-
-    def get_start_end_month_dates(self, month, year):
-        date = month + ' 1 ' + str(year)
-        start_date = CommonAnalytics.convert_date(self, date)
-        day_after = (datetime.strptime(date, '%b %d %Y') + relativedelta(months=1)).isoformat() + 'Z'  # noqa: E501
-        return(start_date, day_after)
-
-    def get_start_end_day_dates(self, day):
+    def convert_dates(self, start_date, end_date):
         """
-        Returns start and end day dates in iso-format
+        Convert date format and add one day to end_date
+        Google calendar is exclusive of end_date
         """
-        start = (datetime.strptime(day, "%b %d %Y"))
-        startdate = start.isoformat() + 'Z'
-        end = (start + relativedelta(days=1)).isoformat() + 'Z'
-        return(startdate, end)
+        if end_date is None:
+            end_date = start_date
+        start_date = datetime.strptime(start_date, '%b %d %Y').isoformat() + 'Z'
+        end_date = (datetime.strptime(end_date, "%b %d %Y") + relativedelta(days=1)).isoformat() + 'Z'  # noqa: E501
+        return(start_date, end_date)
 
     def get_time_duration_for_event(self, start_time, end_time):
         """ Calculate duration range of an event

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -5,7 +5,7 @@ from fixtures.room.room_analytics_least_used_fixtures import (
     get_least_used_room_without_event_query,
     get_least_used_room_without_event_response,
     get_room_usage_analytics,
-    get_room_usage_anaytics_respone,
+    get_room_usage_anaytics_response,
     get_least_used_room_per_month,
     get_least_used_room_per_month_response,
     analytics_for_least_used_room_day,
@@ -54,7 +54,7 @@ class QueryRoomsAnalytics(BaseTestCase):
         CommonTestCases.admin_token_assert_equal(
             self,
             get_room_usage_analytics,
-            get_room_usage_anaytics_respone
+            get_room_usage_anaytics_response
         )
 
     def test_analytics_for_least_used_room_monthly(self):


### PR DESCRIPTION
#### What does this PR do?
This PR refactor analytics to use a date range and make `endDate` argument optional to be able to handle a single day analytics

#### How should this be manually tested?
- Run the server.    
- Test the queries at `localhost:5000/mrm`
- Run the following queries with `startDate` and `endDate` arguments:  
    - `analyticsForMostUsedRooms`
    - `analyticsForLeastUsedRooms`
    - `analyticsForMeetingsPerRoom`
    - `analyticsForMeetingsDurations`

#### What are the relevant pivotal tracker stories?
[Refactor analytics](https://www.pivotaltracker.com/n/projects/2154921/stories/161615830)

#### Screenshots 
##### Snapshot of analyticsForMostUsedRooms for a month range
![image](https://user-images.githubusercontent.com/22454909/47902991-1db92880-de94-11e8-9d90-e3f934951c8e.png)

##### Snapshot of analyticsForMostUsedRooms for a single day
![image](https://user-images.githubusercontent.com/22454909/47903185-68d33b80-de94-11e8-8e61-1c857105e75a.png)

##### Snapshot of analyticsForLeastUsedRooms for a date range
![image](https://user-images.githubusercontent.com/22454909/47903350-a2a44200-de94-11e8-9347-62cca1fce519.png)

##### Snapshot of analyticsForLeastUsedRooms for a single day
![image](https://user-images.githubusercontent.com/22454909/47903643-029ae880-de95-11e8-8c5c-7c6f4bbc1fab.png)

##### Snapshot of analyticsForMeetingsPerRoom for a single day
![image](https://user-images.githubusercontent.com/22454909/47903858-54dc0980-de95-11e8-8bb0-495ae86c419f.png)

##### Snapshot of analyticsForMeetingsDurations for a date range
![image](https://user-images.githubusercontent.com/22454909/47904217-e3508b00-de95-11e8-82f3-44750fac152a.png)

##### Snapshot of analyticsForMeetingsDurations for a single date
![image](https://user-images.githubusercontent.com/22454909/47904831-b0f35d80-de96-11e8-8a8b-ce0dc5761d76.png)
