### PR TITLE
#162269808 Allow the html code to be returned as a string 

### DIFF
--- a/api/analytics/analytic_report.py
+++ b/api/analytics/analytic_report.py
@@ -146,6 +146,24 @@ class AnalyticsReport():
         return report_jpeg
 
     def get_analytics_pdf_reports(self, query, start_date, end_date):
+        rendered = AnalyticsReport.write_analytics_to_html(
+            self, query, start_date, end_date)
+
+        pdf_file = pdfkit.from_string(rendered, False)
+        response = make_response(pdf_file)
+        response.headers['Content-Type'] = 'application/pdf'
+        response.headers['Content-Disposition'] = 'attachment; filename=analytics_report.pdf'  # noqa
+
+        return response
+
+    def get_analytics_html_reports(self, query, start_date, end_date):
+        rendered = AnalyticsReport.write_analytics_to_html(
+            self, query, start_date, end_date)
+        html_string = "{}".format("".join(rendered.splitlines()))
+
+        return jsonify(data=html_string)
+
+    def write_analytics_to_html(self, query, start_date, end_date):
         report_data_frame = AnalyticsReport.generate_combined_analytics_report(
             self, query, start_date, end_date)
         WriteFile.write_to_html_file(
@@ -156,9 +174,4 @@ class AnalyticsReport():
             )
         rendered = render_template('analytics_report.html')
 
-        pdf_file = pdfkit.from_string(rendered, False)
-        response = make_response(pdf_file)
-        response.headers['Content-Type'] = 'application/pdf'
-        response.headers['Content-Disposition'] = 'attachment; filename=analytics_report.pdf'  # noqa
-
-        return response
+        return rendered

--- a/api/analytics/analytics_request.py
+++ b/api/analytics/analytics_request.py
@@ -60,6 +60,9 @@ class AnalyticsRequest():
         elif file_type == 'PDF':
             response = AnalyticsReport.get_analytics_pdf_reports(
                 self, query, start_date, end_date)
+        elif file_type == 'HTML':
+            response = AnalyticsReport.get_analytics_html_reports(
+                self, query, start_date, end_date)
 
         else:
             response = AnalyticsReport.get_json_analytics_report(

--- a/api/analytics/write_files.py
+++ b/api/analytics/write_files.py
@@ -91,12 +91,12 @@ class WriteFile():
         Write an entire dataframe to an HTML file with nice formatting.
         '''
         today = str(datetime.datetime.now())
-        result = '''
+        result = """
         <html>
         <head>
         <style>
             body {
-                font: 12pt Georgia, "Times New Roman", Times, serif;
+                font: 12pt Georgia, 'Times New Roman', Times, serif;
                 line-height: 1.5;
             }
             h1 {
@@ -158,10 +158,10 @@ class WriteFile():
         </style>
         </head>
         <body>
-            '''
-        result += '<h2> %s </h2>\n' % title + "<h3><P>Date generated:"+" " + today + "</p></h3><hr>"   # noqa
-        result += "\n\n<br><h2>Most Booked Rooms</h2>" + most_used_dataframe.to_html(index=False) + "<br><br><hr>"  # noqa
-        result += "\n\n<br><h2>Least Booked Rooms</h2>" + least_used_dataframe.to_html(index=False) + "<br><br><hr>"  # noqa
+            """
+        result += '<h2> %s </h2>\n' % title + '<h3><P>Date generated:'+' ' + today + '</p></h3><hr>'   # noqa
+        result += '\n\n<br><h2>Most Booked Rooms</h2>' + most_used_dataframe.to_html(index=False) + '<br><br><hr>'  # noqa
+        result += '\n\n<br><h2>Least Booked Rooms</h2>' + least_used_dataframe.to_html(index=False) + '<br><br><hr>'  # noqa
         result += '''
     </body>
     </html>


### PR DESCRIPTION
#### What does this PR do?
- Allows the REST endpoint to return the HTML code for the analytics table as a string so they can convert it to JPG or PDF

#### How should this be manually tested?
- Run the server
- On the endpoint `http://127.0.0.1:5000/analytics`, send a post request with the following parameters `start_date`, `end_date` and `filetype: html`

#### What are the relevant pivotal tracker stories?
[#162269808](https://www.pivotaltracker.com/story/show/162269808)

#### Screenshots
<img width="1170" alt="screenshot 2018-11-28 at 15 57 23" src="https://user-images.githubusercontent.com/33119403/49159082-b7111880-f334-11e8-8ab0-d064f0d88075.png">

