### PR TITLE
#163725518:Allow admin to search feedback response by room name

### DIFF
--- a/api/response/schema_query.py
+++ b/api/response/schema_query.py
@@ -32,9 +32,9 @@ class Query(graphene.ObjectType):
         RoomResponse, room_id=graphene.Int())
     all_room_responses = graphene.Field(
         AllResponses,
-        filter_by=graphene.String(),
         upper_limit=graphene.Int(),
-        lower_limit=graphene.Int()
+        lower_limit=graphene.Int(),
+        room=graphene.String()
     )
 
     def get_room_response(self, room_response, room_id):
@@ -114,18 +114,69 @@ class Query(graphene.ObjectType):
                 filtered_responses.append(response)
         return filtered_responses
 
+    def search_response_by_room(
+        self, info, upper_limit, lower_limit, room
+    ):
+        search_result = []
+        filtered_search = []
+        if upper_limit and lower_limit:
+            filtered_response = Query.filter_rooms_by_responses(
+                self, info, upper_limit, lower_limit)
+            for response in filtered_response:
+                if response.room_name.lower() == room.lower():
+                    filtered_search.append(response)
+            if filtered_search:
+                return filtered_search
+            else:
+                raise GraphQLError(
+                    "No response for this room at this range")
+        exact_room = RoomModel.query.filter(
+            RoomModel.name.ilike('%' + room + '%')).first()
+        if not exact_room:
+            raise GraphQLError(
+                "No response for this room, enter a valid room name")
+        room_response_query = Response.get_query(info).filter_by(
+            room_id=exact_room.id)
+        room_response = room_response_query.all()
+        if not room_response:
+            raise GraphQLError("No response for this room at the moment")
+        total_response = room_response_query.count()
+        all_responses, total_room_resources = Query.get_room_response(
+            self, room_response, exact_room.id)
+        responses = RoomResponse(
+            room_name=exact_room.name,
+            total_responses=total_response,
+            total_room_resources=total_room_resources,
+            response=all_responses
+        )
+        search_result.append(responses)
+        return search_result
+
     @Auth.user_roles('Admin')
     def resolve_all_room_responses(
-            self, info, filter_by=None,
-            lower_limit=None, upper_limit=None):
+            self, info, lower_limit=None, upper_limit=None, room=None):
         responses = Query.get_all_reponses(self, info)
-        if filter_by == 'Responses':
-            if isinstance(lower_limit, int) and isinstance(upper_limit, int):
-                responses = Query.filter_rooms_by_responses(
-                    self, info, upper_limit, lower_limit
-                )
-            else:
-                raise GraphQLError("lower_limit and upper_limit are \
-                required to filter by responses")
+        if isinstance(lower_limit, int) and isinstance(upper_limit, int):
+            responses = Query.filter_rooms_by_responses(
+                self, info, upper_limit, lower_limit
+            )
+        if (
+            (isinstance(lower_limit, int)
+                and not isinstance(upper_limit, int))
+                or (isinstance(upper_limit, int)
+                    and not isinstance(lower_limit, int))):
+            raise GraphQLError(
+                "Provide upper and lower limits to filter by response number")
+        if (
+            isinstance(lower_limit, int)
+                and isinstance(upper_limit, int)
+                and room):
+            responses = Query.search_response_by_room(
+                self, info, upper_limit, lower_limit, room)
+        if not upper_limit and not lower_limit and room:
+            upper_limit = None
+            lower_limit = None
+            responses = Query.search_response_by_room(
+                self, info, upper_limit, lower_limit, room)
 
         return AllResponses(responses=responses)

--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -23,7 +23,7 @@ get_room_response_query = '''{
 }
 '''
 
