### PR TITLE
#160609522 Record when room-feedback-questions are viewed

### DIFF
--- a/api/question/schema.py
+++ b/api/question/schema.py
@@ -118,7 +118,28 @@ class DeleteQuestion(graphene.Mutation):
         return DeleteQuestion(question=exact_question)
 
 
+class UpdateQuestionViews(graphene.Mutation):
+    class Arguments:
+        increment_total_views = graphene.Boolean(required=True)
+
+    questions = graphene.List(Question)
+
+    def mutate(self, info, **kwargs):
+        query = Question.get_query(info)
+        questions = query.all()
+        new_total_views = 0
+        for question in questions:
+            if kwargs['increment_total_views'] and not question.total_views:
+                new_total_views = 1
+            if kwargs['increment_total_views'] and question.total_views:
+                new_total_views = question.total_views + 1
+            update_entity_fields(question, total_views=new_total_views)
+            question.save()
+        return UpdateQuestionViews(questions=questions)
+
+
 class Mutation(graphene.ObjectType):
     create_question = CreateQuestion.Field()
     delete_question = DeleteQuestion.Field()
     update_question = UpdateQuestion.Field()
+    update_question_views = UpdateQuestionViews.Field()

--- a/fixtures/questions/create_questions_fixtures.py
+++ b/fixtures/questions/create_questions_fixtures.py
@@ -164,3 +164,15 @@ all_questions_response = {
         ]
     }
 }
+
+query_update_total_views_of_questions = '''
+mutation{
+  updateQuestionViews(incrementTotalViews:true) {
+    questions{
+      question
+      questionType
+      totalViews
+      }
+  }
+}
+'''

--- a/tests/test_questions/test_update_question.py
+++ b/tests/test_questions/test_update_question.py
@@ -4,7 +4,8 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.questions.create_questions_fixtures import (
    update_question_mutation,
    update_question_response,
-   update_question_invalidId
+   update_question_invalidId,
+   query_update_total_views_of_questions
 )
 
 
@@ -32,4 +33,21 @@ class TestUpdateQuestion(BaseTestCase):
             self,
             update_question_invalidId,
             "Question not found"
+        )
+
+    def test_increment_total_views_of_questions(self):
+        """
+        Testing for incrementing the number of views
+        for a room's feedback qustion
+
+        """
+        CommonTestCases.user_token_assert_in(
+            self,
+            query_update_total_views_of_questions,
+            '1'
+        )
+        CommonTestCases.user_token_assert_in(
+            self,
+            query_update_total_views_of_questions,
+            '2'
         )


### PR DESCRIPTION
#### What does this PR do?
The PR enables the converge team keep track of the number of views on the feedback questions

#### Description of Task to be completed?
Currently, the team does not know if people using the rooms view the questions but do not send back any feedback.  The PR raised seeks to remedy that by introducing a counter that increments everytime the `feedback` button is pressed on the Android platform.

#### How should this be manually tested?
- Run the server `http://127.0.0.1:5000/mrm`.
- Run the following query.
```    mutation{
  updateQuestionViews(incrementTotalViews:true) {
    questions{
      id
      question
      totalViews
      }
  }
}
```

#### Any background context you want to add?
- The PR answers the request of the Fellow Project Coordinator to see those who view the feedback questions but do not give any feedback.

#### Screenshots
<img width="1189" alt="screenshot 2019-01-25 at 12 40 47" src="https://user-images.githubusercontent.com/40039818/51738051-3f930780-209f-11e9-99cd-0bb950ff70c1.png">




#### What are the relevant pivotal tracker stories?
[#162576320](https://www.pivotaltracker.com/story/show/162576320)
