### PR TITLE
#162727868 Enable admin add time to a question being created

### DIFF
--- a/api/question/schema.py
+++ b/api/question/schema.py
@@ -3,7 +3,11 @@ from graphene_sqlalchemy import SQLAlchemyObjectType
 from graphql import GraphQLError
 
 from api.question.models import Question as QuestionModel
-from utilities.utility import validate_empty_fields, update_entity_fields
+from utilities.utility import (
+    validate_empty_fields,
+    update_entity_fields,
+    validate_date_time_range
+    )
 from helpers.auth.authentication import Auth
 
 
@@ -16,13 +20,14 @@ class CreateQuestion(graphene.Mutation):
     class Arguments:
         question_type = graphene.String(required=True)
         question = graphene.String(required=True)
-        start_date = graphene.String(required=True)
-        end_date = graphene.String(required=True)
+        start_date = graphene.DateTime(required=True)
+        end_date = graphene.DateTime(required=True)
     question = graphene.Field(Question)
 
     @Auth.user_roles('Admin')
     def mutate(self, info, **kwargs):
         validate_empty_fields(**kwargs)
+        validate_date_time_range(**kwargs)
         question = QuestionModel(**kwargs)
         question.save()
         return CreateQuestion(question=question)
@@ -50,8 +55,8 @@ class UpdateQuestion(graphene.Mutation):
         question_id = graphene.Int(required=True)
         question_type = graphene.String()
         question = graphene.String()
-        start_date = graphene.String()
-        end_date = graphene.String()
+        start_date = graphene.DateTime()
+        end_date = graphene.DateTime()
 
     question = graphene.Field(Question)
 
@@ -63,6 +68,7 @@ class UpdateQuestion(graphene.Mutation):
             QuestionModel.id == question_id).first()
         if not exact_question:
             raise GraphQLError("Question not found")
+        validate_date_time_range(**kwargs)
         update_entity_fields(exact_question, **kwargs)
         exact_question.save()
         return UpdateQuestion(question=exact_question)

--- a/fixtures/questions/create_questions_fixtures.py
+++ b/fixtures/questions/create_questions_fixtures.py
@@ -1,18 +1,42 @@
+import datetime
+
+start_date = (
+  datetime.datetime.now().replace(microsecond=0) + datetime.timedelta(days=1)
+).isoformat()
+end_date = (
+  datetime.datetime.now().replace(microsecond=0) + datetime.timedelta(days=2)
+).isoformat()
+wrong_start_date = (
+  datetime.datetime.now().replace(microsecond=0) + datetime.timedelta(days=-1)
+).isoformat()
+wrong_end_date = (
+  datetime.datetime.now().replace(microsecond=0) + datetime.timedelta(days=1)
+).isoformat()
+
+
 create_question_query = '''
- mutation{
+ mutation{{
   createQuestion(questionType:"Rate",
   question:"How will you rate the brightness of the room",
-  startDate:"20 Nov 2018", endDate:"28 Nov 2018") {
-    question{
+  startDate:"{}", endDate:"{}") {{
+    question{{
       id
       question
       questionType
       startDate
       endDate
-      }
-  }
-}
-'''
+      }}
+  }}
+}}
+'''.format(start_date, end_date)
+
+create_question_query_with_early_startDate = create_question_query.replace(
+  start_date, wrong_start_date
+)
+
+create_question_query_with_early_endDate = create_question_query.replace(
+  end_date, wrong_end_date
+)
 
 create_question_response = {
   "data": {
@@ -21,49 +45,49 @@ create_question_response = {
         "id": "4",
         "question": "How will you rate the brightness of the room",
         "questionType": "rate",
-        "startDate": "20 Nov 2018",
-        "endDate": "28 Nov 2018"
+        "startDate": start_date.replace('T', ' '),
+        "endDate": end_date.replace('T', ' ')
       }
     }
   }
 }
 
 question_mutation_query_without_name = '''
-     mutation{
+     mutation{{
   createQuestion(questionType:"",
   question:"How will you rate the brightness of the room",
-  startDate:"20 Nov 2018", endDate:"28 Nov 2018") {
-    question{
+  startDate:"{}", endDate:"{}") {{
+    question{{
       id
       question
       questionType
       startDate
       endDate
-      }
-  }
-}
-'''
+      }}
+  }}
+}}
+'''.format(start_date, end_date)
 
 update_question_mutation = '''
-  mutation {
+  mutation {{
       updateQuestion(questionId:1,
-      startDate:"12th Dec, 2018", endDate:"18th Dec, 2018") {
-        question {
+      startDate:"{}", endDate:"{}") {{
+        question {{
           id,
           startDate,
           endDate,
-        }
-      }
-  }
-'''
+        }}
+      }}
+  }}
+'''.format(start_date, end_date)
 
 update_question_response = {
   "data": {
     "updateQuestion": {
       "question": {
         "id": "1",
-        "startDate": "12th Dec, 2018",
-        "endDate": "18th Dec, 2018",
+        "startDate": start_date.replace('T', ' '),
+        "endDate": end_date.replace('T', ' '),
       }
     }
   }

--- a/tests/test_questions/test_create_question.py
+++ b/tests/test_questions/test_create_question.py
@@ -4,7 +4,9 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.questions.create_questions_fixtures import (
    create_question_query,
    create_question_response,
-   question_mutation_query_without_name
+   question_mutation_query_without_name,
+   create_question_query_with_early_startDate,
+   create_question_query_with_early_endDate
 )
 
 
@@ -32,4 +34,28 @@ class TestCreateBlock(BaseTestCase):
             self,
             question_mutation_query_without_name,
             "question_type is required field"
+        )
+
+    def test_question_creation_with_wrong_startDate(self):
+        """
+        Testing for question creation when startDate is
+        before current date
+
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_question_query_with_early_startDate,
+            'startDate should be today or after'
+        )
+
+    def test_question_creation_with_wrong_endDate(self):
+        """
+        Testing for question creation when startDate is
+        before current date
+
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_question_query_with_early_endDate,
+            'endDate should be at least a day after startDate'
         )

--- a/utilities/utility.py
+++ b/utilities/utility.py
@@ -1,3 +1,4 @@
+import datetime
 from helpers.database import db_session
 
 
@@ -59,6 +60,24 @@ def validate_rating_field(**kwargs):
     rating = [1, 2, 3, 4, 5]
     if kwargs['rate'] not in rating:
         raise AttributeError("Please rate between 1 and 5")
+
+
+def validate_date_time_range(**kwargs):
+    """
+    Function to validate the dates entered
+    for questions for feedback
+    :params kwargs
+    """
+    if ('start_date' and 'end_date' in kwargs) and\
+            kwargs['start_date'] < datetime.datetime.now():
+        raise ValueError('startDate should be today or after')
+    elif ('start_date' and 'end_date' in kwargs) and\
+            kwargs['end_date'] - kwargs['start_date'] < datetime.timedelta(
+                days=1
+            ):
+        raise ValueError(
+            'endDate should be at least a day after startDate'
+        )
 
 
 class Utility(object):


### PR DESCRIPTION
**What does this PR do?**
- Allows an admin to add a startTime and endTime to a question

**How should this be tested?**
- Run the server `http://127.0.0.1:5000/mrm`.
- Run the following query

```mutation {
  createQuestion(questionType:"Rate",
  question:"How will you rate the brightness of the room",
  startDate:"2018-12-20T23:42:43", endDate:"2018-12-28T15:42:43") {
    question{
      id
      question
      questionType
      startDate
      endDate
      }
  }
}
```

**What are the relevant pivotal tracker stories?**
[#162727868](https://www.pivotaltracker.com/story/show/162727868)

**Screenshots**
<img width="1265" alt="screen shot 2018-12-20 at 12 54 28" src="https://user-images.githubusercontent.com/40039818/50278039-0be91000-0457-11e9-9b98-f360a188709f.png">
<img width="1265" alt="screen shot 2018-12-20 at 12 54 58" src="https://user-images.githubusercontent.com/40039818/50278062-14d9e180-0457-11e9-8de0-429e145e728f.png">
