### PR TITLE
#162157772 Enable Admin update & delete block in Nairobi

### DIFF
--- a/api/block/schema.py
+++ b/api/block/schema.py
@@ -1,14 +1,41 @@
 import graphene
-
+from graphql import GraphQLError
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from api.block.models import Block as BlockModel
 from api.room.schema import Room
+from api.office.models import Office
 from helpers.room_filter.room_filter import room_join_location
+from utilities.utility import validate_empty_fields
+from helpers.auth.authentication import Auth
 
 
 class Block(SQLAlchemyObjectType):
     class Meta:
         model = BlockModel
+
+
+class CreateBlock(graphene.Mutation):
+    class Arguments:
+        name = graphene.String(required=True)
+        office_id = graphene.Int(required=True)
+    block = graphene.Field(Block)
+
+    @Auth.user_roles('Admin')
+    def mutate(self, info, **kwargs):
+        validate_empty_fields(**kwargs)
+        block_name = BlockModel.query.filter_by(name=kwargs['name']).all()
+        if len(block_name) > 0:
+            raise GraphQLError("Block aleady exists")
+        get_office = Office.query.filter_by(id=kwargs['office_id']).first()
+        if get_office is None:
+            raise GraphQLError("Office not found")
+        location = get_office.location.name
+        if location.lower() == 'nairobi':
+            block = BlockModel(**kwargs)
+            block.save()
+        else:
+            raise GraphQLError("You can only create block in Nairobi")
+        return CreateBlock(block=block)
 
 
 class Query(graphene.ObjectType):
@@ -27,3 +54,7 @@ class Query(graphene.ObjectType):
         new_query = room_join_location(query)
         result = new_query.filter(BlockModel.id == block_id)
         return result
+
+
+class Mutation(graphene.ObjectType):
+    create_block = CreateBlock.Field()

--- a/fixtures/block/create_block_fixtures.py
+++ b/fixtures/block/create_block_fixtures.py
@@ -1,0 +1,96 @@
+null = None
+
+create_block_query = '''
+  mutation{
+  createBlock(officeId:2, name:"blask" ) {
+    block{
+      officeId
+        name
+      }
+  }
+}
+'''
+
+create_block_response = {
+  "data": {
+    "createBlock": {
+      "block": {
+        "officeId": 2,
+        "name": "blask"
+      }
+    }
+  }
+}
+
+block_mutation_query_without_name = '''
+     mutation{
+    createBlock(officeId:2, name:"" ) {
+        block{
+            officeId
+            name
+        }
+    }
+}
+'''
+
+block_creation_with_duplicate_name = '''
+mutation{
+  createBlock(officeId:1 name:"EC" ) {
+    block{
+      officeId
+        name
+      }
+  }
+}
+'''
+
+block_creation_with_duplicate_name_response = {
+  "errors": [
+    {
+      "message": "Block aleady exists",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "createBlock"
+      ]
+    }
+  ],
+  "data": {
+    "createBlock": null
+  }
+}
+
+create_block_with_non_existing_office = '''
+mutation{
+  createBlock(officeId:56 name:"Block F" ) {
+    block{
+      officeId
+        name
+      }
+  }
+}
+'''
+
+create_block_with_non_existing_office_response = {
+  "errors": [
+    {
+      "message": "Office not found",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "createBlock"
+      ]
+    }
+  ],
+  "data": {
+    "createBlock": null
+  }
+}

