### PR TITLE
#163388031 Enable admin to view daily events

### DIFF
--- a/fixtures/room/daily_room_events_fixture.py
+++ b/fixtures/room/daily_room_events_fixture.py
@@ -1,0 +1,58 @@
+daily_room_events_query = '''
+query{
+    analyticsForDailyRoomEvents(startDate:"jan 10 2019", endDate:"jan 10 2019"){
+        day
+        events{
+            eventSummary
+            startTime
+            endTime
+            roomName
+            noOfParticipants
+        }
+    }
+}
+'''
+daily_room_events_wrong_date_format_query = '''
+query{
+    analyticsForDailyRoomEvents(startDate:"10 jan 2019", endDate:"jan 10 2019"){
+        day
+        events{
+            eventSummary
+            startTime
+            endTime
+            roomName
+            noOfParticipants
+        }
+    }
+}
+'''
+
+daily_room_events_response = {
+    "data": {
+        "analyticsForDailyRoomEvents": [
+            {
+                "day": "Thu Jan 10 2019",
+                "events": [
+                    {
+                        "eventSummary": "Meeting",
+                        "startTime": "12:30:00",
+                        "endTime": "13:00:00",
+                        "roomName": "Entebbe",
+                        "noOfParticipants": 2
+                    }
+                ]
+            }
+
+        ]
+    }
+}
+
+daily_events_wrong_date_format_response = {'errors': [
+    {
+        'message': "time data '10 jan 2019' does not match format '%b %d %Y'",
+        'locations': [{'line': 3, 'column': 5}],
+        'path': ['analyticsForDailyRoomEvents']}],
+    'data': {
+        'analyticsForDailyRoomEvents': None
+    }
+}

--- a/helpers/calendar/events.py
+++ b/helpers/calendar/events.py
@@ -1,6 +1,10 @@
 import datetime
 import re
+import pytz
+from dateutil import parser
+from graphql import GraphQLError
 
+from .analytics_helper import CommonAnalytics
 from .credentials import Credentials
 
 
@@ -10,6 +14,7 @@ class RoomSchedules(Credentials):
            create_room_event_schedules
            get_room_event_schedules
     """
+
     # define schedule methods here
     def get_room_schedules(self, calendar_id, days):
         """ Get room schedules. This method is responsible
@@ -26,18 +31,17 @@ class RoomSchedules(Credentials):
         events_result = service.events().list(
             calendarId=calendar_id, timeMin=now, timeMax=new_time,
             singleEvents=True, orderBy='startTime').execute()
-
         calendar_events = events_result.get('items', [])
         output = []
         if not calendar_events:
-            return('No upcoming events found.')
+            return ('No upcoming events found.')
         for event in calendar_events:
             event_details = {}
             event_details["start"] = event['start'].get('dateTime', event['start'].get('date'))  # noqa: E501
             event_details["summary"] = event.get("summary")
             output.append(event_details)
 
-    # Define Attendees here
+        # Define Attendees here
         for event in calendar_events:
             all_attendees = []
             if event.get('attendees'):
@@ -48,3 +52,41 @@ class RoomSchedules(Credentials):
                     if match:
                         all_attendees.append(attendee.get('email'))
         return [all_attendees, output]
+
+    def get_all_room_schedules(self, query, start_date, end_date):
+        rooms = query.filter_by(state="active")
+        all_events = []
+        all_dates = []
+        for room in rooms:
+            try:
+                events_result = CommonAnalytics().get_all_events_in_a_room(
+                    calendar_id=room.calendar_id,
+                    min_limit=start_date,
+                    max_limit=end_date
+                )
+            except GraphQLError:
+                continue
+            for event in events_result:
+                CommonAnalytics.format_date(event["start"]["dateTime"])
+                event_start_date = parser.parse(
+                    event["start"]["dateTime"]).astimezone(pytz.utc)
+                event_end_date = parser.parse(
+                    event["end"]["dateTime"]
+                ).astimezone(pytz.utc)
+                day_of_event = event_start_date.strftime("%a %b %d %Y")
+                all_dates.append(day_of_event)
+                attendees = event.get("attendees")
+                no_of_attendees = 0
+                if attendees:
+                    no_of_attendees = len(attendees)
+                current_event = {
+                    "start_time": event_start_date.time(),
+                    "end_time": event_end_date.time(),
+                    "no_of_participants": no_of_attendees,
+                    "room_name": room.name,
+                    "event_summary": event.get("summary"),
+                    "date_of_event": day_of_event
+                }
+                all_events.append(current_event)
+
+        return all_events, all_dates

--- a/tests/test_rooms/test_daily_room_events.py
+++ b/tests/test_rooms/test_daily_room_events.py
@@ -1,0 +1,22 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.room.daily_room_events_fixture import (
+    daily_room_events_query, daily_room_events_response,
+    daily_room_events_wrong_date_format_query,
+    daily_events_wrong_date_format_response,
+)
+
+
+class TestDailyEvents(BaseTestCase):
+    def test_analytics_for_daily_events(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            daily_room_events_query,
+            daily_room_events_response
+        )
+
+    def test_analytics_for_daily_events_wrong_format_date(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            daily_room_events_wrong_date_format_query,
+            daily_events_wrong_date_format_response
+        )


### PR DESCRIPTION
#### What does this PR do?
- Ensure that the admin is able to get the events happening on certain dates

#### Description of Task to be completed?
- To get the events between certain dates you have to query google API for events in all the rooms currently in the database between those days.
-  The data has to be filtered to have only the data that we require which is the event summary, start and end times, room where the event is taking place.
- Provide an endpoint for the query to be send and have the data returned
- Finally write tests to test all the implemented functionality.

#### How should this be manually tested?
- Pull this branch
-  Run the `https://127.0.0.1:8000/mrm[POST] endpoint on insomnia
- Run the following query 
```
query{
  analyticsForDailyRoomEvents(startDate:"jan 10 2019", endDate:"jan 10 2019"){
    day
    events{
      eventSummary
      startTime
      endTime
      roomName
      noOfParticipants
    }
  }
}
```
The data returned should be of a similar structure as seen below in the screenshots.
#### Any background context you want to provide?
- The data relating to this task is gotten from the google calendar API.
- All the times returned by this endpoint are in UTC.

#### What are the relevant pivotal tracker stories?
[#163388031](https://www.pivotaltracker.com/n/projects/2154921/stories/163388031)

### Screenshots
<img width="1194" alt="image" src="https://user-images.githubusercontent.com/30701246/51986458-56779680-24b1-11e9-803a-06817415c185.png">
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/30701246/51986482-61322b80-24b1-11e9-8b9a-eaa3dc5d6b29.png">


