### PR TITLE
#163783849 Add missing responses count for a particular question and room.

### DIFF
--- a/api/response/models.py
+++ b/api/response/models.py
@@ -34,3 +34,9 @@ class Response(Base, Utility):
         secondary="missing_items",
         backref=('resources'),
         lazy="joined")
+
+    @property
+    def question_response_count_in_room(self):
+        return Response.query.filter_by(
+            question_id=self.id, room_id=self.room_id
+        ).count()

--- a/api/response/schema.py
+++ b/api/response/schema.py
@@ -13,6 +13,8 @@ class Response(SQLAlchemyObjectType):
     class Meta:
         model = ResponseModel
 
+    question_response_count_in_room = graphene.Int()
+
 
 class CreateResponse(graphene.Mutation):
     class Arguments:

--- a/fixtures/questions/get_question_fixtures.py
+++ b/fixtures/questions/get_question_fixtures.py
@@ -142,6 +142,7 @@ query {
     endDate
     questionResponseCount
     response {
+      questionResponseCountInRoom
       id
       questionId
       roomId
@@ -160,6 +161,7 @@ get_question_by_id_query_response = {
             'endDate': '28 Nov 2018',
             'questionResponseCount': 1,
             'response': [{
+                'questionResponseCountInRoom': 1,
                 'id': '1',
                 'questionId': 1,
                 'roomId': 1


### PR DESCRIPTION
#### What does this PR do?
The PR enables the retrieval of the total responses for a question in a particular room.

#### Description of Task to be completed?
Enable the query that uses question_id to retrieve the number of responses per room.

#### How should this be manually tested?
Pull the branch and run the following query.

``` 
query {
    question(id: 1){
        question
        id
        response {
          room {
            id
            name
          }
    	  questionResponseCountInRoom
          rate
          check
        }
    }
}
```

The response should be similar to that shown in the screenshots.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#163783849](https://www.pivotaltracker.com/story/show/163783849)

#### Screenshots (if appropriate)
<img width="1189" alt="screenshot 2019-02-12 at 08 32 20" src="https://user-images.githubusercontent.com/40039818/52613884-c4a05e00-2ea0-11e9-9fc5-8941a408d552.png">



