### PR TITLE
#163219021 Add current page on paginator

### DIFF
--- a/fixtures/floor/get_floors_fixures.py
+++ b/fixtures/floor/get_floors_fixures.py
@@ -1,3 +1,4 @@
+null = None
 get_all_floors_query = '''{
     allFloors {
         floors {
@@ -39,6 +40,7 @@ paginated_floors_query = '''
    hasNext
    hasPrevious
    pages
+   currentPage
 }
 }
 '''
@@ -60,7 +62,22 @@ paginated_floors_response = {
             ],
             "hasNext": False,
             "hasPrevious": False,
-            "pages": 1
+            "pages": 1,
+            "currentPage": 1
         }
     }
 }
+
+non_existent_page_query = '''
+ query {
+  allFloors(page:100, perPage:4){
+   floors{
+      id
+      name
+      blockId
+   }
+   pages
+   currentPage
+}
+}
+'''

--- a/helpers/pagination/paginate.py
+++ b/helpers/pagination/paginate.py
@@ -10,6 +10,7 @@ class Paginate(graphene.ObjectType):
     query_total = graphene.Int()
     has_next = graphene.Boolean()
     has_previous = graphene.Boolean()
+    current_page = graphene.Int()
 
     def __init__(self, **kwargs):
         self.page = kwargs.pop('page', None)
@@ -47,6 +48,12 @@ class Paginate(graphene.ObjectType):
                 has_previous = False
 
         return has_previous
+
+    def resolve_current_page(self, pages):
+        pages = self.resolve_pages(pages)
+        if self.page > pages:
+            raise GraphQLError("Page does not exist")
+        return self.page
 
 
 def validate_page(page):

--- a/tests/test_floors/test_query_floors.py
+++ b/tests/test_floors/test_query_floors.py
@@ -4,7 +4,8 @@ from fixtures.floor.get_floors_fixures import (
     get_all_floors_query,
     get_floors_query_response,
     paginated_floors_query,
-    paginated_floors_response
+    paginated_floors_response,
+    non_existent_page_query
 )
 
 import sys
@@ -20,3 +21,8 @@ class TestQueryFloors(BaseTestCase):
     def test_query_paginated_floors(self):
         paginated_floors = self.client.execute(paginated_floors_query)
         self.assertEquals(paginated_floors, paginated_floors_response)
+
+    def test_non_existent_page_query(self):
+        response = self.app_test.post(
+            '/mrm?query='+non_existent_page_query)
+        self.assertIn("Page does not exist", str(response.data))


### PR DESCRIPTION
#### What does this PR do?
 Add current page on paginator
### Description of Task to be completed?
- The current page number is added to the paginator
- Modify the fixtures to cover the added lines
#### How should this be manually tested?
- checkout branch `ft-add-current-page-163219021`
- Run  the application using `make run-app`
- Query any paginated data say rooms.
#### Any background context you want to provide?
The current paginator indicates whether a page has_next or has_previous but does not indicate the current page. 
#### What are the relevant pivotal tracker stories?
[#163219021](https://www.pivotaltracker.com/story/show/163219021)
#### Screenshots 

###### Valid page query

<img width="1006" alt="screen shot 2019-01-28 at 13 46 28" src="https://user-images.githubusercontent.com/39129473/51831473-3bffba80-2303-11e9-918a-0e305a3b31c6.png">

###### Invalid page query

<img width="1033" alt="screen shot 2019-01-28 at 13 48 17" src="https://user-images.githubusercontent.com/39129473/51831564-736e6700-2303-11e9-9319-768e0ada76e9.png">


