### PR TITLE
#163733826 Limit the date range on analytics data

### DIFF
--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -89,12 +89,15 @@ class RoomAnalytics(Credentials):
             - query
             - start_date, end_date(Time range)
         """
-        start_date, end_date = CommonAnalytics.convert_dates(self, start_date, end_date)  # noqa: E501
+        start_date, end_date = CommonAnalytics.validate_current_date(
+            self, start_date, end_date)
+
         rooms = CommonAnalytics.get_calendar_id_name(
             self, query)
         result = []
         for room in rooms:
-            events = CommonAnalytics.get_all_events_in_a_room(self, room['calendar_id'], start_date, end_date)  # noqa: E501
+            events = CommonAnalytics.get_all_events_in_a_room(
+                self, room['calendar_id'], start_date, end_date)
             events_duration = []
             for event in events:
                 start = event['start'].get('dateTime', event['start'].get('date'))  # noqa: E501

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -38,6 +38,20 @@ class CommonAnalytics(Credentials):
         end_date = (datetime.strptime(end_date, "%b %d %Y") + relativedelta(days=1)).isoformat() + 'Z'  # noqa: E501
         return(start_date, end_date)
 
+    def validate_current_date(self, start_date, end_date):
+        start_date, end_date = CommonAnalytics.convert_dates(
+            self, start_date, end_date)
+
+        now = datetime.now().strftime('%b %d %Y')
+        date_now = (datetime.strptime(now, "%b %d %Y") + relativedelta(days=1)).isoformat() + 'Z'  # noqa: E501
+        start_dt = dateutil.parser.parse(start_date)
+        end_dt = dateutil.parser.parse(end_date)
+        today = dateutil.parser.parse(date_now)
+        if start_dt > today or end_dt > today:
+            raise GraphQLError(
+                "Invalid date. You can not retrieve data beyond today")
+        return(start_date, end_date)
+
     def format_date(date):
         '''
         Convert ISO 8601 date to simple DD/MM/YYYY

--- a/helpers/calendar/ratios_and_utilization.py
+++ b/helpers/calendar/ratios_and_utilization.py
@@ -20,7 +20,7 @@ class RoomAnalyticsRatios(Credentials):
          :params
             - start_date, end_date
         """
-        start_date, day_after_end_date = CommonAnalytics.convert_dates(
+        start_date, day_after_end_date = CommonAnalytics.validate_current_date(
                 self, start, end)
         rooms = CommonAnalytics.get_calendar_id_name(
             self, query)
@@ -52,7 +52,7 @@ class RoomAnalyticsRatios(Credentials):
          :params
             - start_date, end_date
         """
-        start_date, day_after_end_date = CommonAnalytics.convert_dates(
+        start_date, day_after_end_date = CommonAnalytics.validate_current_date(
                 self, start, end)
         rooms = CommonAnalytics.get_calendar_id_name(
             self, query)


### PR DESCRIPTION
#### What does this PR do?
- This is to prevent the user from selecting a future date range when querying analytics data that is not applicable to a future date.
#### Description of Task to be completed?
- Given am a user
- When I input a future date range on "% of check-in, % of app bookings, % of auto cancellations and average meeting duration" analytics  
- Then I should get a warning message preventing me from inputting a future date when querying this analytics data.
#### How should this be manually tested?
- pull and checkout branch `ft-limit-date-range-on-analytics-data-163733826`
- run the app using `make run-app`
- Try querying analytics data of meeting durations or any other analytics data in the description
#### What are the relevant pivotal tracker stories?
[#163733826](https://www.pivotaltracker.com/story/show/163733826)
#### Screenshots
##### Invalid date response
<img width="1091" alt="screen shot 2019-02-07 at 12 48 03" src="https://user-images.githubusercontent.com/39129473/52403670-4d517f80-2ad8-11e9-91b4-3639a45ff7dc.png">

##### Valid date reponse
<img width="1069" alt="screen shot 2019-02-07 at 12 48 24" src="https://user-images.githubusercontent.com/39129473/52403734-78d46a00-2ad8-11e9-8e9c-b02f3c122594.png">