### PR TITLE
#163725518:Allow admin to search feedback response by room name

### DIFF
--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -23,7 +23,7 @@ get_room_response_query = '''{
 }
 '''
 
-get_room_response_query_response = {
+get_room_response_query_data = {
     "data": {
         "roomResponse": {
             "roomName": "Entebbe",
@@ -91,7 +91,112 @@ summary_room_response_data = {
 
 filter_by_response_query = '''
 query{
-    allRoomResponses(filterBy:"Responses",upperLimit: 2, lowerLimit: 0 ){
+    allRoomResponses(upperLimit: 2, lowerLimit: 0 ){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+filter_by_response_invalid_query = '''
+query{
+    allRoomResponses(upperLimit: 2){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_query = '''
+query{
+    allRoomResponses(upperLimit: 2, lowerLimit: 0, room:"Entebbe"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_beyond_limits_query = '''
+query{
+    allRoomResponses(upperLimit: 7, lowerLimit: 5, room:"Entebbe"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_invalid_room_query = '''
+query{
+    allRoomResponses(upperLimit: 2, lowerLimit: 0, room:"Entebbes"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_only = '''
+query{
+    allRoomResponses(room:"Entebbe"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_invalid_room = '''
+query{
+    allRoomResponses(room:"Entebbes"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_no_response = '''
+query{
+    allRoomResponses(room:"Kampala"){
         responses{
             totalResponses
             roomName

--- a/fixtures/room/room_fixtures.py
+++ b/fixtures/room/room_fixtures.py
@@ -191,6 +191,11 @@ db_rooms_query_response = {
                 "capacity": 6,
                 "roomType": "meeting",
                 "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+            }, {
+                "name": "Empire State",
+                "capacity": 4,
+                "roomType": "meeting",
+                "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
             }]
     }
 }
@@ -204,6 +209,12 @@ query_rooms_response = {
                     "capacity": 6,
                     "roomType": "meeting",
                     "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+                },
+                {
+                    "name": "Empire State",
+                    "capacity": 4,
+                    "roomType": "meeting",
+                    "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
                 }
             ]
         }
@@ -212,7 +223,7 @@ query_rooms_response = {
 
 paginated_rooms_query = '''
  query {
-  allRooms(page:1, perPage:1){
+  allRooms(page:1, perPage:3){
    rooms{
       name
    }
@@ -229,6 +240,9 @@ paginated_rooms_response = {
             "rooms": [
                 {
                     "name": "Entebbe"
+                },
+                {
+                    "name": "Empire State"
                 }
             ],
             "hasNext": False,

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -3,11 +3,17 @@ import os
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.response.room_response_fixture import (
    get_room_response_query,
-   get_room_response_query_response,
+   get_room_response_query_data,
    get_room_response_non_existence_room_id,
+   search_response_by_room_invalid_room_query,
+   search_response_by_room_query,
+   search_response_by_room_only,
+   search_response_by_room_beyond_limits_query,
+   search_response_by_invalid_room,
    summary_room_response_query,
    summary_room_response_data,
    filter_by_response_query,
+   filter_by_response_invalid_query,
    filter_by_response_data,
 )
 
@@ -20,19 +26,17 @@ class TestRoomResponse(BaseTestCase):
     def test_room_response(self):
         """
         Testing for room response
-
         """
         CommonTestCases.admin_token_assert_equal(
             self,
             get_room_response_query,
-            get_room_response_query_response
+            get_room_response_query_data
         )
 
     def test_room_response_non_existence_room_id(self):
         """
         Testing for room response with non-existent
         room id
-
         """
         CommonTestCases.admin_token_assert_in(
             self,
@@ -60,4 +64,71 @@ class TestRoomResponse(BaseTestCase):
             self,
             filter_by_response_query,
             filter_by_response_data
+        )
+
+    def test_filter_by_number_of_invalid_responses(self):
+        """
+        Testing for filtering the room responses
+        by the number of responses the room has
+        using ignoring one of the limits
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            filter_by_response_invalid_query,
+            "Provide upper and lower limits to filter by response number"
+        )
+
+    def test_filter_search_response_room_name(self):
+        """
+        Testing for filtering the room responses
+        by the number and search by room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            search_response_by_room_query,
+            filter_by_response_data
+        )
+
+    def test_search_response_room_name_only(self):
+        """
+        Testing for searching the room responses
+        by room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            search_response_by_room_only,
+            filter_by_response_data
+        )
+
+    def test_filter_search_response_invalid_room(self):
+        """
+        Test for filter by response and search
+        the room with invalid room name
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            search_response_by_room_invalid_room_query,
+            "No response for this room, enter a valid room name"
+        )
+
+    def test_search_response_invalid_room(self):
+        """
+        Test for search by room name
+        with invalid room name
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            search_response_by_invalid_room,
+            "No response for this room, enter a valid room name"
+        )
+
+    def test_search_response_beyond_limits(self):
+        """
+        Test for search by room name
+        beyond upper and lower limits
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            search_response_by_room_beyond_limits_query,
+            "No response for this room at this range"
         )


### PR DESCRIPTION
 #### What does this PR do?
- Allow admin to search for room feedback response using the room name

#### Description of Task to be completed?
- Add an option to search response by room name in the response schema query
- Updated the test file for search functionality

#### How should this be manually tested?
- Run the server
- Test the query at `localhost:8000/mrm`
- Run `allRoomResponses ` query. Sample query can be found [here](https://github.com/andela/mrm_api/blob/develop/fixtures/response/room_response_fixture.py)

#### What are the relevant pivotal tracker stories?
[#163725518](https://www.pivotaltracker.com/story/show/163725518)

#### Screenshots
1. Room Responses filter by responses and search by room name
<img width="1219" alt="screen shot 2019-02-07 at 3 26 49 pm" src="https://user-images.githubusercontent.com/23406358/52417811-fa35f780-2aec-11e9-9a9a-52f50c98b687.png">


2. Room responses filter by responses and search by room name beyond limits
<img width="1220" alt="screen shot 2019-02-07 at 3 27 32 pm" src="https://user-images.githubusercontent.com/23406358/52417851-0de15e00-2aed-11e9-9314-b479da49af19.png">


3. Room responses search by room name only
<img width="1220" alt="screen shot 2019-02-07 at 11 26 03 am" src="https://user-images.githubusercontent.com/23406358/52406866-090db180-2acf-11e9-8cf7-ee9a47227b9b.png">

4. Room response search by invalid room name
<img width="1216" alt="screen shot 2019-02-07 at 11 25 43 am" src="https://user-images.githubusercontent.com/23406358/52407006-643fa400-2acf-11e9-9ad2-8f3fae29d7cb.png">

5. Room response filter by response and search invalid room name
<img width="1220" alt="screen shot 2019-02-07 at 3 27 03 pm" src="https://user-images.githubusercontent.com/23406358/52417877-1f2a6a80-2aed-11e9-85bc-f31437ac00ec.png">



