### PR TITLE
#161676333 fix create user role duplication

### DIFF
--- a/api/user_role/schema.py
+++ b/api/user_role/schema.py
@@ -1,4 +1,5 @@
 import graphene
+from graphql import GraphQLError
 
 from graphene_sqlalchemy import (SQLAlchemyObjectType)
 
@@ -19,6 +20,11 @@ class CreateUserRole(graphene.Mutation):
     user_role = graphene.Field(UsersRole)
 
     def mutate(self, info, **kwargs):
+        user_role = UserRoleModel.query.filter_by(user_id=kwargs['user_id'],
+                                                  role_id=kwargs['role_id']).\
+                                                  all()
+        if user_role:
+            raise GraphQLError("You cannot create user role twice")
         user_role = UserRoleModel(**kwargs)
         user_role.save()
 


### PR DESCRIPTION
**What does this PR do?**

It ensures that a user role can only be created once, and if one tried to create the same user role again, then it returns a descriptive error message

**How should this be tested?**

- Run the server.
-Test the queries at `localhost:5000/mrm`
-Run the following query: 
`createUsersRole`
It should be successful when you run it once but should fail on the second run

What are the relevant pivotal tracker stories?
[#161676333](https://www.pivotaltracker.com/story/show/161676333)

#### Screenshots 
##### Screenshots for first time run
![image](https://user-images.githubusercontent.com/29063646/48026225-82a3a580-e156-11e8-9f4c-98b55ad6253d.png)
##### Screenshots for second time run
![image](https://user-images.githubusercontent.com/29063646/48026243-94854880-e156-11e8-8758-f70644a6323a.png)


