### PR TITLE
#162631160 Change date for analytics report to a readable format

### DIFF
--- a/api/analytics/analytic_report.py
+++ b/api/analytics/analytic_report.py
@@ -166,10 +166,12 @@ class AnalyticsReport():
     def write_analytics_to_html(self, query, start_date, end_date):
         report_data_frame = AnalyticsReport.generate_combined_analytics_report(
             self, query, start_date, end_date)
+        start_date_formatted = CommonAnalytics.format_date(start_date)
+        end_date_formatted = CommonAnalytics.format_date(end_date)
         WriteFile.write_to_html_file(
             report_data_frame['Most Used Rooms'],
             report_data_frame['Least Used Rooms'],
-            '<h1>Room Analytics Report Summary</h1><p> <h2>Report Period: From ' + str(start_date) + ' to ' + str(end_date) + '</h2>',   # noqa
+            '<h1>Room Analytics Report Summary</h1><p> <h2>Report Period: From ' + start_date_formatted + ' to ' + end_date_formatted + '</h2>',   # noqa
             'templates/analytics_report.html'
             )
         rendered = render_template('analytics_report.html')

--- a/api/analytics/write_files.py
+++ b/api/analytics/write_files.py
@@ -90,7 +90,7 @@ class WriteFile():
         '''
         Write an entire dataframe to an HTML file with nice formatting.
         '''
-        today = str(datetime.datetime.now())
+        today = str(datetime.datetime.now().strftime('%d/%m/%Y'))
         result = """
         <html>
         <head>

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -38,6 +38,18 @@ class CommonAnalytics(Credentials):
         end_date = (datetime.strptime(end_date, "%b %d %Y") + relativedelta(days=1)).isoformat() + 'Z'  # noqa: E501
         return(start_date, end_date)
 
+    def format_date(date):
+        '''
+        Convert ISO 8601 date to simple DD/MM/YYYY
+        :params
+            - date (in ISO format)
+        '''
+        try:
+            result = datetime.strptime(str(date), "%Y-%m-%dT%H:%M:%SZ")
+            return result.strftime('%d/%m/%Y')
+        except Exception:
+            return date
+
     def get_time_duration_for_event(self, start_time, end_time):
         """ Calculate duration range of an event
          :params


### PR DESCRIPTION
#### What does this PR do?
- Change the analytics date to a readable format

#### How should this be manually tested?
- Run the server on `http://127.0.0.1:5000/analytics`
- Make the following request:

> {
	"start_date": "Oct 8 2018",
	"end_date": "Oct 15 2018",
	"file_type": "pdf"
}

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162631160

#### Screenshots
**New Date Format**
<img width="565" alt="screenshot 2018-12-13 at 19 23 01" src="https://user-images.githubusercontent.com/33119403/49954195-f765be80-ff10-11e8-9b75-eb5b7b0caf25.png">

**Old Date Format**
<img width="509" alt="screenshot 2018-12-13 at 19 54 45" src="https://user-images.githubusercontent.com/33119403/49954196-f7fe5500-ff10-11e8-9ac3-44844d32c320.png">
