### PR TITLE
#163356514 Enable admin to update/edit tags

### DIFF
--- a/api/block/schema.py
+++ b/api/block/schema.py
@@ -7,7 +7,8 @@ from api.room.schema import Room
 from api.office.models import Office
 from helpers.room_filter.room_filter import room_join_location
 from helpers.auth.admin_roles import admin_roles
-from utilities.validations import validate_empty_fields, update_entity_fields
+from utilities.validations import validate_empty_fields
+from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
 
 

--- a/api/devices/schema.py
+++ b/api/devices/schema.py
@@ -7,7 +7,8 @@ from sqlalchemy import func
 from api.devices.models import Devices as DevicesModel
 from helpers.auth.authentication import Auth
 from api.room.models import Room as RoomModel
-from utilities.validations import validate_empty_fields, update_entity_fields
+from utilities.validations import validate_empty_fields
+from utilities.utility import update_entity_fields
 from helpers.room_filter.room_filter import location_join_room
 from helpers.auth.admin_roles import admin_roles
 

--- a/api/floor/schema.py
+++ b/api/floor/schema.py
@@ -4,7 +4,8 @@ from graphene_sqlalchemy import SQLAlchemyObjectType
 from graphql import GraphQLError
 from helpers.auth.authentication import Auth
 from helpers.auth.admin_roles import admin_roles
-from utilities.validations import validate_empty_fields, update_entity_fields
+from utilities.validations import validate_empty_fields
+from utilities.utility import update_entity_fields
 from helpers.auth.validator import ErrorHandler
 from helpers.pagination.paginate import Paginate, validate_page
 from api.block.models import Block

--- a/api/location/schema.py
+++ b/api/location/schema.py
@@ -8,11 +8,11 @@ from api.devices.models import Devices as DevicesModel  # noqa: F401
 from api.room_resource.models import Resource as ResourceModel  # noqa: F401
 from api.room.schema import Room
 from utilities.validations import (
-    update_entity_fields,
     validate_empty_fields,
     validate_url,
     validate_country_field,
     validate_timezone_field)
+from utilities.utility import update_entity_fields
 from helpers.room_filter.room_filter import room_join_location
 from helpers.auth.validator import ErrorHandler
 from helpers.auth.authentication import Auth

--- a/api/office/schema.py
+++ b/api/office/schema.py
@@ -5,7 +5,8 @@ from sqlalchemy import exc, func
 
 from api.office.models import Office as OfficeModel
 from api.location.models import Location
-from utilities.validations import update_entity_fields, validate_empty_fields
+from utilities.validations import validate_empty_fields
+from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.room_filter.room_filter import (
     room_join_location,

--- a/api/question/schema.py
+++ b/api/question/schema.py
@@ -5,9 +5,9 @@ from graphql import GraphQLError
 from api.question.models import Question as QuestionModel
 from utilities.validations import (
     validate_empty_fields,
-    update_entity_fields,
     validate_date_time_range
     )
+from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.pagination.paginate import Paginate, validate_page
 

--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -4,7 +4,8 @@ from graphene_sqlalchemy import (SQLAlchemyObjectType)
 from graphql import GraphQLError
 from api.room.models import Room as RoomModel
 from api.office.models import Office
-from utilities.validations import validate_empty_fields, update_entity_fields
+from utilities.validations import validate_empty_fields
+from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.auth.admin_roles import admin_roles
 from helpers.auth.verify_ids_for_room import verify_ids, validate_block

--- a/api/room_resource/schema.py
+++ b/api/room_resource/schema.py
@@ -5,7 +5,8 @@ from graphql import GraphQLError
 
 from api.room_resource.models import Resource as ResourceModel
 from api.room.models import Room as RoomModel
-from utilities.validations import validate_empty_fields, update_entity_fields
+from utilities.validations import validate_empty_fields
+from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.auth.admin_roles import admin_roles
 from helpers.pagination.paginate import Paginate, validate_page

--- a/api/tag/schema.py
+++ b/api/tag/schema.py
@@ -1,9 +1,11 @@
 import graphene
 from sqlalchemy import func
 from graphene_sqlalchemy import SQLAlchemyObjectType
+from graphql import GraphQLError
 
 from api.tag.models import Tag as TagModel
 from utilities.validations import validate_empty_fields
+from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.auth.validator import ErrorHandler
 
@@ -18,7 +20,6 @@ class CreateTag(graphene.Mutation):
         name = graphene.String(required=True)
         color = graphene.String(required=True)
         description = graphene.String(required=True)
-        room_tags = graphene.List(graphene.Int)
     tag = graphene.Field(Tag)
 
     @Auth.user_roles('Admin')
@@ -34,5 +35,27 @@ class CreateTag(graphene.Mutation):
         return CreateTag(tag=tag)
 
 
+class UpdateTag(graphene.Mutation):
+    class Arguments:
+        tag_id = graphene.Int(required=True)
+        name = graphene.String()
+        color = graphene.String()
+        description = graphene.String()
+    tag = graphene.Field(Tag)
+
+    @Auth.user_roles('Admin')
+    def mutate(self, info, tag_id, **kwargs):
+        validate_empty_fields(**kwargs)
+        query_tag = Tag.get_query(info)
+        tag = query_tag.filter(
+            TagModel.id == tag_id).first()
+        if not tag:
+            raise GraphQLError("Tag not found")
+        update_entity_fields(tag, **kwargs)
+        tag.save()
+        return UpdateTag(tag=tag)
+
+
 class Mutation(graphene.ObjectType):
     create_tag = CreateTag.Field()
+    update_tag = UpdateTag.Field()

--- a/api/wing/schema.py
+++ b/api/wing/schema.py
@@ -5,7 +5,8 @@ from sqlalchemy import func
 from graphql import GraphQLError
 from api.floor.models import Floor
 from api.wing.models import Wing as WingModel
-from utilities.validations import update_entity_fields, validate_empty_fields
+from utilities.validations import validate_empty_fields
+from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.auth.error_handler import SaveContextManager
 from helpers.auth.admin_roles import admin_roles

--- a/fixtures/tags/create_tags_fixtures.py
+++ b/fixtures/tags/create_tags_fixtures.py
@@ -89,3 +89,58 @@ create_tag_missing_args_response = {
     "createTag": null
   }
 }
