### PR TITLE
#163066222 make validations to image and name

### DIFF
--- a/api/location/schema.py
+++ b/api/location/schema.py
@@ -6,7 +6,7 @@ from api.location.models import Location as LocationModel
 from api.devices.models import Devices as DevicesModel  # noqa: F401
 from api.room_resource.models import Resource as ResourceModel  # noqa: F401
 from api.room.schema import Room
-from utilities.utility import validate_country_field, validate_timezone_field, update_entity_fields, validate_empty_fields  # noqa: E501
+from utilities.utility import validate_country_field, validate_timezone_field, update_entity_fields, validate_empty_fields, validate_url  # noqa: E501
 from helpers.room_filter.room_filter import room_join_location
 
 
@@ -28,6 +28,7 @@ class CreateLocation(graphene.Mutation):
         # Validate if the country given is a valid country
         validate_country_field(**kwargs)
         validate_timezone_field(**kwargs)
+        validate_url(**kwargs)
         location = LocationModel(**kwargs)
         location.save()
         return CreateLocation(location=location)
@@ -53,8 +54,15 @@ class UpdateLocation(graphene.Mutation):
             validate_timezone_field(**kwargs)
         if "country" in kwargs:
             validate_country_field(**kwargs)
-        if "name" in kwargs or "abbreviation" in kwargs or "imageUrl" in kwargs:  # noqa
+        if "image_url" in kwargs:
+            validate_url(**kwargs)
+        if "abbreviation" in kwargs:  # noqa
             validate_empty_fields(**kwargs)
+        result = location.filter(LocationModel.name == kwargs.get('name'))
+        if result.count() > 0:
+            pass
+        else:
+            raise AttributeError("Not a valid location")
         update_entity_fields(location_object, **kwargs)
         location_object.save()
         return UpdateLocation(location=location_object)

--- a/fixtures/location/create_location_fixtures.py
+++ b/fixtures/location/create_location_fixtures.py
@@ -1,7 +1,7 @@
 
 create_location_query = '''
     mutation {
-  createLocation(name: "Kampala", abbreviation: "KLA", country: "Uganda", timeZone: "EAST_AFRICA_TIME") {   # noqa E501
+  createLocation(name: "Kampala", abbreviation: "KLA", country: "Uganda", timeZone: "EAST_AFRICA_TIME", imageUrl:"https://lala.com") {   # noqa E501
     location {
       name
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ Flask-Testing==0.7.1
 typing==3.6.4
 flake8==3.5.0
 coveralls
+validators==0.12.4

--- a/utilities/utility.py
+++ b/utilities/utility.py
@@ -1,5 +1,16 @@
 import datetime
+import validators
 from helpers.database import db_session
+
+
+def validate_url(**kwargs):
+    """
+    Function to validate url when
+    saving an object
+    :params kwargs
+    """
+    if not validators.url(kwargs.get('image_url')):
+        raise AttributeError("Please enter a valid image url")
 
 
 def validate_empty_fields(**kwargs):


### PR DESCRIPTION
 #### What does this PR do?
* Add Validations to imageUrl and location name.
#### Description of Task to be completed?
* Added validations that ensure the string put as the imageUrl is a valid url and also the location name should be a valid name like Nairobi or Lagos.
#### How should this be manually tested?
* Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
* git checkout to `bg-validate-image-location-name-163066222`, `pip install validators`  and run the following mutation:
```
 mutation {
  createLocation(name: "Kampala", abbreviation: "KLA", country: "Uganda", timeZone: "EAST_AFRICA_TIME") {   # noqa E501
    location {
      name
    }
  }
}
```
```
mutation{
    updateLocation(locationId: 1, name: "Nairobi", country: "Kenya", abbreviation: "KE",imageUrl:"http://image.com"){ # noqa: E501
        location{
            name
            abbreviation
            country
        }
    }
}
```
* play with name and imageUrl in updateLocation mutation to check what is valid
#### Any background context you want to provide?
* Not applicable
#### screenshots:
* invalid url
<img width="1440" alt="screenshot 2019-01-11 at 09 50 28" src="https://user-images.githubusercontent.com/23398223/51021204-ee105600-1591-11e9-8e3f-02294fb91956.png">
* invalid location name
<img width="1440" alt="screenshot 2019-01-11 at 09 51 00" src="https://user-images.githubusercontent.com/23398223/51021214-fb2d4500-1591-11e9-9418-205374160f0d.png">
* everything correct
<img width="1440" alt="screenshot 2019-01-11 at 09 51 21" src="https://user-images.githubusercontent.com/23398223/51021223-01bbbc80-1592-11e9-8d77-c573285e38f6.png">

#### What are the relevant pivotal tracker stories?
[#163066222](https://www.pivotaltracker.com/n/projects/2154921/stories/163066222)

