### PR TITLE
#161947308 Implement cancelation of missed recurring events

### DIFF
--- a/api/analytics/analytic_report.py
+++ b/api/analytics/analytic_report.py
@@ -23,16 +23,16 @@ class AnalyticsReport():
         """
         all_rooms_data_df = []
         for room in rooms_available:
-            calendar_events = CommonAnalytics.get_all_events_in_a_room(
+            all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room['calendar_id'], start_date, end_date)
-            if not calendar_events:
+            if not all_events:
                 all_rooms_data_df.append({
                     'roomName': room['name'],
                     'minutes': 0,
                     'summary': None,
                     'attendees': 0
                 })
-            for event in calendar_events:
+            for event in all_events:
                 if event.get('attendees'):
                     event_details = CommonAnalytics.get_event_details(
                         self, event, room['calendar_id'])

--- a/api/events/schema.py
+++ b/api/events/schema.py
@@ -2,8 +2,11 @@ import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from graphql import GraphQLError
 
+from helpers.calendar.analytics_helper import CommonAnalytics
+from helpers.calendar.events import RoomSchedules
 from api.events.models import Events as EventsModel
-from api.room.models import Room
+from api.room.models import Room as RoomModel
+from api.room.schema_query import PaginatedRooms
 
 
 class Events(SQLAlchemyObjectType):
@@ -12,16 +15,76 @@ class Events(SQLAlchemyObjectType):
 
     def check_status(self, info, **kwargs):
         try:
-            room_id = Room.query.filter_by(calendar_id=kwargs['calendar_id']).first().id  # noqa: E501
+            room_id = RoomModel.query.filter_by(calendar_id=kwargs['calendar_id']).first().id  # noqa: E501
             if EventsModel.query.filter_by(
                     event_id=kwargs['event_id'],
                     room_id=room_id).count() > 0:
-                raise GraphQLError("This event already exists.")
+                raise GraphQLError("You cannot perform this action")
             return room_id
 
         except AttributeError:
             raise GraphQLError(
                 "This Calendar ID is not registered on Converge.")
+
+
+class CalendarEvents(graphene.ObjectType):
+    event_id = graphene.String()
+    start_date = graphene.String()
+    end_date = graphene.String()
+    event_title = graphene.String()
+    recurring_event_id = graphene.String()
+    room_name = graphene.String()
+
+
+class RecurringEvents(graphene.ObjectType):
+    day = graphene.String()
+    events = graphene.List(CalendarEvents)
+
+
+class Query(graphene.ObjectType):
+    rooms = graphene.Field(PaginatedRooms, days=graphene.Int(),)
+    all_recurring_events = graphene.Field(
+        RecurringEvents,
+        date=graphene.String(required=True),
+        )
+
+    def resolve_all_recurring_events(self, info, **kwargs):
+        query = RoomModel.query
+        start_date, end_date = CommonAnalytics().convert_dates(
+            kwargs["date"], None)
+        day = kwargs["date"]
+        events = RoomSchedules().get_all_recurring_events(
+            query, start_date, end_date)
+        all_recurring_events = []
+        for event in events:
+            start_date = event["start_date"]
+            end_date = event["end_date"]
+            recurring_event = CalendarEvents(
+                start_date=start_date,
+                end_date=end_date,
+                room_name=event["room_name"],
+                event_title=event["event_summary"],
+                recurring_event_id=event["recurring_event_id"],
+                event_id=event["event_id"]
+            )
+            all_recurring_events.append(recurring_event)
+        return RecurringEvents(
+            day=day,
+            events=all_recurring_events
+        )
+
+
+class EventList(graphene.Mutation):
+    class Arguments:
+        calendar_id = graphene.String(required=True)
+        event_id = graphene.String(required=True)
+        event_title = graphene.String(required=True)
+        start_time = graphene.String(required=True)
+        end_time = graphene.String(required=True)
+    event = graphene.Field(Events)
+
+    def mutate(self, info, **kwargs):
+        pass
 
 
 class EventCheckin(graphene.Mutation):

--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -27,6 +27,8 @@ class RatioOfCheckinsAndCancellations(graphene.ObjectType):
     bookings = graphene.Int()
     checkins_percentage = graphene.Float()
     cancellations_percentage = graphene.Float()
+    app_bookings = graphene.Int()
+    app_bookings_percentage = graphene.Float()
 
 
 class Calendar(graphene.ObjectType):

--- a/fixtures/events/events_ratios_fixtures.py
+++ b/fixtures/events/events_ratios_fixtures.py
@@ -5,6 +5,8 @@ event_ratio_query = '''query {
         cancellations
         cancellationsPercentage
         checkinsPercentage
+        appBookings
+        appBookingsPercentage
 }
 }
 '''
@@ -16,7 +18,9 @@ event_ratio_response = {
             "checkins": 0,
             "cancellations": 0,
             "cancellationsPercentage": 0,
-            "checkinsPercentage": 0
+            "checkinsPercentage": 0,
+            'appBookings': 0.0,
+            'appBookingsPercentage': 0.0
         }
     }
 }
@@ -28,6 +32,8 @@ event_ratio_for_one_day_query = '''query {
         cancellations
         cancellationsPercentage
         checkinsPercentage
+        appBookings
+        appBookingsPercentage
     }
 }'''
 
@@ -40,6 +46,8 @@ event_ratio_per_room_query = '''query{
             checkinsPercentage
             cancellations
             cancellationsPercentage
+            appBookings
+            appBookingsPercentage
         }
     }
 }'''
@@ -54,7 +62,9 @@ event_ratio_per_room_response = {
                     'checkins': 0,
                     'checkinsPercentage': 0.0,
                     'cancellations': 0,
-                    'cancellationsPercentage': 0.0
+                    'cancellationsPercentage': 0.0,
+                    'appBookings': 0.0,
+                    'appBookingsPercentage': 0.0
                 }
             ]
         }

--- a/fixtures/events/get_recurring_events_fixtures.py
+++ b/fixtures/events/get_recurring_events_fixtures.py
@@ -1,0 +1,47 @@
+recurring_event_query = '''
+{
+  allRecurringEvents(date: "feb 28 2019") {
+    day
+    events {
+      startDate
+      endDate
+      roomName
+      eventTitle
+      recurringEventId
+      eventId
+    }
+  }
+}
+'''
+
+date_out_of_range_query = '''
+{
+  allRecurringEvents(date: "feb 30 2019") {
+    day
+    events {
+      startDate
+      endDate
+      roomName
+      eventTitle
+      recurringEventId
+      eventId
+    }
+  }
+}
+'''
+
+wrong_date_format_query = '''
+{
+  allRecurringEvents(date: "21 jan 2019") {
+    day
+    events {
+      startDate
+      endDate
+      roomName
+      eventTitle
+      recurringEventId
+      eventId
+    }
+  }
+}
+'''

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -26,14 +26,14 @@ class RoomAnalytics(Credentials):
             self, query)
         result, number_of_meetings = [], []
         for room in rooms_available:
-            calendar_events = CommonAnalytics.get_all_events_in_a_room(
+            all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room['calendar_id'], start_date, end_date)
             output = []
-            if not calendar_events:
+            if not all_events:
                 output.append({'RoomName': room['name'], 'has_events': False})
                 number_of_meetings.append(0)
             else:
-                for event in calendar_events:
+                for event in all_events:
                     if event.get('attendees'):
                         event_details = CommonAnalytics.get_event_details(self, event, room['calendar_id'])  # noqa: E501
                         output.append(event_details)
@@ -77,9 +77,9 @@ class RoomAnalytics(Credentials):
             self, query)
         res = []
         for room in rooms_available:
-            calendar_events = CommonAnalytics.get_all_events_in_a_room(
+            all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room['calendar_id'], start_date, end_date)
-            room_details = RoomStatistics(room_name=room["name"], count=len(calendar_events))  # noqa: E501
+            room_details = RoomStatistics(room_name=room["name"], count=len(all_events))  # noqa: E501
             res.append(room_details)
         return res
 

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -91,8 +91,8 @@ class CommonAnalytics(Credentials):
                 singleEvents=True, orderBy='startTime').execute()
         except Exception:
             raise GraphQLError("Resource not found")
-        calendar_events = events_result.get('items', [])
-        return calendar_events
+        all_events = events_result.get('items', [])
+        return all_events
 
     def get_event_details(self, event, calendar_id):
         """ Filter details of an event