+
+
+update_tag_mutation = '''
+mutation {
+        updateTag (tagId: 1,color: "black") {
+    tag {
+      name,
+      color,
+      description
+    }
+  }
+}'''
+
+update_tag_response = {
+  "data": {
+    "updateTag": {
+      "tag": {
+        "name": "Block-B",
+        "color": "black",
+        "description": "The description"
+      }
+    }
+  }
+}
+
+update_non_existent_tag_mutation = '''
+mutation {
+        updateTag (tagId: 20,color: "black") {
+    tag {
+      name,
+      color,
+      description
+    }
+  }
+}'''
+
+update_non_existent_tag_response = {
+  "errors": [
+    {
+      "message": "Tag not found",
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ],
+      "path": [
+        "updateTag"
+      ]
+    }
+  ],
+  "data": {
+    "updateTag": null
+  }
+}

--- a/tests/test_tags/test_create_tags.py
+++ b/tests/test_tags/test_create_tags.py
@@ -5,7 +5,11 @@ from fixtures.tags.create_tags_fixtures import (
     create_duplicate_tag_response,
     create_tag_with_duplicate_name,
     create_tag_with_missing_argument,
-    create_tag_missing_args_response)
+    create_tag_missing_args_response,
+    update_tag_mutation,
+    update_tag_response,
+    update_non_existent_tag_mutation,
+    update_non_existent_tag_response)
 
 
 class TestCreateTag(BaseTestCase):
@@ -35,4 +39,21 @@ class TestCreateTag(BaseTestCase):
             self,
             create_tag_with_missing_argument,
             create_tag_missing_args_response
+        )
+
+    def test_update_tag(self):
+        """
+        Testing for updating tag
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, update_tag_mutation, update_tag_response)
+
+    def test_update_non_existent_tag(self):
+        """
+        Testing for updating non-existent tag
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_non_existent_tag_mutation,
+            update_non_existent_tag_response
         )

--- a/utilities/utility.py
+++ b/utilities/utility.py
@@ -1,6 +1,18 @@
 from helpers.database import db_session
 
 
+def update_entity_fields(entity, **kwargs):
+    """
+    Function to update an entities fields
+    :param kwargs
+    :param entity
+    """
+    keys = kwargs.keys()
+    for key in keys:
+        exec("entity.{0} = kwargs['{0}']".format(key))
+    return entity
+
+
 class Utility(object):
 
     def save(self):

--- a/utilities/validations.py
+++ b/utilities/validations.py
@@ -26,18 +26,6 @@ def validate_empty_fields(**kwargs):
             raise AttributeError(field + " is required field")
 
 
-def update_entity_fields(entity, **kwargs):
-    """
-    Function to update an entities fields
-    :param kwargs
-    :param entity
-    """
-    keys = kwargs.keys()
-    for key in keys:
-        exec("entity.{0} = kwargs['{0}']".format(key))
-    return entity
-
-
 def validate_rating_field(**kwargs):
     """
     Function to validate rating fields when


### PR DESCRIPTION
#### What does this PR do?
Allows admins to update/edit tags

#### Description of Task to be completed?
Currently, tags can be created but not edited, this PR adds a mutation to enable this.

#### How should this be manually tested?
Pull the changes after checking out to a new branch from Develop.
Run the mutation for creating a tag.
Run the following query to edit the tag created, using the tag's id.

``` 
mutation {
        updateTag (tagId: 1, color: "grey") {
    tag {
      name,
      color,
      description
    }
  }
}
```

The response should be similar to that shown in the screenshots.

#### Any background context you want to provide?
The fail on codeclimate is due to code not related to these changes.

#### What are the relevant pivotal tracker stories?
[#163356514](https://www.pivotaltracker.com/story/show/163356514)

#### Screenshots (if appropriate)
<img width="1189" alt="screenshot 2019-01-31 at 11 40 54" src="https://user-images.githubusercontent.com/40039818/52042013-1960e200-254d-11e9-9623-557cfe55a174.png">