### PR TITLE
#163729499 Fix analytics date range for bookingsAnalyticsCount query

### DIFF
--- a/fixtures/room/room_analytics_bookings_count_fixtures.py
+++ b/fixtures/room/room_analytics_bookings_count_fixtures.py
@@ -57,30 +57,6 @@ get_bookings_count_monthly_response = {
     }
 }
 
-get_bookings_count_invalid_date_range = '''
-query {
-  bookingsAnalyticsCount(startDate:"Aug 1 2018", endDate:"Aug 30 2018"){
-   period
-   bookings
-  }
-}
-'''
-
-get_bookings_count_invalid_date_range_response = {
-    "errors": [{
-        "message":
-        "Kindly enter a valid date range(less than 15 days or greater than 90 days",  # noqa E501
-        "locations": [{
-            "line": 3,
-            "column": 3
-        }],
-        "path": ["bookingsAnalyticsCount"]
-    }],
-    "data": {
-        "bookingsAnalyticsCount": null
-    }
-}
-
 get_bookings_count_monthly_diff_years = '''
 query {
   bookingsAnalyticsCount(startDate:"Nov 1 2017", endDate:"May 1 2018"){

--- a/helpers/calendar/ratios_and_utilization.py
+++ b/helpers/calendar/ratios_and_utilization.py
@@ -1,5 +1,4 @@
 import dateutil.parser
-from graphql.error import GraphQLError
 
 from .credentials import Credentials
 from helpers.calendar.analytics_helper import (CommonAnalytics)
@@ -167,7 +166,7 @@ class RoomAnalyticsRatios(Credentials):
         end_dt = dateutil.parser.parse(day_after_end_date)
         number_of_days = (end_dt - start_dt).days
 
-        if number_of_days <= 15:
+        if number_of_days <= 30:
             dates = CommonAnalytics.get_list_of_dates(start, number_of_days)  # noqa E501
             for date in dates:
                 bookings = CommonAnalytics.get_total_bookings(self, query, date[0], date[1])  # noqa E501
@@ -175,15 +174,12 @@ class RoomAnalyticsRatios(Credentials):
                 output = BookingsAnalyticsCount(period=string_date, bookings=bookings) # noqa E501
                 results.append(output)
 
-        elif number_of_days >= 90:
+        else:
             dates = CommonAnalytics.get_list_of_month_dates(start_date, start_dt, day_after_end_date, end_dt)  # noqa E501
             for date in dates:
                 bookings = CommonAnalytics.get_total_bookings(self, query, date[0], date[1])  # noqa E501
                 string_month = dateutil.parser.parse(date[0]).strftime("%B")
                 output = BookingsAnalyticsCount(period=string_month, bookings=bookings) # noqa E501
                 results.append(output)
-
-        else:
-            raise GraphQLError("Kindly enter a valid date range(less than 15 days or greater than 90 days")  # noqa E501
 
         return results

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -31,8 +31,6 @@ from fixtures.room.room_analytics_bookings_count_fixtures import (
     get_bookings_count_daily_response,
     get_bookings_count_monthly,
     get_bookings_count_monthly_response,
-    get_bookings_count_invalid_date_range,
-    get_bookings_count_invalid_date_range_response,
     get_bookings_count_monthly_diff_years,
     get_bookings_count_monthly_diff_years_response,
 )
@@ -113,12 +111,6 @@ class QueryRoomsAnalytics(BaseTestCase):
         CommonTestCases.admin_token_assert_equal(
             self, get_bookings_count_monthly,
             get_bookings_count_monthly_response
-        )
-
-    def test_analytics_for_bookings_invalid_date_range(self):
-        CommonTestCases.admin_token_assert_equal(
-            self, get_bookings_count_invalid_date_range,
-            get_bookings_count_invalid_date_range_response
         )
 
     def test_analytics_for_monthly_bookings_diff_years(self):


### PR DESCRIPTION
#### What does this PR do?
- It enables the user to enter a date range of their choice 

#### Description of Task to be completed?
- Remove the restriction to sending a date range that is bellow 15 days and greater than
90 days. This will enable the user to choose the range freely.

#### How should this be manually tested?
- Pull this branch.
- Run the app using `make run-app`
- run the query below.
```
query{
  bookingsAnalyticsCount(startDate:"jan 2 2019" endDate: "jan 25 2019"){
    bookings
    period
}
}
```

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#163729499](https://www.pivotaltracker.com/n/projects/2154921/stories/163729499)

#### Screenshots (if appropriate)
The query response before the fix
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/30701246/52428760-b4d8f080-2b13-11e9-88ba-26c26dfc19f5.png">

The query response after the fix
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/30701246/52428795-c4583980-2b13-11e9-8a65-fd4f9420bc9c.png">

The query response if the period is greater than 31 days
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/30701246/52464838-6cf6af80-2b8d-11e9-9911-ca43107f2542.png">


#### Questions: