### PR TITLE
#163391316 Allow non-admins to view analytics data

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -168,7 +168,7 @@ class Query(graphene.ObjectType):
             events=resource[1]
         )
 
-    @Auth.user_roles('Admin')
+    @Auth.user_roles('Admin', 'Default User')
     def resolve_analytics_for_least_used_rooms(self, info, start_date, end_date=None):  # noqa: E501
         query = Room.get_query(info)
         room_analytics = RoomAnalytics.get_least_used_rooms_analytics(
@@ -178,7 +178,7 @@ class Query(graphene.ObjectType):
             analytics=room_analytics
         )
 
-    @Auth.user_roles('Admin')
+    @Auth.user_roles('Admin', 'Default User')
     def resolve_analytics_for_most_used_rooms(self, info, start_date, end_date=None):  # noqa: E501
         query = Room.get_query(info)
         room_analytics = RoomAnalytics.get_most_used_rooms_analytics(
@@ -189,7 +189,7 @@ class Query(graphene.ObjectType):
         )
         return room_most_used_per_week
 
-    @Auth.user_roles('Admin')
+    @Auth.user_roles('Admin', 'Default User')
     def resolve_analytics_for_meetings_per_room(self, info, start_date, end_date=None):  # noqa: E501
         query = Room.get_query(info)
         meeting_summary = RoomAnalytics.get_meetings_per_room_analytics(
@@ -199,7 +199,7 @@ class Query(graphene.ObjectType):
             analytics=meeting_summary
         )
 
-    @Auth.user_roles('Admin')
+    @Auth.user_roles('Admin', 'Default User')
     def resolve_analytics_for_meetings_durations(self, info, start_date, end_date=None, per_page=None, page=None):  # noqa: E501
         query = Room.get_query(info)
         results = RoomAnalytics.get_meetings_duration_analytics(self, query, start_date, end_date)  # noqa: E501
@@ -212,21 +212,21 @@ class Query(graphene.ObjectType):
             return Analytics(MeetingsDurationaAnalytics=current_page, has_previous=has_previous, has_next=has_next, pages=pages)  # noqa: E501
         return Analytics(MeetingsDurationaAnalytics=results)
 
-    @Auth.user_roles('Admin')
+    @Auth.user_roles('Admin', 'Default User')
     def resolve_analytics_ratios(self, info, start_date, end_date=None):  # noqa: E501
         query = Room.get_query(info)
         ratio = RoomAnalyticsRatios.get_analytics_ratios(
             self, query, start_date, end_date)
         return ratio
 
-    @Auth.user_roles('Admin')
+    @Auth.user_roles('Admin', 'Default User')
     def resolve_analytics_ratios_per_room(self, info, start_date, end_date=None):  # noqa: E501
         query = Room.get_query(info)
         ratio = RoomAnalyticsRatios.get_analytics_ratios_per_room(
             self, query, start_date, end_date)
         return RatiosPerRoom(ratio)
 
-    @Auth.user_roles('Admin')
+    @Auth.user_roles('Admin', 'Default User')
     def resolve_bookings_analytics_count(self, info, start_date, end_date):  # noqa: E501
         query = Room.get_query(info)
         analytics = RoomAnalyticsRatios.get_bookings_analytics_count(

--- a/tests/test_authentication/test_authentication.py
+++ b/tests/test_authentication/test_authentication.py
@@ -2,8 +2,8 @@ import os
 import sys
 
 from tests.base import BaseTestCase
-from fixtures.room.room_analytics_most_used_fixtures import (
-    get_most_used_room_in_a_month_analytics_query)
+from fixtures.office.office_fixtures import (
+    office_mutation_query)
 from fixtures.token.token_fixture import INVALID_TOKEN
 
 sys.path.append(os.getcwd())
@@ -17,6 +17,6 @@ class TestAuthentication(BaseTestCase):
         """
         headers = {"Authorization": "Bearer" + " " + INVALID_TOKEN}  # noqa E501
         response = self.app_test.post(
-            '/mrm?query=' + get_most_used_room_in_a_month_analytics_query,
+            '/mrm?query=' + office_mutation_query,
             headers=headers)
         self.assertIn("invalid token", str(response.data))


### PR DESCRIPTION
#### What does this PR do?
- Allow non-admins to view analytics data
#### Description of Task to be completed?
- A default user should be able to view the analytics data i.e the piecharts, graphs, and tables that are currently viewable by admins only.
#### How should this be manually tested?
- pull and checkout branch `bg-allow-non-admins-view-analytics-163391316`
- create a default user in the database 
- log into the system with that default user
- provide that user's token in the headers
- run query in the screenshot below or any other query that involves retrieving analytics data.
#### What are the relevant pivotal tracker stories?
[#163391316](https://www.pivotaltracker.com/story/show/163391316)
#### Screenshots 
<img width="875" alt="screen shot 2019-01-29 at 13 14 21" src="https://user-images.githubusercontent.com/39129473/51901069-dd504480-23c7-11e9-8b04-0316ec2d6d75.png">
