### PR TITLE
#163733826 Limit the date range on analytics data

### DIFF
--- a/fixtures/room/room_analytics_duration_fixtures.py
+++ b/fixtures/room/room_analytics_duration_fixtures.py
@@ -33,6 +33,22 @@ get_daily_meetings_total_duration_response = {
     }
 }
 
+meetings_total_duration_query_for_a_future_date = '''
+query {
+    analyticsForMeetingsDurations(startDate:"sep 10 6080"){
+        MeetingsDurationaAnalytics{
+            roomName
+            count
+            totalDuration
+            events{
+                durationInMinutes
+                numberOfMeetings
+            }
+        }
+    }
+}
+'''
+
 get_weekly_meetings_total_duration_query = '''
 query {
     analyticsForMeetingsDurations(startDate:"Jan 3 2018", endDate:"Jan 9 2018"){  # noqa: E501

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -90,7 +90,8 @@ class RoomAnalytics(Credentials):
             - query
             - start_date, end_date(Time range)
         """
-        start_date, end_date = CommonAnalytics.convert_dates(self, start_date, end_date)  # noqa: E501
+        start_date, end_date = CommonAnalytics.validate_current_date(
+            self, start_date, end_date)
         rooms = CommonAnalytics.get_calendar_id_name(
             self, query)
         result = []

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -40,6 +40,24 @@ class CommonAnalytics(Credentials):
         end_date = (datetime.strptime(end_date, "%b %d %Y") + relativedelta(days=1)).isoformat() + 'Z'  # noqa: E501
         return(start_date, end_date)
 
+    def validate_current_date(self, start_date, end_date):
+        """
+        Checks for today's date
+        """
+        start_date, end_date = CommonAnalytics.convert_dates(
+            self, start_date, end_date)
+
+        now = datetime.utcnow().strftime('%b %d %Y')
+        date_now = (datetime.strptime(now, "%b %d %Y") + relativedelta(
+            days=1)).isoformat() + 'Z'
+        user_start_date = dateutil.parser.parse(start_date)
+        user_end_date = dateutil.parser.parse(end_date)
+        today = dateutil.parser.parse(date_now)
+        if user_start_date > today or user_end_date > today:
+            raise GraphQLError(
+                "Invalid date. You can not retrieve data beyond today")
+        return(start_date, end_date)
+
     def format_date(date):
         '''
         Convert ISO 8601 date to simple DD/MM/YYYY

--- a/helpers/calendar/ratios_and_utilization.py
+++ b/helpers/calendar/ratios_and_utilization.py
@@ -19,7 +19,7 @@ class RoomAnalyticsRatios(Credentials):
          :params
             - start_date, end_date
         """
-        start_date, day_after_end_date = CommonAnalytics.convert_dates(
+        start_date, day_after_end_date = CommonAnalytics.validate_current_date(
                 self, start, end)
         rooms = CommonAnalytics.get_calendar_id_name(
             self, query)
@@ -51,7 +51,7 @@ class RoomAnalyticsRatios(Credentials):
          :params
             - start_date, end_date
         """
-        start_date, day_after_end_date = CommonAnalytics.convert_dates(
+        start_date, day_after_end_date = CommonAnalytics.validate_current_date(
                 self, start, end)
         rooms = CommonAnalytics.get_calendar_id_name(
             self, query)

--- a/tests/test_rooms/test_analytics_total_durations.py
+++ b/tests/test_rooms/test_analytics_total_durations.py
@@ -8,6 +8,7 @@ from fixtures.room.room_analytics_duration_fixtures import (
     get_paginated_meetings_total_duration_response,
     get_paginated_meetings_total_duration_query_invalid_page,
     get_paginated_meetings_total_duration_invalid_page_result,
+    meetings_total_duration_query_for_a_future_date
     )
 
 
@@ -48,3 +49,12 @@ class TotalDailyDurations(BaseTestCase):
         CommonTestCases.admin_token_assert_equal(
             self, get_paginated_meetings_total_duration_query_invalid_page,
             get_paginated_meetings_total_duration_invalid_page_result)
+
+    def test_analytics_meeting_durations_future_date(self):
+        """
+        Test for querying data that does not apply in the future
+        """
+        CommonTestCases.admin_token_assert_in(
+            self, meetings_total_duration_query_for_a_future_date,
+            "Invalid date. You can not retrieve data beyond today"
+            )


### PR DESCRIPTION
#### What does this PR do?
- This PR is to prevent the admin from selecting a future date range when querying analytics data that is not applicable to a future date.
#### Description of Task to be completed?
- Given I am an admin
- When I input a future date range on "% of check-in, % of app bookings, % of auto cancellations and average meeting duration" analytics  
- Then I should get a warning message preventing me from inputting a future date when querying this analytics data
#### How should this be manually tested?
- git pull and checkout branch `ft-limit-date-range-on-analytics-data-163733826`
- run the app using `make run-app`
- query meeting durations analytics data or any other data stated in the description
- here is the sample query
```
query {
    analyticsForMeetingsDurations(startDate:"sep 10 6080"){
        MeetingsDurationaAnalytics{
            roomName
            count
            totalDuration
            events{
                durationInMinutes
                numberOfMeetings
            }
        }
    }
}
```
#### What are the relevant pivotal tracker stories?
[#163733826](https://www.pivotaltracker.com/story/show/163733826)
#### Screenshots
- Response for a valid date 
<img width="1093" alt="screen shot 2019-02-07 at 23 08 03" src="https://user-images.githubusercontent.com/39129473/52439846-9c75cf80-2b2d-11e9-8493-038b3efb3f4d.png">

- Response for a future date
<img width="1099" alt="screen shot 2019-02-07 at 23 07 43" src="https://user-images.githubusercontent.com/39129473/52439707-46a12780-2b2d-11e9-979a-24b523c9cd96.png">


