### PR TITLE
#162241777 Admin can filter feedbacks  per room

### DIFF
--- a/fixtures/response/user_response_check.py
+++ b/fixtures/response/user_response_check.py
@@ -82,3 +82,54 @@ mutation{
   }
 }
 '''
+
+filter_question_by_room = '''
+{
+  getRoomResponse(roomId: 1) {
+    room {
+      capacity
+      name
+      roomType
+    }
+  }
+}
+'''
+
+filter_question_by_room_response = {
+    "data": {
+        "getRoomResponse": [{
+            "room": {
+                "capacity": 6,
+                "name": "Entebbe",
+                "roomType": "meeting"
+            }
+        }]
+    }
+}
+
+filter_question_by_invalid_room = '''
+{
+  getRoomResponse(roomId: 100) {
+    room {
+      id
+      name
+      roomType
+    }
+  }
+}
+
+'''
+
+filter_question_by_invalid_room_response = {
+    "errors": [{
+        "message": "No Feedback Found",
+        "locations": [{
+            "line": 3,
+            "column": 3
+        }],
+        "path": ["getRoomResponse"]
+    }],
+    "data": {
+        "getRoomResponse": null
+    }
+}

--- a/schema.py
+++ b/schema.py
@@ -34,7 +34,8 @@ class Query(
     api.wing.schema.Query,
     utilities.calendar_ids_cleanup.Query,
     api.notification.schema.Query,
-    api.question.schema_query.Query
+    api.question.schema_query.Query,
+    api.response.schema.Query
 ):
     pass
 

--- a/tests/test_response/test_user_response.py
+++ b/tests/test_response/test_user_response.py
@@ -11,7 +11,12 @@ from fixtures.response.user_response_fixtures import (
 from fixtures.response.user_response_check import (
     check_non_existing_question,
     check_with_non_existent_room,
-    select_check_question
+    select_check_question,
+    filter_question_by_room,
+    filter_question_by_room_response,
+    filter_question_by_invalid_room,
+    filter_question_by_invalid_room_response
+
 )
 from fixtures.response.user_response_suggestions import (
     create_suggestion_question,
@@ -157,4 +162,26 @@ class TestCreateResponse(BaseTestCase):
             self,
             choose_non_existent_question,
             "Question does not exist"
+        )
+
+    def test_filter_response_by_valid_room_id(self):
+            """
+            Testing for creating rates
+
+            """
+            CommonTestCases.admin_token_assert_equal(
+                self,
+                filter_question_by_room,
+                filter_question_by_room_response
+            )
+
+    def test_filter_response_by_invalid_room_id(self):
+        """
+        Testing for creating rates
+
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            filter_question_by_invalid_room,
+            filter_question_by_invalid_room_response
         )


### PR DESCRIPTION
**What does this PR do?**
-  Enables an admin to filter feedbacks per room

**How should this be tested?**
- Run the server `http://127.0.0.1:5000/mrm`.
- Run the following query

    ```
  {
  getRoomResponse(roomId: 1) {
    room {
      id
      feedback {
        id
        userId
        cleanlinessRating
        comments
      }
      }
    }
  }
   ```

**Screenshots**
<img width="1194" alt="screenshot 2018-12-20 at 14 30 25" src="https://user-images.githubusercontent.com/38909130/50282473-e9112880-0463-11e9-8094-1a32331d4814.png">


**What are the relevant pivotal tracker stories?**

[#162241777](https://www.pivotaltracker.com/story/show/162241777)



