### PR TITLE
#163391935: Fix Email notification bug

### DIFF
--- a/helpers/email/email.py
+++ b/helpers/email/email.py
@@ -1,18 +1,12 @@
 from .email_setup import SendEmail
-from api.user.models import User
 from config import Config
 from flask import render_template
 
 
-def office_created(new_office):
+def send_email_notification(admin_email, new_office):
     # send the email
-    users = User.query.all()
-    recipients = [
-        user.email for user in users if [
-            user_role.role for user_role in user.roles
-            if user_role.role == 'Admin'
-        ]
-    ]
+    recipients = [admin_email]
+
     email = SendEmail(
         'A new office has been added', recipients,
         render_template('office_success.html', office_name=new_office))


### PR DESCRIPTION
#### What does this PR do?
- It sends an email notification to the admin that creates an office and not all admins

#### Description of Task to be completed?
- At the moment, when an admin creates an office, all admin receive the email notification.

### How to manually test it.
- Run the server `http://127.0.0.1:5000/mrm`.
- Create two admin in your database
- Create a new office by running `createOffice` mutation

### Screenshots
- None

### Relevant PT story
[#163391935](https://www.pivotaltracker.com/story/show/163391935)