@@ -111,6 +111,11 @@ class CommonAnalytics(Credentials):
                     event_details["roomName"] = resource.get(
                         'displayName') or None
                     event_details["summary"] = event.get("summary")
+        elif event.get('organizer') and event.get(
+                'organizer').get('email') == calendar_id:
+            event_details["roomName"] = event.get(
+                'organizer').get('displayName') or None
+            event_details["summary"] = event.get("summary")
         return event_details
 
     def get_room_statistics(self, number_of_events_in_room, all_details):
@@ -151,10 +156,10 @@ class CommonAnalytics(Credentials):
         bookings = 0
         rooms = CommonAnalytics.get_calendar_id_name(self, query)
         for room in rooms:
-            calendar_events = CommonAnalytics.get_all_events_in_a_room(
+            all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room["calendar_id"], start_date, end_date)
-            if calendar_events:
-                bookings += len(calendar_events)
+            if all_events:
+                bookings += len(all_events)
         return bookings
 
     @staticmethod

--- a/schema.py
+++ b/schema.py
@@ -37,6 +37,7 @@ class Query(
     api.response.schema.Query,
     api.response.schema_query.Query,
     api.question.schema.Query,
+    api.events.schema.Query,
 ):
     pass
 

--- a/tests/test_events/test_event_checkin.py
+++ b/tests/test_events/test_event_checkin.py
@@ -36,7 +36,7 @@ class TestEventCheckin(BaseTestCase):
         CommonTestCases.user_token_assert_in(
             self,
             event_checkin_mutation,
-            "This event already exists."
+            "You cannot perform this action"
         )
 
     def test_checkin_with_invalid_calendar_id(self):
