### PR TITLE
#161279850 Update analytics to show the top ten most and least used  rooms.

### DIFF
--- a/api/analytics/analytic_report.py
+++ b/api/analytics/analytic_report.py
@@ -52,19 +52,32 @@ class AnalyticsReport():
 
     def get_least_used_rooms(self, all_rooms_summary_df):
         '''
-        Get analytics for 5 least used rooms
+        Get analytics for the 10 least used rooms
         '''
+        # import pdb; pdb.set_trace()
         sorted_all_rooms_summary_df = all_rooms_summary_df.sort_values(
             'Meetings')
-        return sorted_all_rooms_summary_df.head(5)
+        try:
+            tenth_value = sorted_all_rooms_summary_df.loc[10, 'meetings']
+            top_ten = sorted_all_rooms_summary_df.loc[sorted_all_rooms_summary_df['meetings'] <= tenth_value]  # noqa
+        except KeyError:
+            top_ten = sorted_all_rooms_summary_df.head(10)
+
+        return top_ten
 
     def get_most_used_rooms(self, all_rooms_summary_df):
         '''
-        Get analytics for 5 most used rooms
+        Get analytics for the 10 most used rooms
         '''
         sorted_all_rooms_summary_df = all_rooms_summary_df.sort_values(
             'Meetings', ascending=False)
-        return sorted_all_rooms_summary_df.head(5)
+        try:
+            tenth_value = sorted_all_rooms_summary_df.loc[10, 'meetings']
+            top_ten = sorted_all_rooms_summary_df.loc[sorted_all_rooms_summary_df['meetings'] >= tenth_value]  # noqa
+        except KeyError:
+            top_ten = sorted_all_rooms_summary_df.head(10)
+
+        return top_ten
 
     def generate_combined_analytics_report(self, query, start_date, end_date):
         '''


### PR DESCRIPTION
**What does this PR do?**

Allows admins to get analytics for the top ten most and least used rooms. In case of a tie, the number of returned results adjusts appropriately.

**How should this be tested?**

- Run the server.
- Call the `/analytics` endpoint passing the `start_date`, `end_date` and the `file_type`(optional).

What are the relevant pivotal tracker stories?
[#161279850](https://www.pivotaltracker.com/story/show/161645315)

