### PR TITLE
#163653690 Fix cancellation percentage accuracy

### DIFF
--- a/fixtures/events/events_ratios_fixtures.py
+++ b/fixtures/events/events_ratios_fixtures.py
@@ -70,3 +70,18 @@ event_ratio_per_room_response = {
         }
     }
 }
+
+event_ratio_percentage_cancellation_query = '''query {
+    analyticsRatios(startDate:"Jul 10 2018", endDate:"Jul 29 2018"){
+        cancellationsPercentage
+}
+}
+'''
+
+event_ratio_percentage_cancellation_response = {
+    "data": {
+        "analyticsRatios": {
+            "cancellationsPercentage": 100.0
+        }
+    }
+}

--- a/helpers/calendar/ratios_and_utilization.py
+++ b/helpers/calendar/ratios_and_utilization.py
@@ -128,13 +128,13 @@ class RoomAnalyticsRatios(Credentials):
         bookings = len(calendar_events_list) + len(
             app_events_list) + cancellations
         app_bookings = len(app_events_list) + cancellations
-        app_bookings_percentage = RoomAnalyticsRatios.percentage_formater(
+        app_bookings_percentage = RoomAnalyticsRatios().percentage_formater(
             app_bookings,
             bookings)
-        cancellations_percentage = RoomAnalyticsRatios.percentage_formater(
+        cancellations_percentage = RoomAnalyticsRatios().percentage_formater(
             cancellations,
             bookings)
-        checkins_percentage = RoomAnalyticsRatios.percentage_formater(
+        checkins_percentage = RoomAnalyticsRatios().percentage_formater(
             checkins,
             bookings)
         result = RatioOfCheckinsAndCancellations(
@@ -149,14 +149,14 @@ class RoomAnalyticsRatios(Credentials):
             )
         return result
 
-    def percentage_formater(portion, total):
+    def percentage_formater(self, portion, total):
         """ Calculates the percentage of the entered portion to the total and returns it
          :params
             - portion, total
         """
         try:
             percentage = (portion/total) * 100
-            return round(percentage, 1)
+            return percentage
         except ZeroDivisionError:
             return 0
 

--- a/tests/test_events/test_event_checkin.py
+++ b/tests/test_events/test_event_checkin.py
@@ -8,6 +8,9 @@ from fixtures.events.event_checkin_fixtures import (
     cancel_event_mutation,
     cancel_event_respone
 )
+from fixtures.events.events_ratios_fixtures import (
+    event_ratio_percentage_cancellation_query,
+    event_ratio_percentage_cancellation_response)
 
 sys.path.append(os.getcwd())
 
@@ -72,4 +75,10 @@ class TestEventCheckin(BaseTestCase):
             self,
             cancel_event_mutation,
             "You cannot perform this action"
+        )
+        # Test for successful try in percentage_formater function
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            event_ratio_percentage_cancellation_query,
+            event_ratio_percentage_cancellation_response
         )


### PR DESCRIPTION
#### What does this PR do?
The PR increases the number of decimal places of the cancellation percentage.
It also adjusts the function used to return the percentage to make it a member of the class in which it had been placed.
In regards to the assertion added in the associated tests file, the line that returns the percentage is not covered and the assertion resolves this.

#### Description of Task to be completed?
Enable a more accurate figure to be returned when running analytics rations, more especially cancellationsPercentage.

#### How should this be manually tested?
Pull the branch and create an odd number of events with a valid calender_id corresponding to a room_id in the local database.
Run the mutation below with corresponding dates for the events created.

``` 
query {
  analyticsRatios (startDate: "Jul 05 2018", endDate: "Jul 16 2018") {
    cancellationsPercentage
    cancellations
    appBookings
    appBookingsPercentage
  }
}
```

The response should be similar to that shown in the screenshots.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#163653690](https://www.pivotaltracker.com/story/show/163653690)

#### Screenshots (if appropriate)
Before
<img width="849" alt="screen shot 2019-02-01 at 2 42 46 pm" src="https://user-images.githubusercontent.com/40039818/52337001-7958fc00-2a17-11e9-8842-84e49724b60e.png">

After making changes
<img width="1189" alt="screenshot 2019-02-07 at 20 40 42" src="https://user-images.githubusercontent.com/40039818/52431150-b6f17e00-2b18-11e9-8f51-97b0f2cbe260.png">


