### PR TITLE
#163731044 Fix create response mutation

### DIFF
--- a/api/response/schema.py
+++ b/api/response/schema.py
@@ -5,7 +5,8 @@ from api.response.models import Response as ResponseModel
 from utilities.validations import validate_empty_fields
 from graphql import GraphQLError
 from api.room.schema import Room
-from api.question.models import Question
+from api.question.models import Question as QuestionModel
+from api.question.schema import Question
 from helpers.response.create_response import create_response
 
 
@@ -16,13 +17,13 @@ class Response(SQLAlchemyObjectType):
 
 class CreateResponse(graphene.Mutation):
     class Arguments:
-        question_id = graphene.Int(required=True)
+        question_id = graphene.List(graphene.Int, required=True)
         room_id = graphene.Int(required=True)
         rate = graphene.Int()
         text_area = graphene.String()
         missing_items = graphene.List(graphene.Int)
 
-    response = graphene.Field(Response)
+    response = graphene.List(Response)
 
     def mutate(self, info, **kwargs):
         validate_empty_fields(**kwargs)
@@ -30,12 +31,26 @@ class CreateResponse(graphene.Mutation):
         room = query.filter_by(id=kwargs['room_id']).first()
         if not room:
             raise GraphQLError("Non-existent room id")
-        get_question = Question.query.filter_by(id=kwargs['question_id']).first() # noqa
-        if not get_question:
-            raise GraphQLError("Question does not exist")
-        question_type = get_question.question_type
-        resource = create_response(question_type, **kwargs)
-        return CreateResponse(response=resource)
+        question_ids = kwargs.pop('question_id')
+        responses = []
+        questions = Question.get_query(info).filter(
+            QuestionModel.id.in_(question_ids)).all()
+        valid_question_ids = set()
+        for question in questions:
+            valid_question_ids.add(question.id)
+            question_type = question.question_type
+            response = create_response(
+                question_type, question_id=question.id, **kwargs)
+            responses.append(response)
+        invalid_question_ids = set(question_ids).difference(
+            valid_question_ids)
+        if invalid_question_ids:
+            raise GraphQLError(
+                ('Responses for question ids {} were not saved because '
+                    'the questions do not exist').format(
+                    str(invalid_question_ids).strip('{}'))
+                )
+        return CreateResponse(response=responses)
 
 
 class Query(graphene.ObjectType):

--- a/fixtures/response/user_response_check.py
+++ b/fixtures/response/user_response_check.py
@@ -16,7 +16,7 @@ mutation{
 check_non_existing_question_response = {
   "errors": [
     {
-      "message": "Question does not exist",
+      "message": "Responses for question ids",
       "locations": [
         {
           "line": 2,
@@ -61,11 +61,13 @@ mutation{
 create_check_response = {
   "data": {
     "createResponse": {
-      "response": {
-        "id": "3",
-        "questionId": 2,
-        "roomId": 1
-      }
+      "response": [
+        {
+          "id": "3",
+          "questionId": 2,
+          "roomId": 1
+        }
+      ]
     }
   }
 }

--- a/fixtures/response/user_response_fixtures.py
+++ b/fixtures/response/user_response_fixtures.py
@@ -16,12 +16,14 @@ mutation{
 create_rate_response = {
   "data": {
     "createResponse": {
-      "response": {
-        "id": "3",
-        "questionId": 1,
-        "roomId": 1,
-        "rate": 2
-      }
+      "response": [
+        {
+          "id": "3",
+          "questionId": 1,
+          "roomId": 1,
+          "rate": 2
+        }
+      ]
     }
   }
 }

--- a/fixtures/response/user_response_suggestions.py
+++ b/fixtures/response/user_response_suggestions.py
@@ -16,12 +16,14 @@ mutation{
 create_suggestion_question_response = {
   "data": {
     "createResponse": {
-      "response": {
-        "id": "3",
-        "questionId": 3,
-        "roomId": 1,
-        "textArea": "Any other suggestion"
-      }
+      "response": [
+        {
+          "id": "3",
+          "questionId": 3,
+          "roomId": 1,
+          "textArea": "Any other suggestion"
+        }
+      ]
     }
   }
 }

--- a/tests/test_response/test_user_response.py
+++ b/tests/test_response/test_user_response.py
@@ -87,7 +87,7 @@ class TestCreateResponse(BaseTestCase):
         CommonTestCases.user_token_assert_in(
             self,
             check_non_existing_question,
-            "Question does not exist"
+            "Responses for question ids"
         )
 
     def test_check_non_existent_room(self):
@@ -183,7 +183,7 @@ class TestCreateResponse(BaseTestCase):
         CommonTestCases.user_token_assert_in(
             self,
             choose_non_existent_question,
-            "Question does not exist"
+            "Responses for question ids"
         )
 
     def test_filter_response_by_valid_room_id(self):


### PR DESCRIPTION
#### What does this PR do?
- Allows creation of a response for multiple questions

#### Description of Task to be completed?
Change question id to allow a list of integers
Modify tests accordingly

#### How should this be manually tested?
- Clone the repo.
- Run `make build`
- `make run-app`
#### Previous mutation for creating a response:
```
mutation {
  createResponse(questionId: 1, roomId: 164, rate: 1, textArea: "empty", missingItems: [65]) {
    response {
      roomId
      questionId
      question {
        question
      }
    }
  }
}
```
#### After bug fix: New mutation for creating room response

```
mutation {
  createResponse(questionId: [2, 3, 1], roomId: 164, rate: 1, textArea: "empty", missingItems: [65]) {
    response {
      roomId
      questionId
      question {
        question
      }
    }
  }
}
```

**Any background context you want to provide?**
None

**What are the relevant pivotal tracker stories?**
[#163731044](https://www.pivotaltracker.com/story/show/163731044)

#### Screenshots
Before bug fix
<img width="910" alt="screen shot 2019-02-06 at 4 44 16 pm" src="https://user-images.githubusercontent.com/23643904/52353292-8af9ce00-2a2e-11e9-92f2-940bd7750d84.png">

After bug fix

_`with valid ids`_
<img width="938" alt="screen shot 2019-02-07 at 3 09 56 pm" src="https://user-images.githubusercontent.com/23643904/52416818-cb1e8680-2aea-11e9-87f9-56680d279dd3.png">

_`with some invalid ids`_
<img width="951" alt="screen shot 2019-02-08 at 11 31 18 am" src="https://user-images.githubusercontent.com/23643904/52473028-17be9c00-2b95-11e9-9fe5-6e1b1014cb5f.png">



**Questions:**
None
