### PR TITLE
#163849417 Refactor event check-in endpoint

### DIFF
--- a/fixtures/events/event_checkin_fixtures.py
+++ b/fixtures/events/event_checkin_fixtures.py
@@ -98,3 +98,42 @@ cancel_event_respone = {
         }
     }
 }
+
+checkin_mutation_for_event_existing_in_db = '''mutation {
+    eventCheckin(
+        calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
+        eventId:"test_id5", eventTitle:"Onboarding",
+        startTime:"2018-07-11T09:00:00Z",
+        endTime:"2018-07-11T09:45:00Z"){
+            event{
+                eventId
+                roomId
+                checkedIn
+                cancelled
+                room{
+                    id
+                    name
+                    calendarId
+                }
+            }
+        }
+    }
+'''
+
+response_for_event_existing_in_db_checkin = {
+    "data": {
+        "eventCheckin": {
+            "event": {
+                "eventId": "test_id5",
+                "roomId": 1,
+                "checkedIn": True,
+                "cancelled": False,
+                "room": {
+                    "id": "1",
+                    "name": "Entebbe",
+                    "calendarId": "andela.com_3630363835303531343031@resource.calendar.google.com"  # noqa
+                }
+            }
+        }
+    }
+}

--- a/tests/base.py
+++ b/tests/base.py
@@ -17,6 +17,7 @@ from api.room.models import Room
 from api.room_resource.models import Resource
 from api.user.models import User
 from api.role.models import Role
+from api.events.models import Events
 from api.devices.models import Devices
 from api.office.models import Office
 from api.question.models import Question
@@ -123,6 +124,15 @@ class BaseTestCase(TestCase):
                 start_date="20 Nov 2018",
                 end_date="28 Nov 2018"
             )
+            event = Events(
+                event_id="test_id5",
+                room_id=1,
+                event_title="Onboarding",
+                start_time="2018-07-11T09:00:00Z",
+                end_time="2018-07-11T09:45:00Z",
+                checked_in=False,
+                cancelled=False)
+            event.save()
             question_2.save()
             question_3 = Question(
                 question_type="input",

--- a/tests/test_events/test_event_checkin.py
+++ b/tests/test_events/test_event_checkin.py
@@ -6,7 +6,9 @@ from fixtures.events.event_checkin_fixtures import (
     event_checkin_response,
     wrong_calendar_id_checkin_mutation,
     cancel_event_mutation,
-    cancel_event_respone
+    cancel_event_respone,
+    checkin_mutation_for_event_existing_in_db,
+    response_for_event_existing_in_db_checkin
 )
 from fixtures.events.events_ratios_fixtures import (
     event_ratio_percentage_cancellation_query,
@@ -39,7 +41,7 @@ class TestEventCheckin(BaseTestCase):
         CommonTestCases.user_token_assert_in(
             self,
             event_checkin_mutation,
-            "You cannot perform this action"
+            "Event already checked in"
         )
 
     def test_checkin_with_invalid_calendar_id(self):
@@ -49,7 +51,7 @@ class TestEventCheckin(BaseTestCase):
         CommonTestCases.user_token_assert_in(
             self,
             wrong_calendar_id_checkin_mutation,
-            "This Calendar ID is not registered on Converge."
+            "This Calendar ID is invalid"
         )
 
     def test_cancel_event(self):
@@ -74,11 +76,51 @@ class TestEventCheckin(BaseTestCase):
         CommonTestCases.user_token_assert_in(
             self,
             cancel_event_mutation,
-            "You cannot perform this action"
+            "Event already cancelled"
         )
         # Test for successful try in percentage_formater function
         CommonTestCases.admin_token_assert_equal(
             self,
             event_ratio_percentage_cancellation_query,
             event_ratio_percentage_cancellation_response
+        )
+
+    def test_check_in_to_a_cancelled_event(self):
+        """
+        test that you cannot check-in to a cancelled event
+        """
+        CommonTestCases.user_token_assert_equal(
+            self,
+            cancel_event_mutation,
+            cancel_event_respone
+        )
+        CommonTestCases.user_token_assert_in(
+            self,
+            event_checkin_mutation,
+            "Event already cancelled"
+        )
+
+    def test_cancel_a_checked_in_event(self):
+        """
+        test that you cannot check-in to a cancelled event
+        """
+        CommonTestCases.user_token_assert_equal(
+            self,
+            event_checkin_mutation,
+            event_checkin_response
+        )
+        CommonTestCases.user_token_assert_in(
+            self,
+            cancel_event_mutation,
+            "Event already checked in"
+        )
+
+    def test_check_in_event_existing_in_db(self):
+        """
+        test that you can check into an event that is already in the database
+        """
+        CommonTestCases.user_token_assert_equal(
+            self,
+            checkin_mutation_for_event_existing_in_db,
+            response_for_event_existing_in_db_checkin
         )


### PR DESCRIPTION
#### What does this PR do?
- [x] add an helper function to check the status of events
- [x] refactor check-in endpoint


#### Description of Task to be completed?
Make the checkin feature more robust by:

 - Only updating `checkin field` to `True` if the event exists in the DB
 - Add the event to the DB if it does not exist with checkin set to `True`

#### How should this be manually tested?
- Pull this branch
- make the migrations as explained in the [README](https://github.com/andela/mrm_api/blob/develop/Readme.md)
- create an event and run the following query to check-in into that event

```
mutation {
  eventCheckin(calendarId: "your_calendar_id", eventId: "the_event_id", eventTitle: "event_title", startTime: "2019-02-15T01:00:00-08:00", endTime: "2019-02-15T01:30:00-08:00") {
    event {
      eventId
      roomId
      checkedIn
      cancelled
      room {
        id
        name
        calendarId
      }
    }
  }
}

```

### Below are the screenshots 
* successful check-in into an event
<img width="1194" alt="screenshot 2019-02-11 at 22 22 56" src="https://user-images.githubusercontent.com/38909130/52587935-52059300-2e4c-11e9-93a8-67a0ceffd3a9.png">


* trying to check-in into an already checked in event
<img width="1193" alt="screenshot 2019-02-11 at 22 24 15" src="https://user-images.githubusercontent.com/38909130/52587931-4e720c00-2e4c-11e9-90b2-7542a6b29aa9.png">


* checking in into a canceled event
<img width="1195" alt="screenshot 2019-02-11 at 22 25 27" src="https://user-images.githubusercontent.com/38909130/52587915-431ee080-2e4c-11e9-8e70-81f59f2957ef.png">


#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?

[#163849417](https://www.pivotaltracker.com/story/show/163849417)