### PR TITLE
#163518080 Fix alembic migrations on develop:

### DIFF
--- a/alembic/versions/c8a866f85fd7_decouple_device_and_resource_entity.py
+++ b/alembic/versions/c8a866f85fd7_decouple_device_and_resource_entity.py
@@ -1,7 +1,7 @@
 """decouple device and resource entity
 
 Revision ID: c8a866f85fd7
-Revises: 87582873ea02
+Revises: c53edf85cda4
 Create Date: 2019-01-24 13:21:00.368195
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'c8a866f85fd7'
-down_revision = '87582873ea02'
+down_revision = 'c53edf85cda4'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
#### What does this PR do?
- It removes the non-existant down-revision file and replaces it with one that exists

#### Description of Task to be completed?
- Currently, the down-revision file in the `decouple resource and device entity`  doesn't exist.  This PR adds a file that exists

### How to manually test it.
- Checkout from develop after pulling latest changes.
- Run migrations `make migrate message="Migration Message"`

### Screenshots
- None

### Relevant PT story
[#163518080](https://www.pivotaltracker.com/story/show/163518080)
