### PR TITLE
 #163391842 Add office location on email sent on office creation

### DIFF
--- a/api/office/schema.py
+++ b/api/office/schema.py
@@ -40,7 +40,7 @@ class CreateOffice(graphene.Mutation):
         email = admin.email
         with SaveContextManager(office, kwargs['name'], 'Office'):
             new_office = kwargs['name']
-            if not send_email_notification(email, new_office):
+            if not send_email_notification(email, new_office, location.name):
                 raise GraphQLError("Office created but Emails not Sent")
             return CreateOffice(office=office)
 

--- a/helpers/email/email.py
+++ b/helpers/email/email.py
@@ -3,13 +3,17 @@ from config import Config
 from flask import render_template
 
 
-def send_email_notification(admin_email, new_office):
+def send_email_notification(admin_email, new_office, location_name):
     # send the email
     recipients = [admin_email]
 
     email = SendEmail(
         'A new office has been added', recipients,
-        render_template('office_success.html', office_name=new_office))
+        render_template(
+            'office_success.html',
+            office_name=new_office,
+            location_name=location_name
+        ))
 
     return email.send()
 

--- a/templates/office_success.html
+++ b/templates/office_success.html
@@ -1,4 +1,4 @@
-<p>The Office: <b>{{ office_name }}</b> has been succesfully created.
+<p>The Office: <b>{{ office_name }}</b> has been succesfully created in <b> {{location_name}}</b>.
 You are receiving this notification because you are an Admin of Converge.
 </p>
 


### PR DESCRIPTION
#### What does this PR do?
- Adds office location to the email sent to the admin on creating an office

#### Description of Task to be completed?
- Currently, when an office is created, an admin receives an email with just the name. This PR adds the location where the office was created.
### How to manually test it.
- Create an office
- You should be able to receive an email with both the name of the office and the location.

### Screenshots
**Before**
<img width="724" alt="screen shot 2019-01-29 at 9 20 20 am" src="https://user-images.githubusercontent.com/22786444/51888132-23e17700-23a7-11e9-9884-f190286849ba.png">

**After**
<img width="899" alt="screen shot 2019-01-29 at 9 19 01 am" src="https://user-images.githubusercontent.com/22786444/51888086-f3014200-23a6-11e9-899f-b29af0db0154.png">


### Relevant PT story
[ #163391842 ](https://www.pivotaltracker.com/story/show/163391842)
