### PR TITLE
#162241130: View Individual responses from a room

### DIFF
--- a/api/response/models.py
+++ b/api/response/models.py
@@ -30,4 +30,4 @@ class Response(Base, Utility):
         'Resource',
         secondary="missing_items",
         backref=('resources'),
-        lazy="dynamic")
+        lazy="joined")

--- a/api/response/schema_query.py
+++ b/api/response/schema_query.py
@@ -1,0 +1,72 @@
+import graphene
+from graphql import GraphQLError
+
+from api.response.schema import Response
+from api.room.schema import Room
+from helpers.auth.authentication import Auth
+
+
+class ResponseDetails(graphene.ObjectType):
+    response_id = graphene.Int()
+    suggestion = graphene.String()
+    missing_items = graphene.List(graphene.String)
+    created_date = graphene.DateTime()
+    rating = graphene.Int()
+
+
+class RoomResponse(graphene.ObjectType):
+    total_responses = graphene.Int()
+    room_name = graphene.String()
+    response = graphene.List(ResponseDetails)
+
+
+class Query(graphene.ObjectType):
+    room_response = graphene.Field(
+        RoomResponse, room_id=graphene.Int())
+
+    def get_room_response(self, test_response):
+        response = []
+        missing_resource = []
+        for responses in test_response:
+            response_id = responses.id
+            suggestion = responses.text_area
+            created_date = responses.created_date
+            rating = responses.rate
+            if len(responses.missing_resources) > 0:
+                for resources in responses.missing_resources:
+                    resource_name = resources.name
+                    missing_resource.append(resource_name)
+                response_in_room = ResponseDetails(
+                    response_id=response_id,
+                    suggestion=suggestion,
+                    created_date=created_date,
+                    rating=rating,
+                    missing_items=missing_resource)
+                missing_resource = []
+                response.append(response_in_room)
+            else:
+                missing_items = responses.missing_resources
+                response_in_room = ResponseDetails(
+                    response_id=response_id,
+                    suggestion=suggestion,
+                    created_date=created_date,
+                    rating=rating,
+                    missing_items=missing_items)
+                response.append(response_in_room)
+        return response
+
+    @Auth.user_roles('Admin')
+    def resolve_room_response(self, info, room_id):
+        query = Room.get_query(info)
+        query_response = Response.get_query(info)
+        room = query.filter_by(id=room_id).first()
+        if not room:
+            raise GraphQLError("Non-existent room id")
+        room_response = query_response.filter_by(room_id=room_id)
+        responses = Query.get_room_response(self, room_response)
+        total_response = room_response.count()
+        room_name = room.name
+        return RoomResponse(
+                room_name=room_name,
+                total_responses=total_response,
+                response=responses)

--- a/fixtures/questions/get_question_fixtures.py
+++ b/fixtures/questions/get_question_fixtures.py
@@ -17,11 +17,11 @@ get_question_query = '''{
 get_question_query_response = {
   "data": {
     "feedbackQuestion": {
-      "totalResponses": 1,
+      "totalResponses": 2,
       "responses": [
         {
           "roomName": "Entebbe",
-          "responseCount": 1,
+          "responseCount": 2,
           "cleanlinessRating": 2
         }
       ]
@@ -50,11 +50,11 @@ get_paginated_question_query_response = {
       "hasNext": false,
       "hasPrevious": false,
       "pages": 1,
-      "totalResponses": 1,
+      "totalResponses": 2,
       "responses": [
         {
           "roomName": "Entebbe",
-          "responseCount": 1,
+          "responseCount": 2,
           "cleanlinessRating": 2
         }
       ]

--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -1,0 +1,47 @@
+null = None
+
+room_response_query_sample = '''{
+    roomResponse(roomId:1) {
+        roomName,
+        totalResponses,
+        response{
+            responseId,
+            createdDate,
+            missingItems,
+            suggestion,
+            rating
+        }
+    }
+}
+'''
+
+get_room_response_query = '''{
+    roomResponse(roomId:1) {
+        roomName,
+        totalResponses
+    }
+}
+'''
+
+get_room_response_query_response = {
+    "data": {
+        "roomResponse": {
+            "roomName": "Entebbe",
+            "totalResponses": 2
+        }
+    }
+}
+
+get_room_response_non_existence_room_id = '''{
+    roomResponse(roomId:15) {
+        roomName,
+        totalResponses,
+        response{
+            responseId,
+            missingItems,
+            suggestion,
+            rating
+        }
+    }
+}
+'''

--- a/fixtures/response/user_response_check.py
+++ b/fixtures/response/user_response_check.py
@@ -62,7 +62,7 @@ create_check_response = {
   "data": {
     "createResponse": {
       "response": {
-        "id": "2",
+        "id": "3",
         "questionId": 2,
         "roomId": 1
       }
@@ -120,13 +120,22 @@ filter_question_by_room = '''
 
 filter_question_by_room_response = {
     "data": {
-        "getRoomResponse": [{
+        "getRoomResponse": [
+          {
             "room": {
-                "capacity": 6,
-                "name": "Entebbe",
-                "roomType": "meeting"
+              "capacity": 6,
+              "name": "Entebbe",
+              "roomType": "meeting"
             }
-        }]
+          },
+          {
+            "room": {
+              "capacity": 6,
+              "name": "Entebbe",
+              "roomType": "meeting"
+            }
+          }
+        ]
     }
 }
 

