### PR TITLE
#162730598 Allow Admins to see the number of responses to a particular feedback question.

### DIFF
--- a/api/question/models.py
+++ b/api/question/models.py
@@ -1,7 +1,9 @@
 from sqlalchemy import (Column, String, Integer, Boolean)
 from sqlalchemy.orm import relationship, validates
+
 from helpers.database import Base
 from utilities.utility import Utility
+import api.response.models
 
 
 class Question(Base, Utility):
@@ -18,3 +20,8 @@ class Question(Base, Utility):
     @validates('question_type')
     def convert_capitalize(self, key, value):
         return value.lower()
+
+    @property
+    def question_response_count(self):
+        ResponseModel = api.response.models.Response
+        return ResponseModel.query.filter_by(question_id=self.id).count()

--- a/api/response/models.py
+++ b/api/response/models.py
@@ -4,7 +4,10 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 from helpers.database import Base
 from utilities.utility import Utility
-from api.question.models import Question  # noqa: F401
+import api.question.models
+
+# not importing it directly prevents a circular-import error
+Question = api.question.models.Question  # noqa: F401
 
 
 missing_items = Table(

--- a/fixtures/questions/get_question_fixtures.py
+++ b/fixtures/questions/get_question_fixtures.py
@@ -76,3 +76,186 @@ get_paginated_question_invalid_page = '''{
   }
 }
 '''
+
+all_questions_query = '''
+query {
+  questions{
+    questions{
+      id
+      questionType
+      question
+      startDate
+      endDate
+      questionResponseCount
+      response {
+        id
+        questionId
+        roomId
+      }
+    }
+  }
+}
+'''
+
+all_questions_query_response = {
+    'data': {
+        'questions': {
+            'questions': [{
+                'id':
+                '1',
+                'questionType':
+                'rate',
+                'question':
+                'How will you rate the brightness of the room',
+                'startDate':
+                '20 Nov 2018',
+                'endDate':
+                '28 Nov 2018',
+                'questionResponseCount':
+                1,
+                'response': [{
+                    'id': '1',
+                    'questionId': 1,
+                    'roomId': 1
+                }]
+            },
+                          {
+                              'id': '2',
+                              'questionType': 'check',
+                              'question':
+                              'Is there anything missing in the room',
+                              'startDate': '20 Nov 2018',
+                              'endDate': '28 Nov 2018',
+                              'questionResponseCount': 1,
+                              'response': [{
+                                  'id': '2',
+                                  'questionId': 2,
+                                  'roomId': 1
+                              }]
+                          },
+                          {
+                              'id': '3',
+                              'questionType': 'input',
+                              'question': 'Any other suggestion',
+                              'startDate': '20 Nov 2018',
+                              'endDate': '28 Nov 2018',
+                              'questionResponseCount': 0,
+                              'response': []
+                          }]
+        }
+    }
+}
+
+paginated_all_questions_query = '''
+query {
+  questions(page:1, perPage:2){
+    questions{
+      id
+      questionType
+      question
+      startDate
+      endDate
+      questionResponseCount
+      response {
+        id
+        questionId
+        roomId
+      }
+    }
+  }
+}
+'''
+
+paginated_all_questions_query_response = {
+    'data': {
+        'questions': {
+            'questions': [{
+                'id':
+                '1',
+                'questionType':
+                'rate',
+                'question':
+                'How will you rate the brightness of the room',
+                'startDate':
+                '20 Nov 2018',
+                'endDate':
+                '28 Nov 2018',
+                'questionResponseCount':
+                1,
+                'response': [{
+                    'id': '1',
+                    'questionId': 1,
+                    'roomId': 1
+                }]
+            },
+                          {
+                              'id': '2',
+                              'questionType': 'check',
+                              'question':
+                              'Is there anything missing in the room',
+                              'startDate': '20 Nov 2018',
+                              'endDate': '28 Nov 2018',
+                              'questionResponseCount': 1,
+                              'response': [{
+                                  'id': '2',
+                                  'questionId': 2,
+                                  'roomId': 1
+                              }]
+                          }]
+        }
+    }
+}
+
+get_question_by_id_query = '''
+query {
+  question(id:1){
+    id
+    questionType
+    question
+    startDate
+    endDate
+    questionResponseCount
+    response {
+      id
+      questionId
+      roomId
+    }
+  }
+}
+'''
+
+get_question_by_id_query_response = {
+    'data': {
+        'question': {
+            'id': '1',
+            'questionType': 'rate',
+            'question': 'How will you rate the brightness of the room',
+            'startDate': '20 Nov 2018',
+            'endDate': '28 Nov 2018',
+            'questionResponseCount': 1,
+            'response': [{
+                'id': '1',
+                'questionId': 1,
+                'roomId': 1
+            }]
+        }
+    }
+}
+
+get_question_invalid_id_query = '''
+query {
+  question(id:122){
+    id
+    questionType
+    question
+    startDate
+    endDate
+    questionResponseCount
+    response {
+      id
+      questionId
+      roomId
+    }
+  }
+}
+'''

--- a/schema.py
+++ b/schema.py
@@ -37,7 +37,8 @@ class Query(
     api.notification.schema.Query,
     api.question.schema_query.Query,
     api.response.schema.Query,
-    api.response.schema_query.Query
+    api.response.schema_query.Query,
+    api.question.schema.Query,
 ):
     pass
 

--- a/tests/test_questions/test_view_question.py
+++ b/tests/test_questions/test_view_question.py
@@ -7,12 +7,14 @@ from fixtures.questions.get_question_fixtures import (
     get_paginated_question,
     get_paginated_question_query_response,
     get_paginated_question_invalid_page,
-)
-from fixtures.questions.create_questions_fixtures import (
     all_questions_query,
-    all_questions_response
+    all_questions_query_response,
+    paginated_all_questions_query,
+    paginated_all_questions_query_response,
+    get_question_by_id_query,
+    get_question_by_id_query_response,
+    get_question_invalid_id_query,
 )
-
 
 sys.path.append(os.getcwd())
 
@@ -54,11 +56,38 @@ class TestQueryQuestion(BaseTestCase):
 
     def test_all_questions_query(self):
         """
-        Testing for viewing feedback question
-
+        Test getting all questions
         """
         CommonTestCases.admin_token_assert_equal(
             self,
             all_questions_query,
-            all_questions_response
+            all_questions_query_response
+        )
+
+    def test_paginated_all_questions_query(self):
+        """
+        Test getting paginated all questions
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            paginated_all_questions_query,
+            paginated_all_questions_query_response
+        )
+
+    def test_get_question_query(self):
+        """
+        Test getting a question using its id
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, get_question_by_id_query,
+            get_question_by_id_query_response)
+
+    def test_get_question_invalid_id_query(self):
+        """
+        Testing getting a question while passing an invalid id
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            get_question_invalid_id_query,
+            "Question does not exist"
         )


### PR DESCRIPTION
**What does this PR do?**

Allows Admins to see the number of responses to a particular feedback question.

**How should this be tested?**

- Run the server `http://127.0.0.1:5000/mrm`.
- Run the `questions` query to get all the questions. Each question will have a `questionResponseCount` attribute showing the total number of responses to that particular question.
- Run the `questions` query passing `page` and `perPage` as arguments for pagination. Each question will have a `questionResponseCount` attribute showing the total number of responses to that particular question.
- Run the `question` query passing the `id` as an argument. The question will have a `questionResponseCount` attribute showing the total number of responses to that particular question.

**What are the relevant pivotal tracker stories?**

#1162730598

**Screenshots**

1. _Get all questions query._

![image](https://user-images.githubusercontent.com/28927645/50774613-efe1cd00-12a4-11e9-9a8a-432cecddc0cb.png)

2. _Paginated get all questions query._

![image](https://user-images.githubusercontent.com/28927645/50774655-0d169b80-12a5-11e9-9030-118f4a60133d.png)

3. _Get a question by id query._

![image](https://user-images.githubusercontent.com/28927645/50774701-27507980-12a5-11e9-8728-7ed95628918e.png)

4. _Get a question by id query with invalid id._

![image](https://user-images.githubusercontent.com/28927645/50774726-39cab300-12a5-11e9-8c26-edc085e4ce0d.png)


