### PR TITLE
#162299447 users should be able to get analytics for the total number of bookings(daily and monthly).

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -37,6 +37,11 @@ class RoomFilter(graphene.ObjectType):
     rooms = graphene.List(Room)
 
 
+class BookingsAnalyticsCount(graphene.ObjectType):
+    bookings = graphene.Int()
+    period = graphene.String()
+
+
 class CreateRoom(graphene.Mutation):
     class Arguments:
         name = graphene.String(required=True)

--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -7,7 +7,8 @@ from api.room.schema import (PaginatedRooms, Calendar, Room)
 from helpers.calendar.events import RoomSchedules
 from helpers.calendar.analytics import RoomStatistics  # noqa: E501
 from api.room.models import Room as RoomModel
-from api.room.schema import RatioOfCheckinsAndCancellations
+from api.room.schema import (RatioOfCheckinsAndCancellations,
+                             BookingsAnalyticsCount)
 from helpers.pagination.paginate import ListPaginate
 
 
@@ -89,6 +90,12 @@ class Query(graphene.ObjectType):
         RatiosPerRoom,
         start_date=graphene.String(required=True),
         end_date=graphene.String(),
+    )
+
+    bookings_analytics_count = graphene.List(
+        BookingsAnalyticsCount,
+        start_date=graphene.String(required=True),
+        end_date=graphene.String(required=True),
     )
 
     def check_valid_calendar_id(self, query, calendar_id):
@@ -197,3 +204,10 @@ class Query(graphene.ObjectType):
         ratio = RoomAnalyticsRatios.get_analytics_ratios_per_room(
             self, query, start_date, end_date)
         return RatiosPerRoom(ratio)
+
+    @Auth.user_roles('Admin')
+    def resolve_bookings_analytics_count(self, info, start_date, end_date):  # noqa: E501
+        query = Room.get_query(info)
+        analytics = RoomAnalyticsRatios.get_bookings_analytics_count(
+            self, query, start_date, end_date)
+        return analytics

--- a/fixtures/room/room_analytics_bookings_count_fixtures.py
+++ b/fixtures/room/room_analytics_bookings_count_fixtures.py
@@ -1,0 +1,82 @@
+null = None
+
+get_bookings_count_daily = '''
+query {
+  bookingsAnalyticsCount(startDate:"Nov 10 2018", endDate:"Nov 14 2018"){
+   period
+   bookings
+  }
+}
+'''
+
+get_bookings_count_daily_response = {
+    'data': {
+        'bookingsAnalyticsCount': [{
+            'period': 'Nov 10 2018',
+            'bookings': 0
+        }, {
+            'period': 'Nov 11 2018',
+            'bookings': 0
+        }, {
+            'period': 'Nov 12 2018',
+            'bookings': 2
+        }, {
+            'period': 'Nov 13 2018',
+            'bookings': 1
+        }, {
+            'period': 'Nov 14 2018',
+            'bookings': 3
+        }]
+    }
+}
+
+get_bookings_count_monthly = '''
+query {
+  bookingsAnalyticsCount(startDate:"Aug 1 2018", endDate:"Nov 1 2018"){
+   period
+   bookings
+  }
+}
+'''
+
+get_bookings_count_monthly_response = {
+    'data': {
+        'bookingsAnalyticsCount': [{
+            'period': 'August',
+            'bookings': 0
+        }, {
+            'period': 'September',
+            'bookings': 38
+        }, {
+            'period': 'October',
+            'bookings': 65
+        }, {
+            'period': 'November',
+            'bookings': 3
+        }]
+    }
+}
+
+get_bookings_count_invalid_date_range = '''
+query {
+  bookingsAnalyticsCount(startDate:"Aug 1 2018", endDate:"Aug 30 2018"){
+   period
+   bookings
+  }
+}
+'''
+
+get_bookings_count_invalid_date_range_response = {
+    "errors": [{
+        "message":
+        "Kindly enter a valid date range(less than 15 days or greater than 90 days",  # noqa E501
+        "locations": [{
+            "line": 3,
+            "column": 3
+        }],
+        "path": ["bookingsAnalyticsCount"]
+    }],
+    "data": {
+        "bookingsAnalyticsCount": null
+    }
+}

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -26,6 +26,15 @@ from fixtures.room.room_monthly_meeting_duration_fixtures import (
     get_monthly_meetings_total_duration_response
 )
 
+from fixtures.room.room_analytics_bookings_count_fixtures import (
+    get_bookings_count_daily,
+    get_bookings_count_daily_response,
+    get_bookings_count_monthly,
+    get_bookings_count_monthly_response,
+    get_bookings_count_invalid_date_range,
+    get_bookings_count_invalid_date_range_response
+)
+
 
 class QueryRoomsAnalytics(BaseTestCase):
 
@@ -91,3 +100,21 @@ class QueryRoomsAnalytics(BaseTestCase):
             analytics_for_least_used_room_day,
             analytics_for_least_used_room_day_response
             )
+
+    def test_analytics_for_daily_bookings(self):
+        CommonTestCases.admin_token_assert_equal(
+            self, get_bookings_count_daily,
+            get_bookings_count_daily_response
+        )
+
+    def test_analytics_for_monthly_bookings(self):
+        CommonTestCases.admin_token_assert_equal(
+            self, get_bookings_count_monthly,
+            get_bookings_count_monthly_response
+        )
+
+    def test_analytics_for_bookings_invalid_date_range(self):
+        CommonTestCases.admin_token_assert_equal(
+            self, get_bookings_count_invalid_date_range,
+            get_bookings_count_invalid_date_range_response
+        )


### PR DESCRIPTION
**What does this PR do?**

- Enables a user to get analytics for the total number of bookings(daily and monthly).
   - If the date range is less than 15 days, you get the total number of bookings for each day.
   - If the date range is greater than 90 days, you get the total number of bookings for each month.

**How should this be tested?**

Run the server `http://127.0.0.1:5000/mrm`.
Run the `bookingsAnalyticsCount` query with `startDate` and `endDate`(both are required fields).

**What are the relevant pivotal tracker stories?**
[#162299447](https://www.pivotaltracker.com/story/show/162299447)

**Screenshots**
1. Get analytics for a date range that is less than 15 days.
![image](https://user-images.githubusercontent.com/28927645/49582768-1db2b980-f967-11e8-827b-78110b8299a8.png)

2. Get analytics for a date range that is greater than 90 days.
![image](https://user-images.githubusercontent.com/28927645/49582780-27d4b800-f967-11e8-8930-eb176f84600d.png)


3. Get analytics for an invalid date range.
![image](https://user-images.githubusercontent.com/28927645/49582789-2efbc600-f967-11e8-8a41-48e4998923a8.png)

