### PR TITLE
#163976389 refactor the create response mutation

### DIFF
--- a/api/response/schema.py
+++ b/api/response/schema.py
@@ -6,7 +6,6 @@ from utilities.validations import validate_empty_fields
 from graphql import GraphQLError
 from api.room.schema import Room
 from api.question.models import Question as QuestionModel
-from api.question.schema import Question
 from helpers.response.create_response import create_response
 
 
@@ -15,40 +14,47 @@ class Response(SQLAlchemyObjectType):
         model = ResponseModel
 
 
+class ResponseInputs(graphene.InputObjectType):
+    question_id = graphene.Int(required=True)
+    rate = graphene.Int()
+    text_area = graphene.String()
+    missing_items = graphene.List(graphene.Int)
+
+
 class CreateResponse(graphene.Mutation):
     class Arguments:
-        question_id = graphene.List(graphene.Int, required=True)
+        responses = graphene.List(
+            ResponseInputs, required=True
+        )
         room_id = graphene.Int(required=True)
-        rate = graphene.Int()
-        text_area = graphene.String()
-        missing_items = graphene.List(graphene.Int)
 
     response = graphene.List(Response)
 
     def mutate(self, info, **kwargs):
         validate_empty_fields(**kwargs)
         query = Room.get_query(info)
+        responses = []
+        errors = []
         room = query.filter_by(id=kwargs['room_id']).first()
         if not room:
             raise GraphQLError("Non-existent room id")
-        question_ids = kwargs.pop('question_id')
-        responses = []
-        questions = Question.get_query(info).filter(
-            QuestionModel.id.in_(question_ids)).all()
-        valid_question_ids = set()
-        for question in questions:
-            valid_question_ids.add(question.id)
+        for each_response in kwargs['responses']:
+            question = QuestionModel.query.filter_by(
+                id=each_response.question_id).first()
+            if not question:
+                errors.append(
+                    "Response to question {} was not saved because it does not exist".format(each_response.question_id)) # noqa
+                continue
             question_type = question.question_type
-            response = create_response(
-                question_type, question_id=question.id, **kwargs)
-            responses.append(response)
-        invalid_question_ids = set(question_ids).difference(
-            valid_question_ids)
-        if invalid_question_ids:
+            each_response['room_id'] = kwargs['room_id']
+            responses, errors = create_response(question_type,
+                                                errors,
+                                                responses,
+                                                **each_response)
+        if errors:
             raise GraphQLError(
-                ('Responses for question ids {} were not saved because '
-                    'the questions do not exist').format(
-                    str(invalid_question_ids).strip('{}'))
+                ('The following errors occured: {}').format(
+                    str(errors).strip('[]'))
                 )
         return CreateResponse(response=responses)
 