--- a/fixtures/block/create_block_fixtures.py
+++ b/fixtures/block/create_block_fixtures.py
@@ -12,14 +12,14 @@ create_block_query = '''
 '''
 
 create_block_response = {
-  "data": {
-    "createBlock": {
-      "block": {
-        "officeId": 2,
-        "name": "blask"
-      }
+    "data": {
+        "createBlock": {
+            "block": {
+                "officeId": 2,
+                "name": "blask"
+            }
+        }
     }
-  }
 }
 
 block_mutation_query_without_name = '''
@@ -45,23 +45,23 @@ mutation{
 '''
 
 block_creation_with_duplicate_name_response = {
-  "errors": [
-    {
-      "message": "Block aleady exists",
-      "locations": [
+    "errors": [
         {
-          "line": 3,
-          "column": 3
+            "message": "Block aleady exists",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 3
+                }
+            ],
+            "path": [
+                "createBlock"
+            ]
         }
-      ],
-      "path": [
-        "createBlock"
-      ]
+    ],
+    "data": {
+        "createBlock": null
     }
-  ],
-  "data": {
-    "createBlock": null
-  }
 }
 
 create_block_with_non_existing_office = '''
@@ -76,21 +76,130 @@ mutation{
 '''
 
 create_block_with_non_existing_office_response = {
-  "errors": [
-    {
-      "message": "Office not found",
-      "locations": [
+    "errors": [
         {
-          "line": 3,
-          "column": 3
+            "message": "Office not found",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 3
+                }
+            ],
+            "path": [
+                "createBlock"
+            ]
         }
-      ],
-      "path": [
-        "createBlock"
-      ]
+    ],
+    "data": {
+        "createBlock": null
     }
-  ],
-  "data": {
-    "createBlock": null
+}
+
+update_block = '''
+mutation{
+  updateBlock(name: "Block A", blockId: 1){
+    block{
+      name
+      id
+    }
   }
+}
+'''
+
+
+update_block_response = {
+    "data": {
+        "updateBlock": {
+            "block": {
+                "name": "Block A",
+                "id": "1"
+            }
+        }
+    }
+}
+
+delete_block = '''
+mutation{
+  DeleteBlock(blockId:1){
+    block{
+      name
+      id
+    }
+  }
+}
+'''
+
+delete_block_response = {
+    "data": {
+        "DeleteBlock": {
+            "block": {
+                "name": "EC",
+                "id": "1"
+            }
+        }
+    }
+}
+
+delete_non_existent_block = '''
+mutation{
+  DeleteBlock(blockId:431){
+    block{
+      name
+      id
+    }
+  }
+}
+'''
+
+delete_non_existent_block_response = {
+    "errors": [
+        {
+            "message": "Block not found",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 3
+                }
+            ],
+            "path": [
+                "DeleteBlock"
+            ]
+        }
+    ],
+    "data": {
+        "DeleteBlock": null
+    }
+}
+
+
+update_non_existent_block = '''
+mutation{
+  updateBlock(name: "Block A", blockId: 423){
+    block{
+      name
+      id
+    }
+  }
+}
+
+'''
+
+update_non_existent_block_response = {
+    "errors": [
+        {
+            "message": "Block not found",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 3
+                }
+            ],
+            "path": [
+                "updateBlock"
+            ]
+        }
+    ],
+    "data": {
+        "updateBlock": null
+    }
 }

--- a/helpers/auth/admin_roles.py
+++ b/helpers/auth/admin_roles.py
@@ -5,7 +5,7 @@ from api.location.models import Location
 from api.room.models import Room as RoomModel
 from api.room_resource.models import Resource as ResourceModel
 from helpers.auth.user_details import get_user_from_db
-from helpers.room_filter.room_filter import location_join_resources, location_join_room  # noqa: E501
+from helpers.room_filter.room_filter import location_join_resources, location_join_room, location_join_block  # noqa: E501
 
 
 class Admin_roles():
@@ -57,6 +57,14 @@ class Admin_roles():
         admin_details = get_user_from_db()
         location = Location.query.filter_by(name=admin_details.location).first()
         return location.id
+
+    def update_delete_block(self, block_id):
+        admin_details = get_user_from_db()
+        location_query = location_join_block()
+        block_location = location_query.filter_by(id=block_id).first()
+        if admin_details.location != block_location.name:
+            raise GraphQLError(
+                "You are not authorized to make changes in " + block_location.name)  # noqa: E501
 
 
 admin_roles = Admin_roles()

--- a/helpers/room_filter/room_filter.py
+++ b/helpers/room_filter/room_filter.py
@@ -65,6 +65,11 @@ def location_join_room():
     return location_query
 
 
