### PR TITLE
#162444849 Add functionality to sort users by location and role

### DIFF
--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -170,3 +170,48 @@ send_invitation_to_existent_user_response = {
         "inviteToConverge": null
     }
 }
+
+get_users_by_location = '''
+query{
+    users(page:1, perPage:1, locationId:1){
+        users{
+            name
+            location
+        }
+    }
+}
+'''
+
+get_users_by_location_and_role = '''
+query{
+    users(page:1, perPage:1, locationId:1, roleId:1){
+        users{
+            name
+            location
+        }
+    }
+}
+'''
+
+get_users_by_role = '''
+query{
+    users(page:1, perPage:1, roleId:1){
+        users{
+            name
+            location
+        }
+    }
+}
+'''
+get_user_by_role_reponse = {
+    'data': {
+        'users': {
+            'users': [
+                {
+                    'name': 'Peter Walugembe',
+                    'location': None
+                }
+            ]
+        }
+    }
+}

--- a/helpers/user_filter/user_filter.py
+++ b/helpers/user_filter/user_filter.py
@@ -1,0 +1,40 @@
+from graphql import GraphQLError
+
+from api.user_role.models import UsersRole
+from api.location.models import Location as LocationModel
+
+
+def user_filter(query, filter_data):
+    """
+    Filters for users by given specifics and
+    returns all users if no specific is passed
+    :param
+        query
+        filter_data
+    :return
+        List of users
+    """
+    location = filter_data.get('location_id', None)
+    role = filter_data.get('role_id', None)
+
+    if location and not role:
+        return filter_by_location(query, location)
+    elif role and not location:
+        return filter_by_role(query, role)
+    elif all([location, role]):
+        query = filter_by_location(query, location)
+        return filter_by_role(query, role)
+    else:
+        return query
+
+
+def filter_by_location(query, location):
+    get_location = LocationModel.query.filter_by(id=location).first()
+    if not get_location:
+        raise GraphQLError("No users found")
+    return query.filter_by(location=get_location.name)
+
+
+def filter_by_role(query, role):
+    query = query.join(UsersRole)
+    return query.filter_by(role_id=role)

--- a/tests/test_user/test_query_user.py
+++ b/tests/test_user/test_query_user.py
@@ -2,7 +2,9 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.user.user_fixture import (
     user_query, user_query_response,
     query_user_by_email, query_user_email_response,
-    paginated_users_query, paginated_users_response
+    paginated_users_query, paginated_users_response,
+    get_users_by_location, get_users_by_location_and_role,
+    get_user_by_role_reponse, get_users_by_role
 )
 from helpers.database import db_session
 from api.user.models import User
@@ -58,3 +60,27 @@ class TestQueryUser(BaseTestCase):
 
         expected_responese = query_user_email_response
         self.assertEqual(execute_query, expected_responese)
+
+    def test_get_users_by_location_error(self):
+        """
+        Testing that returns error for no users in location
+        """
+        CommonTestCases.admin_token_assert_in(
+            self, get_users_by_location, "No users found"
+        )
+
+    def test_get_user_by_role(self):
+        """
+        Testing that users can be filtered by role
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, get_users_by_role, get_user_by_role_reponse
+            )
+
+    def test_get_users_by_location_and_role(self):
+        """
+        Test for error returned for incorrect role id
+        """
+        CommonTestCases.user_token_assert_in(
+            self, get_users_by_location_and_role, "No users found"
+            )


### PR DESCRIPTION
#### What does this PR do?
- Allows the filtering of users by their location and their role

#### How should this be manually tested?
- Run the server and use the URL `localhost:5000/mrm`
- Run the query `users` to retrieve Paginated Users with the parameter `locationId`. This should return the users in the location specified
- Run the query `users` to retrieve Paginated Users with the parameter `roleId`. This should return the users with the specified role

#### What are the relevant pivotal tracker stories?
[#162444849](https://www.pivotaltracker.com/story/show/162444849)

#### Screenshots
**Get users by their location**
<img width="1077" alt="screenshot 2018-12-06 at 16 42 34" src="https://user-images.githubusercontent.com/33119403/49588750-a38b3080-f978-11e8-82fa-c6ddef1e4a73.png">


**Query a non-existent or unused location/role**
<img width="1113" alt="screenshot 2018-12-06 at 16 43 40" src="https://user-images.githubusercontent.com/33119403/49588753-a38b3080-f978-11e8-9fe7-f7cde14c1011.png">

**Query users by their role**
<img width="1121" alt="screenshot 2018-12-06 at 16 42 51" src="https://user-images.githubusercontent.com/33119403/49588752-a38b3080-f978-11e8-9019-e3b67cab97bb.png">


**Query users by their role and location**
<img width="1133" alt="screenshot 2018-12-06 at 16 42 04" src="https://user-images.githubusercontent.com/33119403/49588749-a2f29a00-f978-11e8-9af0-96541675ff58.png">