-get_room_response_query_response = {
+get_room_response_query_data = {
     "data": {
         "roomResponse": {
             "roomName": "Entebbe",
@@ -91,7 +91,112 @@ summary_room_response_data = {
 
 filter_by_response_query = '''
 query{
-    allRoomResponses(filterBy:"Responses",upperLimit: 2, lowerLimit: 0 ){
+    allRoomResponses(upperLimit: 2, lowerLimit: 0 ){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+filter_by_response_invalid_query = '''
+query{
+    allRoomResponses(upperLimit: 2){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_query = '''
+query{
+    allRoomResponses(upperLimit: 2, lowerLimit: 0, room:"Entebbe"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_beyond_limits_query = '''
+query{
+    allRoomResponses(upperLimit: 7, lowerLimit: 5, room:"Entebbe"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_invalid_room_query = '''
+query{
+    allRoomResponses(upperLimit: 2, lowerLimit: 0, room:"Entebbes"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_only = '''
+query{
+    allRoomResponses(room:"Entebbe"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_invalid_room = '''
+query{
+    allRoomResponses(room:"Entebbes"){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+search_response_by_room_no_response = '''
+query{
+    allRoomResponses(room:"Kampala"){
         responses{
             totalResponses
             roomId
@@ -110,20 +215,19 @@ filter_by_response_data = {
         'allRoomResponses': {
             'responses': [
                 {
-                    'totalResponses': 2,
-                    'roomId': 1,
-                    'roomName': 'Entebbe',
                     'response': [
                         {
-                            'responseId': 2,
                             'missingItems': ['Markers'],
+                            'responseId': 2,
                         },
                         {
-                            'responseId': 1,
                             'missingItems': [],
+                            'responseId': 1,
                         }
 
-                    ]
+                    ],
+                    'roomName': 'Entebbe',
+                    'totalResponses': 2,
                 }
             ]
         }

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -3,11 +3,17 @@ import os
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.response.room_response_fixture import (
    get_room_response_query,
-   get_room_response_query_response,
+   get_room_response_query_data,
    get_room_response_non_existence_room_id,
+   search_response_by_room_invalid_room_query,
+   search_response_by_room_query,
+   search_response_by_room_only,
+   search_response_by_room_beyond_limits_query,
+   search_response_by_invalid_room,
    summary_room_response_query,
    summary_room_response_data,
    filter_by_response_query,
+   filter_by_response_invalid_query,
    filter_by_response_data,
 )
 
@@ -20,19 +26,17 @@ class TestRoomResponse(BaseTestCase):
     def test_room_response(self):
         """
         Testing for room response
-
         """
         CommonTestCases.admin_token_assert_equal(
             self,
             get_room_response_query,
-            get_room_response_query_response
+            get_room_response_query_data
         )
 
     def test_room_response_non_existence_room_id(self):
         """
         Testing for room response with non-existent
         room id
-
         """
         CommonTestCases.admin_token_assert_in(
             self,
@@ -60,4 +64,71 @@ class TestRoomResponse(BaseTestCase):
             self,
             filter_by_response_query,
             filter_by_response_data
+        )
+
+    def test_filter_by_number_of_invalid_responses(self):
+        """
+        Testing for filtering the room responses
+        by the number of responses the room has
+        using ignoring one of the limits
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            filter_by_response_invalid_query,
+            "Provide upper and lower limits to filter by response number"
+        )
+
+    def test_filter_search_response_room_name(self):
+        """
+        Testing for filtering the room responses
+        by the number and search by room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            search_response_by_room_query,
+            filter_by_response_data
+        )
+
+    def test_search_response_room_name_only(self):
+        """
+        Testing for searching the room responses
+        by room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            search_response_by_room_only,
+            filter_by_response_data
+        )
+
+    def test_filter_search_response_invalid_room(self):
+        """
+        Test for filter by response and search
+        the room with invalid room name
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            search_response_by_room_invalid_room_query,
+            "No response for this room, enter a valid room name"
+        )
+
+    def test_search_response_invalid_room(self):
+        """
+        Test for search by room name
+        with invalid room name
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            search_response_by_invalid_room,
+            "No response for this room, enter a valid room name"
+        )
+
+    def test_search_response_beyond_limits(self):
+        """
+        Test for search by room name
+        beyond upper and lower limits
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            search_response_by_room_beyond_limits_query,
+            "No response for this room at this range"
         )


### PR DESCRIPTION
 #### What does this PR do?
- Allow admin to search for room feedback response using the room name

#### Description of Task to be completed?
- Add an option to search response by room name in the response schema query
- Updated the test file for search functionality

#### How should this be manually tested?
- Run the server
- Test the query at `localhost:8000/mrm`
- Run `allRoomResponses ` query. Sample query can be found [here](https://github.com/andela/mrm_api/blob/develop/fixtures/response/room_response_fixture.py)

#### What are the relevant pivotal tracker stories?
[#163725518](https://www.pivotaltracker.com/story/show/163725518)

#### Screenshots
1. Room Responses filter by responses and search by room name
<img width="1219" alt="screen shot 2019-02-07 at 3 26 49 pm" src="https://user-images.githubusercontent.com/23406358/52417811-fa35f780-2aec-11e9-9a9a-52f50c98b687.png">


2. Room responses filter by responses and search by room name beyond limits
<img width="1220" alt="screen shot 2019-02-07 at 3 27 32 pm" src="https://user-images.githubusercontent.com/23406358/52417851-0de15e00-2aed-11e9-9314-b479da49af19.png">


3. Room responses search by room name only
<img width="1220" alt="screen shot 2019-02-07 at 11 26 03 am" src="https://user-images.githubusercontent.com/23406358/52406866-090db180-2acf-11e9-8cf7-ee9a47227b9b.png">

4. Room response search by invalid room name
<img width="1216" alt="screen shot 2019-02-07 at 11 25 43 am" src="https://user-images.githubusercontent.com/23406358/52407006-643fa400-2acf-11e9-9ad2-8f3fae29d7cb.png">

5. Room response filter by response and search invalid room name
<img width="1220" alt="screen shot 2019-02-07 at 3 27 03 pm" src="https://user-images.githubusercontent.com/23406358/52417877-1f2a6a80-2aed-11e9-85bc-f31437ac00ec.png">