--- a/fixtures/response/user_response_check.py
+++ b/fixtures/response/user_response_check.py
@@ -2,7 +2,7 @@ null = None
 
 check_non_existing_question = '''
 mutation{
-  createResponse(questionId:5, roomId:1, missingItems:[1]) {
+  createResponse(responses: [{questionId:5, missingItems:[1]}], roomId:1) {
     response{
       id
       questionId
@@ -16,7 +16,7 @@ mutation{
 check_non_existing_question_response = {
   "errors": [
     {
-      "message": "Responses for question ids",
+      "message": "Response to question",
       "locations": [
         {
           "line": 2,
@@ -35,7 +35,7 @@ check_non_existing_question_response = {
 
 check_with_non_existent_room = '''
 mutation{
-  createResponse(questionId:2, roomId:9, missingItems:[1]) {
+  createResponse(responses: [{questionId:2,  missingItems:[1]}], roomId:9) {
     response{
       id
       questionId
@@ -48,7 +48,7 @@ mutation{
 
 create_check_query = '''
 mutation{
-  createResponse(questionId:2, roomId:1, missingItems:[1]) {
+  createResponse(responses: [{questionId:2, missingItems:[1]}], roomId:1) {
     response{
       id
       questionId
@@ -72,33 +72,9 @@ create_check_response = {
   }
 }
 
-create_check_query_no_missing_item = '''
-mutation{
-  createResponse(questionId:2, roomId:1) {
-    response{
-      id
-      questionId
-      roomId
-      }
-  }
-}
-'''
-
-create_check_query_empty_missing_item = '''
-mutation{
-  createResponse(questionId:2, roomId:1, missingItems:[]) {
-    response{
-      id
-      questionId
-      roomId
-      }
-  }
-}
-'''
-
 create_check_query_non_existence_item = '''
 mutation{
-  createResponse(questionId:2, roomId:1, missingItems:[10]) {
+  createResponse(responses: [{questionId:2, missingItems:[10]}], roomId:1) {
     response{
       id
       questionId

--- a/fixtures/response/user_response_fixtures.py
+++ b/fixtures/response/user_response_fixtures.py
@@ -2,7 +2,7 @@ null = None
 
 create_rate_query = '''
 mutation{
-  createResponse(questionId:1, roomId:1, rate:2) {
+  createResponse(responses: [{questionId:1, rate:2}], roomId:1) {
     response{
       id
       questionId
@@ -25,39 +25,6 @@ create_rate_response = {
         }
       ]
     }
-  }
-}
-
-rate_wrong_question = '''
-mutation{
-  createResponse(questionId:2, roomId:1, rate:2) {
-    response{
-      id
-      questionId
-      roomId
-      rate
-      }
-  }
-}
-'''
-
-rate_wrong_question_response = {
-  "errors": [
-    {
-      "message": "Provide a rating response",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "createResponse"
-      ]
-    }
-  ],
-  "data": {
-    "createResponse": null
   }
 }
 
@@ -96,7 +63,7 @@ rate_non_existing_question_response = {
 
 invalid_rating_number = '''
 mutation{
-  createResponse(questionId:1, roomId:1, rate:6) {
+  createResponse(responses: [{questionId:1, rate:6}], roomId:1) {
     response{
       id
       questionId
@@ -129,7 +96,7 @@ invalid_rating_number_response = {
 
 rate_with_non_existent_room = '''
 mutation{
-  createResponse(questionId:1, roomId:9, rate:2) {
+  createResponse(responses: [{questionId:1, rate:2}], roomId:9) {
     response{
       id
       questionId

--- a/fixtures/response/user_response_suggestions.py
+++ b/fixtures/response/user_response_suggestions.py
@@ -2,7 +2,8 @@ null = None
 
 create_suggestion_question = '''
 mutation{
-  createResponse(questionId:3, roomId:1, textArea:"Any other suggestion") {
+  createResponse(
+    responses: [{questionId:3, textArea:"Any other suggestion"}], roomId:1) {
     response{
       id
       questionId
@@ -30,7 +31,8 @@ create_suggestion_question_response = {
 
 make_suggestion_in_non_existent_room = '''
 mutation{
-  createResponse(questionId:3, roomId:90, textArea:"Any other suggestion") {
+  createResponse(
+    responses: [{questionId:3, textArea:"Any other suggestion"}], roomId:90) {
     response{
       id
       questionId
@@ -43,33 +45,8 @@ mutation{
 
 choose_wrong_question = '''
 mutation{
-  createResponse(questionId:1, roomId:1, textArea:"Any other suggestion") {
-    response{
-      id
-      questionId
-      roomId
-      textArea
-      }
-  }
-}
-'''
-
-choose_non_existent_question = '''
-mutation{
-  createResponse(questionId:8, roomId:1, textArea:"Any other suggestion") {
-    response{
-      id
-      questionId
-      roomId
-      textArea
-      }
-  }
-}
-'''
-
-make_suggestion_on_wrong_question = '''
-mutation{
-  createResponse(questionId:2, roomId:1, textArea:"Any other suggestion") {
+  createResponse(
+    responses: [{questionId:1, textArea:"Any other suggestion"}], roomId:1) {
     response{
       id
       questionId

--- a/helpers/response/create_response.py
+++ b/helpers/response/create_response.py
@@ -1,52 +1,51 @@
 from datetime import datetime
-from graphql import GraphQLError
 from api.response.models import Response
 from api.room_resource.models import Resource
-from utilities.validations import (
-    validate_rating_field,
-    validate_missing_items_field)
 
 
-def create_response(question_type, **kwargs):
+def create_response(question_type, errors, responses, **kwargs):
     if question_type.lower() == 'rate':
-        if 'rate' not in kwargs:
-            raise GraphQLError("Provide a rating response")
-        else:
-            validate_rating_field(**kwargs)
+        if 'rate' in kwargs and kwargs['rate']:
+            rating = [1, 2, 3, 4, 5]
+            if kwargs['rate'] not in rating:
+                errors.append(
+                    'Please rate between 1 and 5 for question {}'.format(
+                        kwargs['question_id']))
+                return responses, errors
             rating = Response(
                 rate=kwargs['rate'],
                 room_id=kwargs['room_id'],
                 question_id=kwargs['question_id'],
                 created_date=datetime.now())
             rating.save()
-            return rating
+            responses.append(rating)
     if question_type.lower() == 'check':
-        validate_missing_items_field(**kwargs)
-        response = Response(
-            check=True,
-            room_id=kwargs['room_id'],
-            question_id=kwargs['question_id'],
-            created_date=datetime.now())
-        response.save()
-        for item_id in kwargs['missing_items']:
-            missing_item = Resource.query.filter_by(
-                id=item_id, room_id=kwargs['room_id']).first()
-            if not missing_item:
-                response.delete()
-                raise GraphQLError(
-                    'One of the resource provided does not exist in this room')
-            response.missing_resources.append(
-                missing_item
-            )
+        if 'missing_items' in kwargs and kwargs['missing_items']:
+            response = Response(
+                check=True,
+                room_id=kwargs['room_id'],
+                question_id=kwargs['question_id'],
+                created_date=datetime.now())
             response.save()
-        return response
+            for item_id in kwargs['missing_items']:
+                missing_item = Resource.query.filter_by(
+                    id=item_id, room_id=kwargs['room_id']).first()
+                if not missing_item:
+                    response.delete()
+                    errors.append('Response to question {} was not saved because one of the resource provided does not exist'.format(kwargs['question_id'])) # noqa
+                    return responses, errors
+                response.missing_resources.append(
+                    missing_item
+                )
+                response.save()
+            responses.append(response)
     if question_type.lower() == 'input':
-        if 'text_area' not in kwargs:
-            raise GraphQLError("Provide a text response")
-        suggestion = Response(
-            text_area=kwargs['text_area'],
-            room_id=kwargs['room_id'],
-            question_id=kwargs['question_id'],
-            created_date=datetime.now())
-        suggestion.save()
-        return suggestion
+        if 'text_area' in kwargs and kwargs['text_area']:
+            suggestion = Response(
+                text_area=kwargs['text_area'],
+                room_id=kwargs['room_id'],
+                question_id=kwargs['question_id'],
+                created_date=datetime.now())
+            suggestion.save()
+            responses.append(suggestion)
+    return responses, errors

--- a/tests/test_response/test_user_response.py
+++ b/tests/test_response/test_user_response.py
@@ -4,7 +4,6 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.response.user_response_fixtures import (
     create_rate_query,
     create_rate_response,
-    rate_wrong_question,
     invalid_rating_number,
     rate_with_non_existent_room
 )
@@ -17,16 +16,12 @@ from fixtures.response.user_response_check import (
     filter_question_by_invalid_room_response,
     create_check_query,
     create_check_response,
-    create_check_query_empty_missing_item,
-    create_check_query_no_missing_item,
-    create_check_query_non_existence_item,
+    create_check_query_non_existence_item
 )
 from fixtures.response.user_response_suggestions import (
     create_suggestion_question,
     create_suggestion_question_response,
-    make_suggestion_in_non_existent_room,
-    make_suggestion_on_wrong_question,
-    choose_non_existent_question
+    make_suggestion_in_non_existent_room
 )
 
 
@@ -44,17 +39,6 @@ class TestCreateResponse(BaseTestCase):
             self,
             create_rate_query,
             create_rate_response
-        )
-
-    def test_rate_wrong_question(self):
-        """
-        Testing for rating wrong question
-
-        """
-        CommonTestCases.user_token_assert_in(
-            self,
-            rate_wrong_question,
-            "Provide the missing items"
         )
 
     def test_invalid_rating_number(self):
@@ -87,7 +71,7 @@ class TestCreateResponse(BaseTestCase):
         CommonTestCases.user_token_assert_in(
             self,
             check_non_existing_question,
-            "Responses for question ids"
+            "Response to question"
         )
 
     def test_check_non_existent_room(self):
@@ -112,26 +96,6 @@ class TestCreateResponse(BaseTestCase):
             create_check_response
         )
 
-    def test_check_empty_missing_items(self):
-        """
-        Testing for empty missing items list
-        """
-        CommonTestCases.user_token_assert_in(
-            self,
-            create_check_query_empty_missing_item,
-            "missing_items is required field"
-        )
-
-    def test_check_no_missing_items(self):
-        """
-        Testing for no missing items list
-        """
-        CommonTestCases.user_token_assert_in(
-            self,
-            create_check_query_no_missing_item,
-            "Provide the missing items"
-        )
-
     def test_check_non_existence_missing_items(self):
         """
         Testing for no missing items list
@@ -139,7 +103,7 @@ class TestCreateResponse(BaseTestCase):
         CommonTestCases.user_token_assert_in(
             self,
             create_check_query_non_existence_item,
-            "One of the resource provided does not exist in this room"
+            "one of the resource provided does not exist"
         )
 
     def test_create_suggestion(self):
@@ -162,28 +126,6 @@ class TestCreateResponse(BaseTestCase):
             self,
             make_suggestion_in_non_existent_room,
             "Non-existent room id"
-        )
-
-    def test_suggestion_on_wrong_question(self):
-        """
-        Testing for invalid rating number
-
-        """
-        CommonTestCases.user_token_assert_in(
-            self,
-            make_suggestion_on_wrong_question,
-            "Provide the missing items"
-        )
-
-    def test_suggestion_on_non_existent_question(self):
-        """
-        Testing for invalid rating number
-
-        """
-        CommonTestCases.user_token_assert_in(
-            self,
-            choose_non_existent_question,
-            "Responses for question ids"
         )
 
     def test_filter_response_by_valid_room_id(self):

--- a/utilities/validations.py
+++ b/utilities/validations.py
@@ -26,17 +26,6 @@ def validate_empty_fields(**kwargs):
             raise AttributeError(field + " is required field")
 
 
-def validate_rating_field(**kwargs):
-    """
-    Function to validate rating fields when
-    saving an object
-    :params kwargs
-    """
-    rating = [1, 2, 3, 4, 5]
-    if kwargs['rate'] not in rating:
-        raise AttributeError("Please rate between 1 and 5")
-
-
 def validate_date_time_range(**kwargs):
     """
     Function to validate the dates entered
@@ -53,16 +42,6 @@ def validate_date_time_range(**kwargs):
         raise ValueError(
             'endDate should be at least a day after startDate'
         )
-
-
-def validate_missing_items_field(**kwargs):
-    """
-    Function to validate the missing item field
-    when saving a check question response
-    :params kwargs
-    """
-    if 'missing_items' not in kwargs:
-        raise AttributeError("Provide the missing items")
 
 
 def validate_country_field(**kwargs):


### PR DESCRIPTION
#### What does this PR do?
- Allow sending responses as list of objects

#### Description of Task to be completed?
- Change mutation to allow sending list of objects
- Modify tests accordingly

#### How should this be manually tested?
- Clone the repo.
- Run `make build`
- `make run-app`

#### Run the following mutation:
```
mutation {
  createResponse(responses: [{questionId: 1 textArea: "text here", missingItems: []}, {questionId: 2, rate: 4, textArea: "", missingItems: []}, {questionId: 3, missingItems: [65, 67]}], roomId: 164) {
    response {
      roomId
      questionId
       textArea
      question {
        question
      }
    }
  }
}

```

**Any background context you want to provide?**
None

**What are the relevant pivotal tracker stories?**
[#163976389](https://www.pivotaltracker.com/story/show/163976389)

#### Screenshots
_Sending correct mutation
<img width="991" alt="screen shot 2019-02-18 at 3 20 24 pm" src="https://user-images.githubusercontent.com/23643904/52956917-c8484f00-3390-11e9-9389-e49cf0de7fb5.png">



_Sending with an incorrect question id_
<img width="974" alt="screen shot 2019-02-18 at 2 26 03 pm" src="https://user-images.githubusercontent.com/23643904/52953980-3ee14e80-3389-11e9-9957-fa00a53f6541.png">



**Questions:**
None
