### PR TITLE
#162781153 Filter floors by block

### DIFF
--- a/api/floor/schema.py
+++ b/api/floor/schema.py
@@ -99,6 +99,7 @@ class Query(graphene.ObjectType):
         lambda: Room,
         floor_id=graphene.Int()
     )
+    filter_by_block = graphene.List(Floor, blockId=graphene.Int())
 
     def resolve_all_floors(self, info):
         query = Floor.get_query(info)
@@ -108,6 +109,14 @@ class Query(graphene.ObjectType):
         query = Room.get_query(info)
         rooms = query.filter(RoomModel.floor_id == floor_id)
         return rooms
+
+    @Auth.user_roles('Admin')
+    def resolve_filter_by_block(self, info, blockId):
+        query = Floor.get_query(info)
+        floors = query.filter_by(block_id=blockId)
+        if floors.count() < 1:
+            raise GraphQLError('Floors not found in this block')
+        return floors
 
 
 class Mutation(graphene.ObjectType):

--- a/fixtures/floor/filter_by_block_fixtures.py
+++ b/fixtures/floor/filter_by_block_fixtures.py
@@ -1,0 +1,47 @@
+filter_by_block_query = '''query {
+    filterByBlock(blockId: 1){
+        id
+        name
+        blockId
+        }
+    }'''
+
+filter_by_block_response = {
+        "data": {
+            "filterByBlock": [
+                {
+                    "id": "4",
+                    "name": "3rd",
+                    "blockId": 1
+                }
+            ]
+        }
+    }
+
+filter_by_non_existent_block = '''query {
+    filterByBlock(blockId: 8){
+        id
+        name
+        blockId
+        }
+    }'''
+
+error_response = {
+        "errors": [
+            {
+                "message": "Floors not found in this block",
+                "locations": [
+                    {
+                        "line": 2,
+                        "column": 5
+                    }
+                ],
+                "path": [
+                    "filterByBlock"
+                ]
+            }
+        ],
+        "data": {
+            "filterByBlock": None
+        }
+    }

--- a/tests/test_floors/test_filter_by_block.py
+++ b/tests/test_floors/test_filter_by_block.py
@@ -1,0 +1,25 @@
+from tests.base import BaseTestCase, CommonTestCases
+
+from fixtures.floor.filter_by_block_fixtures import (
+    filter_by_block_query,
+    filter_by_block_response,
+    filter_by_non_existent_block,
+    error_response,
+
+)
+
+
+class TestFilterByBlock(BaseTestCase):
+    def test_filter_rooms_in_block(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            filter_by_block_query,
+            filter_by_block_response
+            )
+
+    def test_filter_rooms_with_nonexistend_block(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            filter_by_non_existent_block,
+            error_response
+            )


### PR DESCRIPTION
**What does this PR do?**
-  Enables an admin to filter floors by block

**Description of task to be completed**
- Ensure that as an admin I can filter the floors by blocks


**How should this be tested?**
- Run the server `http://127.0.0.1:5000/mrm`.
- Run the `filterByblock` query  passing a `blockId` that is oresent in the datbase as shown below

 ```
 query {
  filterByBlock(blockId: 1){
    id
    name
    blockId
}
}
```


**Screenshots**
<img width="1195" alt="image" src="https://user-images.githubusercontent.com/30701246/50744119-08180480-1231-11e9-9767-5a8a81a43554.png">



**What are the relevant pivotal tracker stories?**

[#162241777](https://www.pivotaltracker.com/story/show/162781153)



