### PR TITLE
#163055834 Fix add location bug

### DIFF
--- a/fixtures/location/create_location_fixtures.py
+++ b/fixtures/location/create_location_fixtures.py
@@ -1,7 +1,6 @@
-
 create_location_query = '''
     mutation {
-  createLocation(name: "Kampala", abbreviation: "KLA", country: "Uganda", timeZone: "EAST_AFRICA_TIME", imageUrl:"https://lala.com") {   # noqa E501
+  createLocation(name: "New", abbreviation: "KLA", country: "Uganda", timeZone: "EAST_AFRICA_TIME", imageUrl:"https://lala.com") {   # noqa E501
     location {
       name
     }
@@ -13,8 +12,30 @@ create_location_response = {
     "data": {
         "createLocation": {
             "location": {
-                "name": "Kampala"
+                "name": "New"
             }
         }
     }
 }
+
+create_duplicate_location_response = '''
+{
+  "errors": [
+    {
+      "message": "New Location already exists",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "createLocation"
+      ]
+    }
+  ],
+  "data": {
+    "createLocation": null
+  }
+}
+'''

--- a/fixtures/location/update_location_fixtures.py
+++ b/fixtures/location/update_location_fixtures.py
@@ -15,8 +15,8 @@ expected_query_update_all_fields = {
         "updateLocation": {
             "location": {
                 "name": "Nairobi",
-                "country": "Kenya",
-                "abbreviation": "KE"
+                "abbreviation": "KE",
+                "country": "CountryType.Kenya"
             }
         }
     }
@@ -41,7 +41,7 @@ expected_location_id_non_existant_query = {
       "message": "Location not found",
       "locations": [
         {
-          "line": 3,
+          "line": 2,
           "column": 3
         }
       ],

--- a/tests/test_location/test_create_location.py
+++ b/tests/test_location/test_create_location.py
@@ -1,4 +1,4 @@
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.location.create_location_fixtures import (
     create_location_query,
     create_location_response)
@@ -14,6 +14,5 @@ class TestCreateLocation(BaseTestCase):
         """
         Testing for location creation
         """
-        query = self.client.execute(create_location_query)
-        expected_response = create_location_response
-        self.assertEqual(query, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self, create_location_query, create_location_response)

--- a/tests/test_location/test_update_location.py
+++ b/tests/test_location/test_update_location.py
@@ -1,20 +1,19 @@
-
-
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 
 from fixtures.location.update_location_fixtures import (
-    query_update_all_fields,
-    query_location_id_non_existant
-)
+    query_update_all_fields, query_location_id_non_existant,
+    expected_query_update_all_fields, expected_location_id_non_existant_query)
 
 
 class TestUpdateLocation(BaseTestCase):
 
     def test_if_all_fields_updated(self):
-        response = self.app_test.post('/mrm?query='+query_update_all_fields)
-        self.assertIn("Nairobi", str(response.data))
+        CommonTestCases.admin_token_assert_equal(
+            self, query_update_all_fields, expected_query_update_all_fields)
 
     def test_updatelocation_mutation_when_id_is_wrong(self):
-        response = self.app_test.post(
-            '/mrm?query='+query_location_id_non_existant)
-        self.assertIn("Location not found", str(response.data))
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_location_id_non_existant,
+            expected_location_id_non_existant_query
+        )


### PR DESCRIPTION
#### What does this PR do?
- Solves the issue of creating multiple locations with similar names

#### Description of Task to be completed?
At the moment, one can create multiple rooms with similar names. This should not be the case since it might lead to conflicts.

### How to manually test it.
- Run the server `http://127.0.0.1:5000/mrm`.
- Run the following query twice

```
 mutation {
  createLocation(name: "TestLocation", abbreviation: "KLA", country: "Kenya", timeZone: "EAST_AFRICA_TIME") {
    location {
      name
    }
  }
}
```

### Screenshots
**initial creation of a location**
<img width="1012" alt="screenshot 2019-01-09 at 16 44 37" src="https://user-images.githubusercontent.com/38909130/50904707-12552100-1432-11e9-93a0-49b13b7b8568.png">

**duplicate creation of a room**
<img width="1124" alt="screenshot 2019-01-09 at 16 44 49" src="https://user-images.githubusercontent.com/38909130/50904741-26008780-1432-11e9-9c45-4aef5f1f7edd.png">

**duplicate creation of the same room with different cases**
<img width="1131" alt="screenshot 2019-01-18 at 11 39 27" src="https://user-images.githubusercontent.com/38909130/51375074-e7478d00-1b15-11e9-81a5-212dfcb72874.png">

<img width="1099" alt="screenshot 2019-01-18 at 11 38 49" src="https://user-images.githubusercontent.com/38909130/51375089-f3334f00-1b15-11e9-8c28-e78c88c5f8c2.png">


### Relevant PT story
[#163055834](https://www.pivotaltracker.com/story/show/163055834)