--- a/fixtures/response/user_response_fixtures.py
+++ b/fixtures/response/user_response_fixtures.py
@@ -17,7 +17,7 @@ create_rate_response = {
   "data": {
     "createResponse": {
       "response": {
-        "id": "2",
+        "id": "3",
         "questionId": 1,
         "roomId": 1,
         "rate": 2

--- a/fixtures/response/user_response_suggestions.py
+++ b/fixtures/response/user_response_suggestions.py
@@ -17,7 +17,7 @@ create_suggestion_question_response = {
   "data": {
     "createResponse": {
       "response": {
-        "id": "2",
+        "id": "3",
         "questionId": 3,
         "roomId": 1,
         "textArea": "Any other suggestion"

--- a/schema.py
+++ b/schema.py
@@ -18,6 +18,7 @@ import api.feedback.schema
 import api.question.schema
 import api.question.schema_query
 import api.response.schema
+import api.response.schema_query
 
 
 class Query(
@@ -35,7 +36,8 @@ class Query(
     utilities.calendar_ids_cleanup.Query,
     api.notification.schema.Query,
     api.question.schema_query.Query,
-    api.response.schema.Query
+    api.response.schema.Query,
+    api.response.schema_query.Query
 ):
     pass
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -127,6 +127,14 @@ class BaseTestCase(TestCase):
                 created_date=datetime.now()
             )
             response_1.save()
+            response_2 = Response(
+                question_id=question_2.id,
+                room_id=room.id,
+                check=True,
+                created_date=datetime.now()
+            )
+            response_2.save()
+            response_2.missing_resources.append(resource)
             db_session.commit()
 
     def tearDown(self):

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -1,0 +1,37 @@
+import sys
+import os
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.response.room_response_fixture import (
+   get_room_response_query,
+   get_room_response_query_response,
+   get_room_response_non_existence_room_id
+)
+
+
+sys.path.append(os.getcwd())
+
+
+class TestRoomResponse(BaseTestCase):
+
+    def test_room_response(self):
+        """
+        Testing for room response
+
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_room_response_query,
+            get_room_response_query_response
+        )
+
+    def test_room_response_non_existence_room_id(self):
+        """
+        Testing for room response with non-existent
+        room id
+
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            get_room_response_non_existence_room_id,
+            "Non-existent room id"
+        )


### PR DESCRIPTION
 #### What does this PR do?
- Allow Admin to view individual responses in a room.

#### How should this be manually tested?
- Run the server
- Test the query at `localhost:5000/mrm`
- Run `roomResponse` query with the parameter `room_id`

#### What are the relevant pivotal tracker stories?
[#162241130](https://www.pivotaltracker.com/story/show/162241130)

#### Screenshots
1. Response for Non-existence roomID
<img width="1189" alt="screen shot 2019-01-03 at 2 55 32 pm" src="https://user-images.githubusercontent.com/23406358/50641275-b721bb00-0f67-11e9-9423-dbbbfff2a4a6.png">

2. Room response for valid room ID
<img width="1265" alt="screen shot 2019-01-03 at 2 57 07 pm" src="https://user-images.githubusercontent.com/23406358/50641328-e0dae200-0f67-11e9-9ca1-d654f20d5ba6.png">
