### PR TITLE
#163782051 get remote rooms from google calendar api

### DIFF
--- a/fixtures/room/query_room_fixtures.py
+++ b/fixtures/room/query_room_fixtures.py
@@ -1,5 +1,16 @@
 null = None
 
+all_remote_rooms_query = '''
+ query {
+  allRemoteRooms {
+    rooms {
+      calendarId
+      name
+    }
+  }
+}
+'''
+
 paginated_rooms_query = '''
  query {
   allRooms(page:1, perPage:1){

--- a/tests/test_rooms/test_query_rooms.py
+++ b/tests/test_rooms/test_query_rooms.py
@@ -1,6 +1,6 @@
 import json
 
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room.create_room_fixtures import (
     rooms_query,
     query_rooms_response)
@@ -10,8 +10,8 @@ from fixtures.room.query_room_fixtures import (
     room_query_by_id,
     room_query_by_id_response,
     room_with_non_existant_id,
-    room_query_with_non_existant_id_response
-
+    room_query_with_non_existant_id_response,
+    all_remote_rooms_query
 )
 
 
@@ -27,6 +27,13 @@ class QueryRooms(BaseTestCase):
         paginate_query = json.loads(response.data)
         expected_response = paginated_rooms_response
         self.assertEqual(paginate_query, expected_response)
+
+    def test_query_remote_rooms(self):
+        CommonTestCases.admin_token_assert_in(
+            self,
+            all_remote_rooms_query,
+            "calendar.google.com"
+        )
 
     def test_query_room_with_id(self):
         query = self.client.execute(room_query_by_id)


### PR DESCRIPTION
#### What does this PR do?
- Gets the list of rooms from google calendar api

#### Description of Task to be completed?
Return all rooms from the google calendar api

#### How should this be manually tested?
- Clone the repo.
- Run `make build`
- `make run-app`

#### Run the following query:
```
query {
   allRemoteRooms {
    rooms {
      calendarId
      name
    }
  }
}
```

**Any background context you want to provide?**
None

**What are the relevant pivotal tracker stories?**
[#163782051](https://www.pivotaltracker.com/story/show/163782051)

#### Screenshots
<img width="995" alt="screen shot 2019-02-11 at 4 31 09 pm" src="https://user-images.githubusercontent.com/23643904/52573453-78123f80-2e1a-11e9-8d93-ca04db5fae7f.png">



**Questions:**
None
