### PR TITLE
#163143276 Paginate the wings response

### DIFF
--- a/fixtures/wing/wing_fixtures.py
+++ b/fixtures/wing/wing_fixtures.py
@@ -221,3 +221,71 @@ delete_wing_id_not_found = '''
     }
 }
 '''
+
+get_all_wings_query = '''query {
+    allWings {
+        wings {
+            id
+            name
+            floorId
+        }
+    }
+}
+'''
+
+get_all_wings_query_response = {
+    "data": {
+        "allWings": {
+            "wings": [
+                {
+                    "id": "1",
+                    "name": "Naija",
+                    "floorId": 5
+                },
+                {
+                    "id": "2",
+                    "name": "Big Apple",
+                    "floorId": 5
+                }
+            ]
+        }
+    }
+}
+
+paginated_wings_query = '''query {
+    allWings(page: 1, perPage: 2) {
+        wings {
+            id
+            name
+            floorId
+        }
+        queryTotal
+        pages
+        hasNext
+        hasPrevious
+    }
+}
+'''
+
+paginated_wings_query_response = {
+    "data": {
+        "allWings": {
+            "wings": [
+                {
+                    "id": "1",
+                    "name": "Naija",
+                    "floorId": 5
+                },
+                {
+                    "id": "2",
+                    "name": "Big Apple",
+                    "floorId": 5
+                }
+            ],
+            "queryTotal": 2,
+            "pages": 1,
+            "hasNext": False,
+            "hasPrevious": False
+        }
+    }
+}

--- a/tests/test_wing/test_query_wings.py
+++ b/tests/test_wing/test_query_wings.py
@@ -1,0 +1,22 @@
+from tests.base import BaseTestCase
+
+from fixtures.wing.wing_fixtures import (
+   get_all_wings_query,
+   get_all_wings_query_response,
+   paginated_wings_query,
+   paginated_wings_query_response
+)
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestQueryWings(BaseTestCase):
+    def test_query_all_wings(self):
+        all_wings = self.client.execute(get_all_wings_query)
+        self.assertEquals(all_wings, get_all_wings_query_response)
+
+    def test_query_paginated_wings(self):
+        paginated_wings = self.client.execute(paginated_wings_query)
+        self.assertEquals(paginated_wings, paginated_wings_query_response)


### PR DESCRIPTION
#### What does this PR do?
- Paginate the wings response

#### Description of Task to be completed?
The task is to allow the admin to be able to scroll through all the available wings .

#### How should this be manually tested?
- Run the server `http://127.0.0.1:5000/mrm`.
- Run the following query
```
query {
    allWings(page: 1, perPage: 2) {
        wings {
            id
            name
            floorId
        }
        queryTotal
        pages
        hasNext
        hasPrevious
    }
}
```

**Any background context you want to provide?**
None

**What are the relevant pivotal tracker stories?**
[#163143276](https://www.pivotaltracker.com/story/show/163143276)

#### Screenshots
<img width="856" alt="screen shot 2019-01-14 at 11 53 08 am" src="https://user-images.githubusercontent.com/23643904/51108598-016e2c00-17f3-11e9-997f-560ecca9299f.png">

**Questions:**
None
