### PR TITLE
#163756241 Add room Id field to allRoomResponses query

### DIFF
--- a/api/response/schema_query.py
+++ b/api/response/schema_query.py
@@ -16,6 +16,7 @@ class ResponseDetails(graphene.ObjectType):
 
 
 class RoomResponse(graphene.ObjectType):
+    room_id = graphene.Int()
     room_name = graphene.String()
     total_responses = graphene.Int()
     total_room_resources = graphene.Int()
@@ -81,10 +82,10 @@ class Query(graphene.ObjectType):
         total_response = room_response.count()
         room_name = room.name
         return RoomResponse(
-                room_name=room_name,
-                total_responses=total_response,
-                total_room_resources=total_room_resources,
-                response=responses)
+            room_name=room_name,
+            total_responses=total_response,
+            total_room_resources=total_room_resources,
+            response=responses)
 
     def get_all_reponses(self, info):
         response = []
@@ -96,6 +97,7 @@ class Query(graphene.ObjectType):
             all_responses, total_room_resources = Query.get_room_response(
                 self, room_response, room.id)
             responses = RoomResponse(
+                room_id=room.id,
                 room_name=room_name,
                 total_responses=total_response,
                 total_room_resources=total_room_resources,

--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -94,6 +94,7 @@ query{
     allRoomResponses(filterBy:"Responses",upperLimit: 2, lowerLimit: 0 ){
         responses{
             totalResponses
+            roomId
             roomName
             response{
                 responseId
@@ -110,6 +111,7 @@ filter_by_response_data = {
             'responses': [
                 {
                     'totalResponses': 2,
+                    'roomId': 1,
                     'roomName': 'Entebbe',
                     'response': [
                         {


### PR DESCRIPTION
#### What does this PR do?
Adds room Id field to query all room responses.

#### Description of Task to be completed?
`allRoomResponses` should be returned with the `roomId`, `roomName`, `response`, and `totalResponses` for each particular room

#### Any background context you want to provide?
N/A
#### How should this be manually tested?
* pull and checkout branch `bg-add-room-id-to-room-responses-163756241`
* run the app using `make run-app`
* run the query below
```
query{
    allRoomResponses(filterBy:"Responses",upperLimit: 2, lowerLimit: 0 ){
        responses{          
            totalResponses
            roomId
            roomName          	
            response{
                responseId
                missingItems
            }
        }
    }
}
```
expected response
```
{
  "data": {
    "allRoomResponses": {
      "responses": [
        {
          "totalResponses": 0,
          "roomId": 1076,
          "roomName": "TestRoom",
          "response": []
        },
        {
          "totalResponses": 0,
          "roomId": 168,
          "roomName": "Conakry",
          "response": []
        }
]}
}
}
```

#### What are the relevant pivotal tracker stories?
[#163756241](https://www.pivotaltracker.com/story/show/163756241)

#### Screenshots
![image](https://user-images.githubusercontent.com/39625835/52417508-1cd00c80-2afd-11e9-8f09-bd9347303fa6.png)