@@ -57,4 +57,19 @@ class TestEventCheckin(BaseTestCase):
             self,
             cancel_event_mutation,
             cancel_event_respone
+        )
+
+    def test_cancel_event_twice(self):
+        '''
+        test that you cannot cancel an event twice
+        '''
+        CommonTestCases.user_token_assert_equal(
+            self,
+            cancel_event_mutation,
+            cancel_event_respone
+        )
+        CommonTestCases.user_token_assert_in(
+            self,
+            cancel_event_mutation,
+            "You cannot perform this action"
         )

--- a/tests/test_events/test_recurring_events.py
+++ b/tests/test_events/test_recurring_events.py
@@ -1,0 +1,46 @@
+import sys
+import os
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.events.get_recurring_events_fixtures import (
+    recurring_event_query,
+    # recurring_event_responce,
+    # non_recurring_event_query,
+    date_out_of_range_query,
+    wrong_date_format_query
+    # non_recurring_event_responce
+)
+
+sys.path.append(os.getcwd())
+
+
+class TestRecurringEvent(BaseTestCase):
+
+    def test_get_recurring_events(self):
+        """
+        test if the query returns all recurring events for a day
+        """
+        CommonTestCases.user_token_assert_in(
+            self,
+            recurring_event_query,
+            "feb 28 2019"
+        )
+
+    def test_for_out_of_range_date_entry(self):
+        '''
+        test for incorrectly entered dates
+        '''
+        CommonTestCases.user_token_assert_in(
+            self,
+            date_out_of_range_query,
+            "day is out of range for month"
+        )
+
+    def test_wrong_time_format(self):
+        """
+        test for dates entered in an incorrect format
+        """
+        CommonTestCases.user_token_assert_in(
+            self,
+            wrong_date_format_query,
+            "does not match format"
+        )


### PR DESCRIPTION
#### What does this PR do?
- [x] add querry to get all recurring events per room
- [ ] Refactor create and checkin event mutation
- [ ] Preload event model with google api event data 
- [ ] Create check-in relationship
- [ ] Implement functionality to cancel event after 3 consecutive missed checkins

#### Description of Task to be completed?
- A recurring meeting should be cancelled when a user fails to check in consecutively 3 times. This is to avoid ghost meetings and make the room available for use.

#### How should this be manually tested?
- Pull this branch
-  Run the `https://127.0.0.1:8000/mrm[POST] endpoint on insomnia
- Run the following query 
```
{
  allRecurringEvents(date: "feb 28 2019") {
    day
    events {
      startDate
      endDate
      roomName
      eventTitle
      recurringEventId
      eventId
    }
  }
}
```
#### Below are the screenshots expected from the query

* screenshot for days with recurring events

<img width="1195" alt="screenshot 2019-01-31 at 19 14 07" src="https://user-images.githubusercontent.com/38909130/52068456-bfccd780-258d-11e9-9821-76e59947fefb.png">

* screenshot for days without recurring events

<img width="1194" alt="screenshot 2019-01-31 at 19 24 59" src="https://user-images.githubusercontent.com/38909130/52068548-eee34900-258d-11e9-8ab9-0e116b0c0147.png">



#### Any background context you want to provide?
- The data relating to this task is gotten from the google calendar API.

#### What are the relevant pivotal tracker stories?

[#161947308](https://www.pivotaltracker.com/story/show/161947308)