### PR TITLE
#162158635 users should be able to get paginated results from the meeting room duration analytics.

### DIFF
--- a/fixtures/room/room_analytics_duration_fixtures.py
+++ b/fixtures/room/room_analytics_duration_fixtures.py
@@ -1,4 +1,6 @@
 null = None
+true = True
+false = False
 
 get_daily_meetings_total_duration_query = '''
 query {
@@ -56,3 +58,73 @@ get_weekly_meetings_total_duration_response = {
                     'count': 0,
                     'totalDuration': 0,
                     'events': []}]}}}
+
+get_paginated_meetings_total_duration_query = '''
+query {
+    analyticsForMeetingsDurations(startDate:"sep 10 2018", perPage:1, page:1){
+    hasPrevious,
+    hasNext,
+    pages,
+    MeetingsDurationaAnalytics{
+      roomName
+      count
+      totalDuration
+      events{
+        durationInMinutes
+        numberOfMeetings
+      }
+    }
+  }
+}
+'''
+
+get_paginated_meetings_total_duration_response = {
+  "data": {
+    "analyticsForMeetingsDurations": {
+      "hasPrevious": false,
+      "hasNext": false,
+      "pages": 1,
+      "MeetingsDurationaAnalytics": [
+        {
+          "roomName": "Entebbe",
+          "count": 0,
+          "totalDuration": 0,
+          "events": []
+        }
+      ]
+    }
+  }
+}
+
+get_paginated_meetings_total_duration_query_invalid_page = '''
+query {
+    analyticsForMeetingsDurations(startDate:"sep 10 2018", perPage:1, page:100){
+    hasPrevious,
+    hasNext,
+    pages,
+    MeetingsDurationaAnalytics{
+      roomName
+      count
+      totalDuration
+      events{
+        durationInMinutes
+        numberOfMeetings
+      }
+    }
+  }
+}
+'''
+
+get_paginated_meetings_total_duration_invalid_page_result = {
+    "errors": [{
+        "message": "Page does not exist",
+        "locations": [{
+            "line": 3,
+            "column": 5
+        }],
+        "path": ["analyticsForMeetingsDurations"]
+    }],
+    "data": {
+        "analyticsForMeetingsDurations": null
+    }
+}

--- a/helpers/pagination/paginate.py
+++ b/helpers/pagination/paginate.py
@@ -1,3 +1,5 @@
+import itertools
+
 import graphene
 from math import ceil
 from graphql import GraphQLError
@@ -49,6 +51,71 @@ class Paginate(graphene.ObjectType):
 
 def validate_page(page):
     if page < 1:
-        return GraphQLError("No page requested")
+        raise GraphQLError("No page requested")
     else:
         return page - 1
+
+
+class ListPaginate:
+    """Handles pagination for data(list) which is queried from google calendar
+    API rather than from our database
+    """
+    def __init__(self, iterable, per_page, page):
+        self.iterable = iterable
+        self.per_page = per_page
+        self.page = page
+        self.query_total = self.get_query_total()
+        self.pages = self.get_pages()
+        self.has_next = self.get_has_next()
+        self.has_previous = self.get_has_previous()
+        self.paginated = self.get_paginated()
+        self.current_page = self.get_current_page()
+
+    def get_query_total(self):
+        return len(self.iterable)
+
+    def get_pages(self):
+        pages = ceil(self.query_total / self.per_page)
+        return pages
+
+    def get_has_next(self):
+        if self.page < self.pages:
+            has_next = True
+        else:
+            has_next = False
+        return has_next
+
+    def get_has_previous(self):
+        if self.page > 1:
+            has_previous = True
+        else:
+            has_previous = False
+        return has_previous
+
+    @staticmethod
+    def get_paginated_result(iterable, per_page):
+        while True:
+            it1, it2 = itertools.tee(iterable)
+            iterable, result = (itertools.islice(it1, per_page, None),
+                                list(itertools.islice(it2, per_page)))
+            if len(result) == 0:
+                break
+            yield result
+
+    # get page_number that can be used in list indexing
+    def get_page_index(self):
+        if self.page < 1:
+            raise GraphQLError("Invalid page requested")
+        return self.page - 1
+
+    def get_paginated(self):
+        result = self.get_paginated_result(
+            iterable=self.iterable, per_page=self.per_page)
+        return list(result)
+
+    def get_current_page(self):
+        try:
+            self.current_page = self.paginated[self.get_page_index()]
+        except IndexError:
+            raise GraphQLError("Page does not exist")
+        return self.current_page

--- a/tests/test_rooms/test_analytics_total_durations.py
+++ b/tests/test_rooms/test_analytics_total_durations.py
@@ -3,8 +3,12 @@ from fixtures.room.room_analytics_duration_fixtures import (
     get_daily_meetings_total_duration_query,
     get_daily_meetings_total_duration_response,
     get_weekly_meetings_total_duration_query,
-    get_weekly_meetings_total_duration_response
-)
+    get_weekly_meetings_total_duration_response,
+    get_paginated_meetings_total_duration_query,
+    get_paginated_meetings_total_duration_response,
+    get_paginated_meetings_total_duration_query_invalid_page,
+    get_paginated_meetings_total_duration_invalid_page_result,
+    )
 
 
 class TotalDailyDurations(BaseTestCase):
@@ -28,3 +32,19 @@ class TotalDailyDurations(BaseTestCase):
             get_weekly_meetings_total_duration_query,
             get_weekly_meetings_total_duration_response
         )
+
+    def test_paginated_meetings_total_duration(self):
+        """
+        Tests getting the paginated total durations for meetings
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, get_paginated_meetings_total_duration_query,
+            get_paginated_meetings_total_duration_response)
+
+    def test_paginated_meetings_total_duration_invalid_page(self):
+        """
+        Tests getting the paginated total durations for meetings
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, get_paginated_meetings_total_duration_query_invalid_page,
+            get_paginated_meetings_total_duration_invalid_page_result)


### PR DESCRIPTION
**What does this PR do?**

Enables a user to get paginated results from the meeting room duration analytics.

**How should this be tested?**

- Run the server `http://127.0.0.1:5000/mrm`.
- Run the `analyticsForMeetingsDurations` query with `startDate`, `endDate`(optional), `page` and `perPage` as the arguments.

What are the relevant pivotal tracker stories?
[#162158635](https://www.pivotaltracker.com/story/show/162158635)

**Screenshots**

1. _Query without pagination details specified_
![image](https://user-images.githubusercontent.com/28927645/49137870-c2e1e800-f2fe-11e8-8ee5-a81730452d9f.png)

2. _Query with a valid page argument and a valid perPage argument_
![image](https://user-images.githubusercontent.com/28927645/49137962-fb81c180-f2fe-11e8-8f76-2c29fd589653.png)

3. _Query with an invalid page argument and a valid perPage argument_
![image](https://user-images.githubusercontent.com/28927645/49138073-51566980-f2ff-11e8-85dc-9284aa1d91d4.png)