### PR TITLE
#163817764 Prevent creating a Room with duplicate calendar Id

### DIFF
--- a/fixtures/room/create_room_fixtures.py
+++ b/fixtures/room/create_room_fixtures.py
@@ -280,3 +280,40 @@ room_mutation_query_duplicate_name_response = {
             "createRoom": null
         }
     }
+
+room_duplicate_calender_id_mutation_query = '''
+    mutation {
+        createRoom(
+            name: "Mbarara", roomType: "Meeting", capacity: 4, floorId: 4, officeId: 1,
+            calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            room {
+                name
+                roomType
+                capacity
+                floorId
+                imageUrl
+            }
+        }
+    }
+'''
+
+room_duplicate_calendar_id_mutation_response = {
+  "errors": [
+    {
+      "message": "andela.com_3630363835303531343031@resource.calendar.google.com CalenderId already exists",  # noqa: E501
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ],
+      "path": [
+        "createRoom"
+      ]
+    }
+  ],
+  "data": {
+    "createRoom": null
+  }
+}

--- a/fixtures/room/room_analytics_bookings_count_fixtures.py
+++ b/fixtures/room/room_analytics_bookings_count_fixtures.py
@@ -49,7 +49,7 @@ get_bookings_count_monthly_response = {
             'bookings': 38
         }, {
             'period': 'October',
-            'bookings': 65
+            'bookings': 64
         }, {
             'period': 'November',
             'bookings': 3

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -10,10 +10,12 @@ from fixtures.room.create_room_fixtures import (
     room_mutation_query_duplicate_name,
     room_mutation_query_duplicate_name_response,
     room_invalid_calendar_id_mutation_query,
-    room_invalid_calendar_id_mutation_response)
+    room_invalid_calendar_id_mutation_response,
+    room_duplicate_calender_id_mutation_query,
+    room_duplicate_calendar_id_mutation_response)
 from fixtures.room.create_room_in_block_fixtures import (
     room_blockId_not_required_mutation
-    )
+)
 from fixtures.token.token_fixture import ADMIN_TOKEN
 
 sys.path.append(os.getcwd())
@@ -100,4 +102,14 @@ class TestCreateRoom(BaseTestCase):
             self,
             room_invalid_calendar_id_mutation_query,
             room_invalid_calendar_id_mutation_response
+        )
+
+    def test_room_creation_with_invalid_duplicate_calendar_id(self):
+        """
+        Test room creation with a duplicate callender Id
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            room_duplicate_calender_id_mutation_query,
+            room_duplicate_calendar_id_mutation_response
         )


### PR DESCRIPTION
#### What does this PR do?
* This PR is to prevent having multiple Rooms with the same `calendar_id` in the database
#### Description of Task to be completed?
* Validate the calendar_id provided by the user to ensure that it's unique and applies to exactly one room in the database.
#### How should this be manually tested?
* git pull and checkout branch `bg-creating-multiple-rooms-with-similar-calendar-Id-163817764`
* run the app using `make run-app`
* run a query to create a room
* change the room name and run the same query again.
Example query
````
mutation {
        createRoom(
            name: "Accra", roomType: "Meeting", capacity: 4, floorId: 5, officeId: 4,
            calendarId:"andela.com_3836303335343335373932@resource.calendar.google.com",
            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
            room {
                name
                roomType
                capacity
                floorId
                imageUrl
            }
        }
    }
````
Expected Response.
````
{
  "errors": [
    {
      "message": "andela.com_3836303335343335373932@resource.calendar.google.com CalenderId already exists",
      "locations": [
        {
          "line": 2,
          "column": 9
        }
      ],
      "path": [
        "createRoom"
      ]
    }
  ],
  "data": {
    "createRoom": null
  }
}
````
#### What are the relevant pivotal tracker stories?
[#163817764](https://www.pivotaltracker.com/story/show/163817764)
#### Screenshots
![image](https://user-images.githubusercontent.com/39625835/52586827-8cb9fc00-2e49-11e9-8620-d455dbeddd71.png)
