### PR TITLE
#163371157 Admin delete unused location

### DIFF
--- a/api/location/models.py
+++ b/api/location/models.py
@@ -28,4 +28,4 @@ class Location(Base, Utility):
     country = Column(Enum(CountryType))
     time_zone = Column(Enum(TimeZoneType))
     image_url = Column(String)
-    offices = relationship('Office')
+    offices = relationship('Office', cascade="all, delete-orphan")

--- a/api/location/schema.py
+++ b/api/location/schema.py
@@ -82,6 +82,23 @@ class UpdateLocation(graphene.Mutation):
         return UpdateLocation(location=location_object)
 
 
+class DeleteLocation(graphene.Mutation):
+    class Arguments:
+        location_id = graphene.Int(required=True)
+
+    location = graphene.Field(Location)
+
+    @Auth.user_roles('Admin')
+    def mutate(self, info, location_id, **kwargs):
+        query = Location.get_query(info)
+        location = query.filter(
+            LocationModel.id == location_id).first()  # noqa: E501
+        if not location:
+            raise GraphQLError("location not found")
+        location.delete()
+        return DeleteLocation(location=location)
+
+
 class Query(graphene.ObjectType):
     all_locations = graphene.List(Location)
     get_rooms_in_a_location = graphene.List(
@@ -103,3 +120,4 @@ class Query(graphene.ObjectType):
 class Mutation(graphene.ObjectType):
     create_location = CreateLocation.Field()
     update_location = UpdateLocation.Field()
+    delete_location = DeleteLocation.Field()

--- a/fixtures/location/delete_location_fixtures.py
+++ b/fixtures/location/delete_location_fixtures.py
@@ -1,0 +1,30 @@
+delete_location_query = '''
+    mutation{
+    deleteLocation(locationId:1){
+        location{
+        id
+        }
+    }
+    }
+'''
+
+delete_location_response = {
+
+  "data": {
+    "deleteLocation": {
+      "location": {
+        "id": "1"
+      }
+    }
+  }
+}
+
+delete_non_existent_location = '''
+mutation{
+  deleteLocation(locationId:10){
+    location{
+      id
+    }
+  }
+}
+'''

--- a/tests/test_location/test_delete_location.py
+++ b/tests/test_location/test_delete_location.py
@@ -1,0 +1,22 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.location.delete_location_fixtures import (
+    delete_location_query,
+    delete_location_response,
+    delete_non_existent_location,
+)
+
+
+class TestDeleteLocation(BaseTestCase):
+    def test_delete_location(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_location_query,
+            delete_location_response
+        )
+
+    def test_delete_non_existent_location(self):
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_non_existent_location,
+            "location not found"
+        )


### PR DESCRIPTION
 #### What does this PR do?
* Admin should be able to delete a location that is not used anymore.
#### Description of Task to be completed?
*  Added delete fuction to the `api/location/schema.py` file.
* Added mutations and expected responses to the `fixtures/locations/delete_location_fixtures.py`
* Added tests to `tests/test_location/test_delete_location.py`
#### How should this be manually tested?
* Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
* git checkout to `ft-admin-delete-location-163371157` and run the following mutation:
```
 mutation {
  createLocation(name: "Kampala", abbreviation: "KLA", country: "Uganda", timeZone: "EAST_AFRICA_TIME") {   # noqa E501
    location {
      name
    }
  }
}
```
```
mutation{
    deleteLocation(locationId:1){
        location{
        id
        }
    }
    }
```
* The above mutation is assuming the location you created is of `id` 1, otherwise the `id` should be of the location you want to delete.
#### Any background context you want to provide?
* Not applicable
#### screenshots:
* successful delete
<img width="1194" alt="screenshot 2019-01-23 at 09 31 54" src="https://user-images.githubusercontent.com/23398223/51587448-dae67a00-1ef1-11e9-84eb-79ee6c71f426.png">

* location not found

<img width="1194" alt="screenshot 2019-01-23 at 09 31 18" src="https://user-images.githubusercontent.com/23398223/51587475-ea65c300-1ef1-11e9-825c-f90813c80a2f.png">


#### What are the relevant pivotal tracker stories?
[#163066222](https://www.pivotaltracker.com/n/projects/2154921/stories/163371157)