### PR TITLE
#163111433 Enable admin to filter room responses by number of responses

### DIFF
--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -88,3 +88,42 @@ summary_room_response_data = {
     }
   }
 }
+
+filter_by_response_query = '''
+query{
+    allRoomResponses(filterBy:"Responses",upperLimit: 2, lowerLimit: 0 ){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+filter_by_response_data = {
+    'data': {
+        'allRoomResponses': {
+            'responses': [
+                {
+                    'totalResponses': 2,
+                    'roomName': 'Entebbe',
+                    'response': [
+                        {
+                            'responseId': 2,
+                            'missingItems': ['Markers'],
+                        },
+                        {
+                            'responseId': 1,
+                            'missingItems': [],
+                        }
+
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -6,7 +6,9 @@ from fixtures.response.room_response_fixture import (
    get_room_response_query_response,
    get_room_response_non_existence_room_id,
    summary_room_response_query,
-   summary_room_response_data
+   summary_room_response_data,
+   filter_by_response_query,
+   filter_by_response_data,
 )
 
 
@@ -47,4 +49,15 @@ class TestRoomResponse(BaseTestCase):
             self,
             summary_room_response_query,
             summary_room_response_data
+        )
+
+    def test_filter_by_number_of_responses(self):
+        """
+        Testing for filtering the room responses
+        by the number of responses the room has
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            filter_by_response_query,
+            filter_by_response_data
         )


### PR DESCRIPTION
#### What does this PR do?
- Have implementation of filtration of rooms by the number of responses
#### Description of Task to be completed?
- Have the implementation of a query that accepts three arguments `filterBy` `upper_limit` and `lower_limit` and returns the rooms whose total response is within the range of the two. The rationale fot the filterBy filed is to allow the same field to be used by another developer in the future who requires to filter the responses by a different metric. I had to change the response schema_query to include the filter since this is where the code for the room responses is. I also introduced a fixture file that contains the data that I will use for testing the query I created. Finally introduced a test file that tests the functionality of the introduced query. This ensures that if any other developer were to break the code it would easily be caught by just running the test.

#### How should this be manually tested?
- After cloning this repo cd into mrm_api
- Checkout to the `ft-filter-by-responses-163111433`  branch 
- Start the server as explained in the `README`.
 - Run the following query 
```
query{
allRoomResponses(filterBy:"Responses",upperLimit: 2, lowerLimit: 0 ){
    responses{
      totalResponses
      roomName
      response{
        responseId
        missingItems
        suggestion
      }
      
    }
}
}
```
#### Any background context you want to provide?
- The responses mentioned above are the responses to the questions about the room.
#### What are the relevant pivotal tracker stories?
[#163111433](https://www.pivotaltracker.com/n/projects/2154921/stories/163111433)
#### Screenshots (if appropriate)
<img width="1194" alt="image" src="https://user-images.githubusercontent.com/30701246/51473053-4adaf000-1d8c-11e9-9d7f-fb2832841faa.png">