+def location_join_block():
+    location_query = Location.query.join(Office).join(Block)
+    return location_query
+
+
 def location_join_resources():
     location_query = Location.query.join(Office).join(Block).join(Floor).join(Room).join(Resource)  # noqa: E501
     return location_query

--- a/schema.py
+++ b/schema.py
@@ -46,7 +46,8 @@ class Mutation(
     api.office.schema.Mutation,
     api.events.schema.Mutation,
     api.notification.schema.Mutation,
-    api.feedback.schema.Mutation
+    api.feedback.schema.Mutation,
+    api.block.schema.Mutation
 ):
     pass
 

--- a/tests/test_block/test_create_block.py
+++ b/tests/test_block/test_create_block.py
@@ -1,0 +1,58 @@
+import sys
+import os
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.block.create_block_fixtures import (
+    create_block_query,
+    create_block_response,
+    block_mutation_query_without_name,
+    create_block_with_non_existing_office,
+    block_creation_with_duplicate_name,
+    block_creation_with_duplicate_name_response
+)
+
+
+sys.path.append(os.getcwd())
+
+
+class TestCreateBlock(BaseTestCase):
+
+    def test_block_creation(self):
+        """
+        Testing for block creation
+
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            create_block_query,
+            create_block_response
+        )
+
+    def test_block_creation_with_name_empty(self):
+        """
+        Test block creation with name field empty
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            block_mutation_query_without_name,
+            "name is required field"
+        )
+
+    def test_block_creation_with_non_existent_office(self):
+        """
+        Test block creation with non-existent office
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_block_with_non_existing_office,
+            "Office not found"
+        )
+
+    def test_block_creation_with_duplicate_name(self):
+        """
+        Test block creation with an already existing room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            block_creation_with_duplicate_name,
+            block_creation_with_duplicate_name_response
+        )

--- a/tests/test_block/test_create_block.py
+++ b/tests/test_block/test_create_block.py
@@ -7,7 +7,15 @@ from fixtures.block.create_block_fixtures import (
     block_mutation_query_without_name,
     create_block_with_non_existing_office,
     block_creation_with_duplicate_name,
-    block_creation_with_duplicate_name_response
+    block_creation_with_duplicate_name_response,
+    update_block,
+    update_block_response,
+    update_non_existent_block,
+    update_non_existent_block_response,
+    delete_block,
+    delete_block_response,
+    delete_non_existent_block,
+    delete_non_existent_block_response
 )
 
 
@@ -55,4 +63,44 @@ class TestCreateBlock(BaseTestCase):
             self,
             block_creation_with_duplicate_name,
             block_creation_with_duplicate_name_response
+        )
+
+    def test_update_block(self):
+        """
+        Test block creation with an already existing room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_block,
+            update_block_response
+        )
+
+    def test_update_non_existent_block(self):
+        """
+        Test block creation with an already existing room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_non_existent_block,
+            update_non_existent_block_response
+        )
+
+    def test_delete_block(self):
+        """
+        Test block creation with an already existing room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_block,
+            delete_block_response
+        )
+
+    def test_delete_non_existent_block(self):
+        """
+        Test block creation with an already existing room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_non_existent_block,
+            delete_non_existent_block_response
         )


### PR DESCRIPTION
**What does this PR do?**
Admin updates & delete blocks in the Nairobi office.

**How should this be manually tested?**
- Run the server
- Test the mutation at localhost:5000/mrm
- Run `updateBlock` - updating block and `DeleteBlock` for deleting block


**What are the relevant pivotal tracker stories?**
[#162157772](https://www.pivotaltracker.com/story/show/162157772)

_Update block_
![image](https://user-images.githubusercontent.com/39412037/49012410-63fb6200-f18a-11e8-9237-2e0e14d35dc3.png)

_Delete block_
![image](https://user-images.githubusercontent.com/39412037/49012428-72e21480-f18a-11e8-89aa-805a6a647710.png)
