### PR TITLE
#162054093 Enable admin create blocks in Nairobi office

### DIFF
--- a/api/block/models.py
+++ b/api/block/models.py
@@ -1,5 +1,5 @@
 from sqlalchemy import (Column, String, Integer, ForeignKey)
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, validates
 
 from helpers.database import Base
 from utilities.utility import Utility
@@ -13,3 +13,7 @@ class Block(Base, Utility):
     office_id = Column(Integer, ForeignKey('offices.id'))
     offices = relationship('Office')
     floors = relationship('Floor', cascade="all, delete-orphan")
+
+    @validates('name')
+    def convert_upper(self, key, value):
+        return value.title()

--- a/api/block/schema.py
+++ b/api/block/schema.py
@@ -24,11 +24,11 @@ class CreateBlock(graphene.Mutation):
     @Auth.user_roles('Admin')
     def mutate(self, info, **kwargs):
         validate_empty_fields(**kwargs)
-        block_name = BlockModel.query.filter_by(name=kwargs['name']).all()
-        if len(block_name) > 0:
+        block_name = BlockModel.query.filter_by(name=kwargs['name'].title()).all() # noqa
+        if block_name:
             raise GraphQLError("Block aleady exists")
         get_office = Office.query.filter_by(id=kwargs['office_id']).first()
-        if get_office is None:
+        if not get_office:
             raise GraphQLError("Office not found")
         location = get_office.location.name
         if location.lower() == 'nairobi':

--- a/fixtures/block/block_fixtures.py
+++ b/fixtures/block/block_fixtures.py
@@ -11,11 +11,11 @@ get_blocks_query_response = {
         "allBlocks": [
             {
                 "id": "1",
-                "name": "EC"
+                "name": "Ec"
             },
             {
                 "id": "2",
-                "name": "Epic tower"
+                "name": "Epic Tower"
             }
         ]
     }

--- a/fixtures/block/create_block_fixtures.py
+++ b/fixtures/block/create_block_fixtures.py
@@ -12,14 +12,14 @@ create_block_query = '''
 '''
 
 create_block_response = {
-    "data": {
-        "createBlock": {
-            "block": {
-                "officeId": 2,
-                "name": "blask"
-            }
-        }
+  "data": {
+    "createBlock": {
+      "block": {
+        "officeId": 2,
+        "name": "Blask"
+      }
     }
+  }
 }
 
 block_mutation_query_without_name = '''
@@ -35,7 +35,7 @@ block_mutation_query_without_name = '''
 
 block_creation_with_duplicate_name = '''
 mutation{
-  createBlock(officeId:1 name:"EC" ) {
+  createBlock(officeId:1 name:"Ec" ) {
     block{
       officeId
         name
@@ -45,23 +45,23 @@ mutation{
 '''
 
 block_creation_with_duplicate_name_response = {
-    "errors": [
+  "errors": [
+    {
+      "message": "Block aleady exists",
+      "locations": [
         {
-            "message": "Block aleady exists",
-            "locations": [
-                {
-                    "line": 3,
-                    "column": 3
-                }
-            ],
-            "path": [
-                "createBlock"
-            ]
+          "line": 3,
+          "column": 3
         }
-    ],
-    "data": {
-        "createBlock": null
+      ],
+      "path": [
+        "createBlock"
+      ]
     }
+  ],
+  "data": {
+    "createBlock": null
+  }
 }
 
 create_block_with_non_existing_office = '''
@@ -133,7 +133,7 @@ delete_block_response = {
     "data": {
         "DeleteBlock": {
             "block": {
-                "name": "EC",
+                "name": "Ec",
                 "id": "1"
             }
         }

--- a/fixtures/location/all_locations_fixtures.py
+++ b/fixtures/location/all_locations_fixtures.py
@@ -31,7 +31,7 @@ expected_query_all_locations = {
                 {
                     "name": "St. Catherines",
                     "blocks": [{
-                        "name": "EC",
+                        "name": "Ec",
                         "floors": [{
                             "name": "3rd",
                             "rooms": [{
@@ -61,7 +61,7 @@ expected_query_all_locations = {
                 {
                     "name": "Epic tower",
                     "blocks": [{
-                        "name": "Epic tower",
+                        "name": "Epic Tower",
                         "floors": [{
                             "name": "2nd",
                             "rooms": []

--- a/fixtures/office/office_fixtures.py
+++ b/fixtures/office/office_fixtures.py
@@ -56,7 +56,7 @@ get_office_by_name_response = {
             'name': 'St. Catherines',
             'id': '1',
             'blocks': [{
-                'name': 'EC',
+                'name': 'Ec',
                 'floors': [{
                     'name': '3rd',
                     'id': '1',

--- a/fixtures/office/update_delete_office_fixture.py
+++ b/fixtures/office/update_delete_office_fixture.py
@@ -88,7 +88,7 @@ delete_office_mutation_response = {
                 "name": "St. Catherines",
                 "blocks": [
                     {
-                        "name": "EC",
+                        "name": "Ec",
                         "floors": [
                             {
                                 "name": "3rd",


### PR DESCRIPTION
 #### What does this PR do?
- Adds create block mutation to enable an admin to create blocks in the Nairobi office.

#### How should this be manually tested?
- Run the server
- Test the mutation at `localhost:5000/mrm`
- Run `createBlock` mutation with the parameter 'room_id'  and 'name', as  required parameters

#### What are the relevant pivotal tracker stories?
[#162054093](https://www.pivotaltracker.com/story/show/162054093)

#### Screenshots
1. Create block
![image](https://user-images.githubusercontent.com/29063646/48840663-5c117b80-eda0-11e8-80cd-fdd31cc768fb.png)

2. Try duplicate same block name
![image](https://user-images.githubusercontent.com/29063646/48840841-d17d4c00-eda0-11e8-9275-53220b291efb.png)

3.Create block without name
![image](https://user-images.githubusercontent.com/29063646/48840753-a266da80-eda0-11e8-8676-564484afabe6.png)

4. Try to create a block that is not in the Nairobi office
![image](https://user-images.githubusercontent.com/29063646/48840949-1acd9b80-eda1-11e8-81d9-84e24d5b1605.png)

5. Error message for the non-existent office
![image](https://user-images.githubusercontent.com/29063646/48938523-84c17e80-ef22-11e8-88d8-fa2e19905b0e.png)

