### PR TITLE
#162572539 Enable admin to view tool availability and additional feedback

### DIFF
--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -45,3 +45,46 @@ get_room_response_non_existence_room_id = '''{
     }
 }
 '''
+
+summary_room_response_query = '''{
+    allRoomResponses {
+        responses {
+        roomName,
+        totalResponses,
+        response {
+          responseId,
+          rating,
+          suggestion,
+          missingItems
+        }
+      }
+    }
+}
+'''
+
+summary_room_response_data = {
+  "data": {
+    "allRoomResponses": {
+      "responses": [
+        {
+          "roomName": "Entebbe",
+          "totalResponses": 2,
+          "response": [
+            {
+              "responseId": 2,
+              "rating": None,
+              "suggestion": None,
+              "missingItems": ['Markers']
+            },
+            {
+              "responseId": 1,
+              "rating": 2,
+              "suggestion": None,
+              "missingItems": []
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -4,7 +4,9 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.response.room_response_fixture import (
    get_room_response_query,
    get_room_response_query_response,
-   get_room_response_non_existence_room_id
+   get_room_response_non_existence_room_id,
+   summary_room_response_query,
+   summary_room_response_data
 )
 
 
@@ -34,4 +36,15 @@ class TestRoomResponse(BaseTestCase):
             self,
             get_room_response_non_existence_room_id,
             "Non-existent room id"
+        )
+
+    def test_summary_room_responses(self):
+        """
+        Testing for all responses in all rooms
+
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            summary_room_response_query,
+            summary_room_response_data
         )


### PR DESCRIPTION
**What does this PR do?**
- Admin is able to view the total tool availability of a room (missing tools) and the additional feedback given per room (comments given per room).

**Description of task to be completed**
- As an admin, I want to view the details of tool availability and additional comments feedback question, so that I can be able to see the response summaries from all the rooms on which these two questions were asked.

**Any background context you want to provide?**
The data returned is response data in all rooms. The aggregate data e.g the number of missing items will be done in the front-end.

**How should this be tested?**
- Run the server `http://127.0.0.1:5000/mrm`.
- Add questions using the questions mutation
- Provide feedback to any rooms available i.e rating, report any missing items, and give any additional feedback.

Run the following query:
```query {
    allRoomResponses {
	responses {
        roomName,
        totalResponses,
        response {
          responseId,
          rating,
          createdDate,
          suggestion,
          missingItems
        }
      }
    }
}
```
**What are the relevant pivotal stories?**
[#162241130](https://www.pivotaltracker.com/story/show/162572539)

**Screenshots**
This is what to expect:

<img width="1440" alt="screenshot 2019-01-15 at 18 31 16" src="https://user-images.githubusercontent.com/26184534/51190677-d3bcdc00-18f3-11e9-8982-6582fdae39a7.png">