### PR TITLE
#163456848 Enable admin to view the app bookings percentage

### DIFF
--- a/api/analytics/analytic_report.py
+++ b/api/analytics/analytic_report.py
@@ -23,16 +23,16 @@ class AnalyticsReport():
         """
         all_rooms_data_df = []
         for room in rooms_available:
-            calendar_events = CommonAnalytics.get_all_events_in_a_room(
+            all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room['calendar_id'], start_date, end_date)
-            if not calendar_events:
+            if not all_events:
                 all_rooms_data_df.append({
                     'roomName': room['name'],
                     'minutes': 0,
                     'summary': None,
                     'attendees': 0
                 })
-            for event in calendar_events:
+            for event in all_events:
                 if event.get('attendees'):
                     event_details = CommonAnalytics.get_event_details(
                         self, event, room['calendar_id'])

--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -27,6 +27,8 @@ class RatioOfCheckinsAndCancellations(graphene.ObjectType):
     bookings = graphene.Int()
     checkins_percentage = graphene.Float()
     cancellations_percentage = graphene.Float()
+    app_bookings = graphene.Int()
+    app_bookings_percentage = graphene.Float()
 
 
 class Calendar(graphene.ObjectType):

--- a/fixtures/events/events_ratios_fixtures.py
+++ b/fixtures/events/events_ratios_fixtures.py
@@ -5,6 +5,8 @@ event_ratio_query = '''query {
         cancellations
         cancellationsPercentage
         checkinsPercentage
+        appBookings
+        appBookingsPercentage
 }
 }
 '''
@@ -16,7 +18,9 @@ event_ratio_response = {
             "checkins": 0,
             "cancellations": 0,
             "cancellationsPercentage": 0,
-            "checkinsPercentage": 0
+            "checkinsPercentage": 0,
+            'appBookings': 0.0,
+            'appBookingsPercentage': 0.0
         }
     }
 }
@@ -28,6 +32,8 @@ event_ratio_for_one_day_query = '''query {
         cancellations
         cancellationsPercentage
         checkinsPercentage
+        appBookings
+        appBookingsPercentage
     }
 }'''
 
@@ -40,6 +46,8 @@ event_ratio_per_room_query = '''query{
             checkinsPercentage
             cancellations
             cancellationsPercentage
+            appBookings
+            appBookingsPercentage
         }
     }
 }'''
@@ -54,7 +62,9 @@ event_ratio_per_room_response = {
                     'checkins': 0,
                     'checkinsPercentage': 0.0,
                     'cancellations': 0,
-                    'cancellationsPercentage': 0.0
+                    'cancellationsPercentage': 0.0,
+                    'appBookings': 0.0,
+                    'appBookingsPercentage': 0.0
                 }
             ]
         }

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -26,14 +26,14 @@ class RoomAnalytics(Credentials):
             self, query)
         result, number_of_meetings = [], []
         for room in rooms_available:
-            calendar_events = CommonAnalytics.get_all_events_in_a_room(
+            all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room['calendar_id'], start_date, end_date)
             output = []
-            if not calendar_events:
+            if not all_events:
                 output.append({'RoomName': room['name'], 'has_events': False})
                 number_of_meetings.append(0)
             else:
-                for event in calendar_events:
+                for event in all_events:
                     if event.get('attendees'):
                         event_details = CommonAnalytics.get_event_details(self, event, room['calendar_id'])  # noqa: E501
                         output.append(event_details)
@@ -77,9 +77,9 @@ class RoomAnalytics(Credentials):
             self, query)
         res = []
         for room in rooms_available:
-            calendar_events = CommonAnalytics.get_all_events_in_a_room(
+            all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room['calendar_id'], start_date, end_date)
-            room_details = RoomStatistics(room_name=room["name"], count=len(calendar_events))  # noqa: E501
+            room_details = RoomStatistics(room_name=room["name"], count=len(all_events))  # noqa: E501
             res.append(room_details)
         return res
 

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -91,8 +91,8 @@ class CommonAnalytics(Credentials):
                 singleEvents=True, orderBy='startTime').execute()
         except Exception:
             raise GraphQLError("Resource not found")
-        calendar_events = events_result.get('items', [])
-        return calendar_events
+        all_events = events_result.get('items', [])
+        return all_events
 
     def get_event_details(self, event, calendar_id):
         """ Filter details of an event
@@ -111,6 +111,11 @@ class CommonAnalytics(Credentials):
                     event_details["roomName"] = resource.get(
                         'displayName') or None
                     event_details["summary"] = event.get("summary")
+        elif event.get('organizer') and event.get(
+                'organizer').get('email') == calendar_id:
+            event_details["roomName"] = event.get(
+                'organizer').get('displayName') or None
+            event_details["summary"] = event.get("summary")
         return event_details
 
     def get_room_statistics(self, number_of_events_in_room, all_details):
@@ -151,10 +156,10 @@ class CommonAnalytics(Credentials):
         bookings = 0
         rooms = CommonAnalytics.get_calendar_id_name(self, query)
         for room in rooms:
-            calendar_events = CommonAnalytics.get_all_events_in_a_room(
+            all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room["calendar_id"], start_date, end_date)
-            if calendar_events:
-                bookings += len(calendar_events)
+            if all_events:
+                bookings += len(all_events)
         return bookings
 
     @staticmethod


### PR DESCRIPTION
#### What does this PR do?
- Enables the admin to see app bookings percentage

#### Description of Task to be completed?
The task is to admin to view the percentage of bookings that were made from the mobile app. 

#### How should this be manually tested?
- Clone the repo.
- Run `make build`
- `make run-app`
- Then run either of the following queries:
```
query {
  analyticsRatios(startDate: "Dec 09 2018", endDate: "Jan 17 2019") {
     checkins
     cancellations
     bookings
     checkinsPercentage
     roomName
     cancellationsPercentage
     appBookings
     appBookingsPercentage
  }
}
```
#### OR

```
query {
  analyticsRatiosPerRoom(startDate: "Dec 09 2018", endDate: "Jan 17 2019") {
       ratios {
        bookings
         checkins
         cancellations
         cancellationsPercentage
         checkinsPercentage
         appBookingsPercentage
         appBookings
         roomName
      }
  }
}
```
- You will see the app bookings percentage returned.

**Any background context you want to provide?**
None

**What are the relevant pivotal tracker stories?**
[#163456848](https://www.pivotaltracker.com/story/show/163456848)

#### Screenshots
<img width="886" alt="screen shot 2019-01-28 at 10 30 58 pm" src="https://user-images.githubusercontent.com/23643904/51867783-a1c46480-234c-11e9-8ac3-add2434418c2.png">
<img width="886" alt="screen shot 2019-01-28 at 10 32 15 pm" src="https://user-images.githubusercontent.com/23643904/51867785-a25cfb00-234c-11e9-8dc2-0aeab02cca56.png">


**Questions:**
@Bonifase 
(1) Should the number of cancellations be added to the app_bookings?

<img width="563" alt="screen shot 2019-01-29 at 11 42 51 am" src="https://user-images.githubusercontent.com/23643904/51902796-17671980-23bb-11e9-8302-ba1c857e7ee6.png">