### PR TITLE
#163584006 Implement tags on Room CRUD operations

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -3,6 +3,7 @@ from sqlalchemy import func
 from graphene_sqlalchemy import (SQLAlchemyObjectType)
 from graphql import GraphQLError
 from api.room.models import Room as RoomModel
+from api.tag.models import Tag as TagModel
 from api.office.models import Office
 from utilities.validations import validate_empty_fields, update_entity_fields
 from helpers.auth.authentication import Auth
@@ -18,6 +19,18 @@ from helpers.pagination.paginate import Paginate, validate_page
 class Room(SQLAlchemyObjectType):
     class Meta:
         model = RoomModel
+
+
+def save_room_tags(room, room_tags):
+    missing_tags = ""
+    for tag in room_tags:
+        room_tag = TagModel.query.filter_by(id=tag).first()
+        if not room_tag:
+            missing_tags += str(tag)+" "
+        room.room_tags.append(room_tag)
+    if missing_tags:
+        raise GraphQLError("Tag id {}not found".format(missing_tags))
+    room.save()
 
 
 class RatioOfCheckinsAndCancellations(graphene.ObjectType):
@@ -55,6 +68,7 @@ class CreateRoom(graphene.Mutation):
         wing_id = graphene.Int()
         block_id = graphene.Int()
         cancellation_duration = graphene.Int()
+        room_tags = graphene.List(graphene.Int)
     room = graphene.Field(Room)
 
     @Auth.user_roles('Admin')
@@ -79,8 +93,11 @@ class CreateRoom(graphene.Mutation):
         # remove block ID from kwargs, can't be saved in rooms model
         if kwargs.get('block_id'):
             kwargs.pop('block_id')
+        room_tags = []
+        if kwargs.get('room_tags'):
+            room_tags = kwargs.pop('room_tags')
         room = RoomModel(**kwargs)
-        room.save()
+        save_room_tags(room, room_tags)
         return CreateRoom(room=room)
 
 
@@ -114,6 +131,7 @@ class UpdateRoom(graphene.Mutation):
         image_url = graphene.String()
         calendar_id = graphene.String()
         cancellation_duration = graphene.Int()
+        room_tags = graphene.List(graphene.Int)
     room = graphene.Field(Room)
 
     @Auth.user_roles('Admin')
@@ -121,15 +139,19 @@ class UpdateRoom(graphene.Mutation):
         validate_empty_fields(**kwargs)
         query_room = Room.get_query(info)
         active_rooms = query_room.filter(RoomModel.state == "active")
-        exact_room = active_rooms.filter(RoomModel.id == room_id).first()
-        if not exact_room:
+        room = active_rooms.filter(RoomModel.id == room_id).first()
+        if not room:
             raise GraphQLError("Room not found")
 
         admin_roles.update_delete_rooms_create_resource(room_id)
-        update_entity_fields(exact_room, **kwargs)
-
-        exact_room.save()
-        return UpdateRoom(room=exact_room)
+        room_tags = []
+        if kwargs.get('room_tags'):
+            room_tags = kwargs.pop('room_tags')
+        update_entity_fields(room, **kwargs)
+        previous_tags = room.room_tags
+        previous_tags.clear()
+        save_room_tags(room, room_tags)
+        return UpdateRoom(room=room)
 
 
 class DeleteRoom(graphene.Mutation):
@@ -147,7 +169,7 @@ class DeleteRoom(graphene.Mutation):
             RoomModel.id == room_id).first()
         if not exact_room:
             raise GraphQLError("Room not found")
-
+        exact_room.room_tags.clear()
         admin_roles.update_delete_rooms_create_resource(room_id)
         update_entity_fields(exact_room, state="archived", **kwargs)
         exact_room.save()

--- a/fixtures/helpers/decorators_fixtures.py
+++ b/fixtures/helpers/decorators_fixtures.py
@@ -49,11 +49,42 @@ room_mutation_query = '''
     }
 '''
 
+room_mutation_with_tags_query = '''
+ mutation {
+        createRoom(
+          name: "Syne",
+          calendarId: "andela.com_3836323338323230343935@resource.calendar.google.com",  # noqa: E501
+          roomType: "Meeting",
+          capacity: 1,
+          officeId: 1
+          floorId: 4,
+          roomTags: [1],
+          imageUrl: "http://url.com") {
+            room {
+                name
+                roomType
+                capacity
+                floorId,
+                calendarId,
+                imageUrl
+                roomTags {
+                  name
+                  color
+                }
+            }
+        }
+    }
+'''
+
 user_role_401_msg = b'{"errors":[{"message":"You are not authorized to perform this action","locations":[{"line":3,"column":9}]}],"data":{"createRoom":null}}'  # noqa: E501
 
 query_string = '/mrm?query='+room_mutation_query
 
