### PR TITLE
#163646779 Refactor most booked and least booked endpoints from Rest to GraphQL

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -96,6 +96,18 @@ class Query(graphene.ObjectType):
         end_date=graphene.String(),
     )
 
+    analytics_for_most_booked_rooms = graphene.Field(
+        Analytics,
+        start_date=graphene.String(required=True),
+        end_date=graphene.String(),
+    )
+
+    analytics_for_least_booked_rooms = graphene.Field(
+        Analytics,
+        start_date=graphene.String(required=True),
+        end_date=graphene.String(),
+    )
+
     analytics_for_meetings_per_room = graphene.Field(
         Analytics,
         start_date=graphene.String(required=True),
@@ -213,21 +225,24 @@ class Query(graphene.ObjectType):
         return Analytics(MeetingsDurationaAnalytics=results)
 
     @Auth.user_roles('Admin', 'Default User')
-    def resolve_analytics_ratios(self, info, start_date, end_date=None):  # noqa: E501
+    def resolve_analytics_ratios(
+            self, info, start_date, end_date=None):
         query = Room.get_query(info)
         ratio = RoomAnalyticsRatios.get_analytics_ratios(
             self, query, start_date, end_date)
         return ratio
 
     @Auth.user_roles('Admin', 'Default User')
-    def resolve_analytics_ratios_per_room(self, info, start_date, end_date=None):  # noqa: E501
+    def resolve_analytics_ratios_per_room(
+            self, info, start_date, end_date=None):
         query = Room.get_query(info)
         ratio = RoomAnalyticsRatios.get_analytics_ratios_per_room(
             self, query, start_date, end_date)
         return RatiosPerRoom(ratio)
 
     @Auth.user_roles('Admin', 'Default User')
-    def resolve_bookings_analytics_count(self, info, start_date, end_date):  # noqa: E501
+    def resolve_bookings_analytics_count(
+            self, info, start_date, end_date):
         query = Room.get_query(info)
         analytics = RoomAnalyticsRatios.get_bookings_analytics_count(
             self, query, start_date, end_date)
@@ -264,3 +279,29 @@ class Query(graphene.ObjectType):
             )
 
         return all_days_events
+
+    @Auth.user_roles('Admin', 'Default User')
+    def resolve_analytics_for_most_booked_rooms(
+            self, info, start_date, end_date=None):
+        query = Room.get_query(info)
+        active_rooms = query.filter(RoomModel.state == "active")
+        most_booked = RoomAnalytics.get_booked_rooms(
+            self, active_rooms, start_date, end_date
+        )[:10]
+        room_most_booked_per_week = Analytics(
+            analytics=most_booked
+        )
+        return room_most_booked_per_week
+
+    @Auth.user_roles('Admin', 'Default User')
+    def resolve_analytics_for_least_booked_rooms(
+            self, info, start_date, end_date=None):
+        query = Room.get_query(info)
+        active_rooms = query.filter(RoomModel.state == "active")
+        least_booked = RoomAnalytics.get_booked_rooms(
+            self, active_rooms, start_date, end_date
+        )[-10:]
+        room_least_booked_per_week = Analytics(
+            analytics=least_booked
+        )
+        return room_least_booked_per_week