+tag_query_string = '/mrm?query='+room_mutation_with_tags_query
+
 query_string_response = b'{"data":{"createRoom":{"room":{"name":"Syne","roomType":"Meeting","capacity":1,"floorId":4,"calendarId":"andela.com_3836323338323230343935@resource.calendar.google.com","imageUrl":"http://url.com"}}}}'  # noqa: E501
+
+tag_query_string_response = b'{"data":{"createRoom":{"room":{"name":"Syne","roomType":"Meeting","capacity":1,"floorId":4,"calendarId":"andela.com_3836323338323230343935@resource.calendar.google.com","imageUrl":"http://url.com","roomTags":[{"name":"Block-B","color":"green"}]}}}}'  # noqa: E501
 
 expired_token = jwt.encode(expired, SECRET_KEY)
 

--- a/fixtures/room/create_room_with_tags_fixtures.py
+++ b/fixtures/room/create_room_with_tags_fixtures.py
@@ -1,0 +1,138 @@
+null = None
+
+room_mutation_query = '''
+    mutation {
+        createRoom(
+            name: "Mbarara", roomType: "Meeting", capacity: 4, floorId: 2, officeId: 1,
+            calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
+            roomTags: [1],
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            room {
+                id
+                name
+                roomType
+                capacity
+                floorId
+                imageUrl
+                roomTags {
+                  name
+                  description
+                }
+            }
+        }
+    }
+'''
+
+update_fields_mutation = '''mutation{
+    updateRoom(roomId: 1, name: "Jinja", capacity: 8,
+    roomType: "board room", roomTags: [2]){
+        room{
+            name
+            capacity
+            roomType
+            roomTags {
+                name
+                color
+            }
+        }
+    }
+}
+'''
+
+update_fields_response = {
+    "data": {
+        "updateRoom": {
+            "room": {
+                "name": "Jinja",
+                "capacity": 8,
+                "roomType": "board room",
+                "roomTags": [
+                  {
+                    "name": "Block-C",
+                    "color": "blue"
+                  }
+                ]
+            }
+        }
+    }
+}
+
+non_existing_tag_room_update = '''mutation{
+    updateRoom(roomId: 1, name: "Jinja", capacity: 8,
+    roomType: "board room", roomTags: [8]){
+        room{
+            name
+            capacity
+            roomType
+        }
+    }
+}
+'''
+
+rooms_query = '''
+query {
+  allRooms{
+   rooms{
+      name
+      capacity
+      roomType
+      imageUrl
+      roomTags {
+          name
+          color
+      }
+        }
+    }
+}
+'''
+
+query_rooms_response = {
+    "data": {
+        "allRooms": {
+            "rooms": [
+                {
+                    "name": "Entebbe",
+                    "capacity": 6,
+                    "roomType": "meeting",
+                    "roomTags": [
+                        {
+                            "name": "Block-B",
+                            "color": "green"
+                        }
+                    ],
+                    "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+                }
+            ]
+        }
+    }
+}
+
+room_query_by_id = '''
+{
+    getRoomById(roomId: 1){
+        capacity
+        name
+        roomType
+        roomTags {
+            name
+            color
+        }
+    }
+}
+'''
+
+room_query_by_id_response = {
+    "data": {
+        "getRoomById": {
+            "capacity": 6,
+            "name": "Entebbe",
+            "roomType": "meeting",
+            "roomTags": [
+                {
+                    "name": "Block-B",
+                    "color": "green"
+                }
+            ],
+        }
+    }
+}

--- a/fixtures/room/room_fixtures.py
+++ b/fixtures/room/room_fixtures.py
@@ -361,8 +361,8 @@ room_search_by_empty_name = '''
         name
         }
 }
-
 '''
+
 room_search_by_empty_name_response = "Please input Room Name"
 
 room_search_by_invalid_name = '''

--- a/tests/base.py
+++ b/tests/base.py
@@ -83,6 +83,10 @@ class BaseTestCase(TestCase):
                       color='green',
                       description='The description')
             tag.save()
+            tag_two = Tag(name='Block-C',
+                          color='blue',
+                          description='The description')
+            tag_two.save()
             room = Room(name='Entebbe',
                         room_type='meeting',
                         capacity=6,
@@ -90,6 +94,7 @@ class BaseTestCase(TestCase):
                         calendar_id='andela.com_3630363835303531343031@resource.calendar.google.com',  # noqa: E501
                         image_url="https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg")  # noqa: E501
             room.save()
+            room.room_tags.append(tag)
             resource = Resource(name='Markers',
                                 quantity=3,
                                 room_id=room.id)

--- a/tests/test_rooms/test_room_crud_with_tags.py
+++ b/tests/test_rooms/test_room_crud_with_tags.py
@@ -1,0 +1,68 @@
+import sys
+import os
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.helpers.decorators_fixtures import (
+    tag_query_string, tag_query_string_response
+)
+from fixtures.room.create_room_with_tags_fixtures import (
+    update_fields_mutation,
+    update_fields_response,
+    non_existing_tag_room_update,
+    rooms_query,
+    query_rooms_response,
+    room_query_by_id,
+    room_query_by_id_response
+)
+from fixtures.token.token_fixture import ADMIN_TOKEN
+
+sys.path.append(os.getcwd())
+
+
+class TestCreateRoomWithTags(BaseTestCase):
+
+    def test_room_creation_with_tags(self):
+        """
+        Testing for room creation using tags
+        """
+        headers = {"Authorization": "Bearer" + " " + ADMIN_TOKEN}
+
+        query = self.app_test.post(tag_query_string, headers=headers)
+        expected_response = tag_query_string_response
+
+        self.assertEqual(query.data, expected_response)
+
+    def test_update_with_non_existant_tag(self):
+        """
+        Testing for room creation with inexistent tag
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            non_existing_tag_room_update,
+            "Tag id 8 not found")
+
+    def test_update_room_with_existant_tag(self):
+        """
+        Testing for room creation with existing tag
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_fields_mutation,
+            update_fields_response)
+
+    def test_query_room_with_tags(self):
+        """
+        Testing for room query
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            rooms_query,
+            query_rooms_response)
+
+    def test_query_room_by_id_with_tags(self):
+        """
+        Testing for room query
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            room_query_by_id,
+            room_query_by_id_response)


### PR DESCRIPTION
#### What does this PR do?
Allows admins to include tags in room CRUD operations i.e Creating rooms and Updating rooms.

#### Description of Task to be completed?
Admin's adding and editing rooms should select tags that are to be associated with the room. Deleting rooms should remove the relationship between the room and tags.

#### How should this be manually tested?
* Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
* git checkout to `ft-implement-tags-in-rooms-163584006` and run the following mutations:

Create room:
```
mutation {
        createRoom(
            name: "Room 2", roomType: "Meeting", capacity: 4, floorId: 2, officeId: 1, roomTags: [1, 3],
      calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  
            room {
                id
                name
                roomType
                capacity
                floorId
                imageUrl
                roomTags {
                  name
                  description
                }
            }
        }
    }
```
Update room:
```
mutation{
    updateRoom(roomId: 2, name: "Jinja", capacity: 8,
    roomType: "board room", roomTags: [1, 3]){
        room{
            name
            capacity
            roomType
          	roomTags {
              name
              color
              description
            }
        }
    }
}
```

#### Any background context you want to provide?
An admin can add/update one or more tags in a room. Deleting a room automatically deletes the relationship between the room and its tags.

#### Screenshots
* On creating a room:
<img width="1440" alt="screenshot 2019-01-31 at 18 50 38" src="https://user-images.githubusercontent.com/26184534/52068144-230a3a00-258d-11e9-8d1d-177cfd70f705.png">

* On creating a room with a no-existing tag
<img width="1440" alt="screenshot 2019-02-04 at 12 19 42" src="https://user-images.githubusercontent.com/26184534/52199498-51cb2d80-2877-11e9-89f8-014c18a2f3af.png">

*On updating a room
<img width="1440" alt="screenshot 2019-01-31 at 19 22 25" src="https://user-images.githubusercontent.com/26184534/52068349-93b15680-258d-11e9-9d8e-6d1a68a15fd4.png">

*On getting all rooms
<img width="1440" alt="screenshot 2019-02-04 at 20 07 23" src="https://user-images.githubusercontent.com/26184534/52224768-dfc80800-28b9-11e9-8ebf-7620b99e9cd3.png">


#### What are the relevant pivotal tracker stories?
[#163584006](https://www.pivotaltracker.com/story/show/163584006)