--- a/fixtures/room/most_booked_room_least_booked_rooms_fixtures.py
+++ b/fixtures/room/most_booked_room_least_booked_rooms_fixtures.py
@@ -1,0 +1,69 @@
+get_top_ten_rooms = '''
+    {
+        analyticsForMostBookedRooms(
+            startDate:"Jan 1 2019", endDate:"Jan 31 2019")
+        {
+            analytics {
+                roomName
+                meetings
+                percentage
+            }
+        }
+    }
+'''
+
+get_bottom_ten_rooms = '''
+    {
+        analyticsForLeastBookedRooms(
+            startDate:"Jan 1 2019", endDate:"Jan 31 2019")
+        {
+            analytics {
+                roomName
+                meetings
+                percentage
+            }
+        }
+    }
+'''
+
+bottom_ten_response = {
+  "data": {
+    "analyticsForLeastBookedRooms": {
+      "analytics": [
+        {
+          "meetings": 29,
+          "percentage": 100,
+          "roomName": "Entebbe",
+        }
+      ]
+    }
+  }
+}
+
+top_ten_response = {
+  "data": {
+    "analyticsForMostBookedRooms": {
+      "analytics": [
+        {
+          "meetings": 29,
+          "percentage": 100,
+          "roomName": "Entebbe",
+        }
+      ]
+    }
+  }
+}
+
+test_for_division_error = '''
+    {
+        analyticsForLeastBookedRooms(
+            startDate:"Aug 8 2018", endDate: "Aug 12 2018")
+        {
+            analytics {
+                roomName
+                meetings
+                percentage
+            }
+        }
+    }
+'''

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -20,9 +20,11 @@ class EventsDuration(graphene.ObjectType):
 class RoomStatistics(graphene.ObjectType):
     room_name = graphene.String()
     count = graphene.Int()
+    meetings = graphene.Int()
     events = graphene.List(EventsDuration)
     has_events = graphene.Boolean()
     total_duration = graphene.Int()
+    percentage = graphene.Int()
 
 
 class CommonAnalytics(Credentials):

--- a/tests/test_rooms/test_most_booked_least_booked.py
+++ b/tests/test_rooms/test_most_booked_least_booked.py
@@ -1,0 +1,32 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.room.most_booked_room_least_booked_rooms_fixtures import (
+    get_bottom_ten_rooms,
+    get_top_ten_rooms,
+    top_ten_response,
+    bottom_ten_response,
+    test_for_division_error
+    )
+
+
+class QueryRoomsAnalytics(BaseTestCase):
+
+    def test_bottom_ten_most_used_rooms(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_bottom_ten_rooms,
+            bottom_ten_response
+        )
+
+    def test_top_ten_most_used_rooms(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_top_ten_rooms,
+            top_ten_response
+        )
+
+    def test_for_percentage_division_error(self):
+        CommonTestCases.admin_token_assert_in(
+            self,
+            test_for_division_error,
+            "There are no meetings"
+        )


### PR DESCRIPTION
 #### What does this PR do?
* Refactor analytics code that using REST to start using GraphQL so that we can have a one API, which is GraphQL served. 
#### Description of Task to be completed?
*  Added a function to `helpers/calendar/analytics.py` to calculate percentage and room meetings per room.
* Added resolvers to `api/room/schema_query.py` to get mutations for top ten and bottom ten most booked rooms per a varied period.
#### How should this be manually tested?
* Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
* git checkout to `ft-graphql-endpoints-for-most-booked-least-booked-rooms-16364677` and run the following query:
## query for top ten most used room
```
 {
        analyticsForMostBookedRooms(startDate:"Jul 1 2018", endDate:"Jul 10 2018")
        {
            analytics {
                roomName
                meetings
              	percentage
            }
        }
    }

```
## query for bottom ten most used room
```
{
        analyticsForLeastBookedRooms(startDate:"Jul 1 2018", endDate:"Jul 10 2018")
        {
            analytics {
                roomName
                meetings
              	percentage
            }
        }
    }
```
#### Any background context you want to provide?
* Not applicable
#### screenshots:
* Most booked rooms
<img width="1190" alt="screenshot 2019-02-07 at 11 32 39" src="https://user-images.githubusercontent.com/23398223/52399058-1c6b4d80-2acc-11e9-9d57-c4e93aa89e0d.png">


* Least booked rooms
<img width="1139" alt="screenshot 2019-02-06 at 17 19 48" src="https://user-images.githubusercontent.com/23398223/52399112-40c72a00-2acc-11e9-9631-8a8ff3738ce0.png">

#### What are the relevant pivotal tracker stories?
[#163646779](https://www.pivotaltracker.com/n/projects/2154921/stories/163646779)