### PR TITLE
#163904284: Add pagination to room responses

### DIFF
--- a/api/response/schema.py
+++ b/api/response/schema.py
@@ -1,6 +1,6 @@
 import graphene
-from helpers.auth.authentication import Auth
 from graphene_sqlalchemy import SQLAlchemyObjectType
+from helpers.auth.authentication import Auth
 from api.response.models import Response as ResponseModel
 from utilities.validations import validate_empty_fields
 from graphql import GraphQLError
@@ -49,7 +49,7 @@ class CreateResponse(graphene.Mutation):
                 ('Responses for question ids {} were not saved because '
                     'the questions do not exist').format(
                     str(invalid_question_ids).strip('{}'))
-                )
+            )
         return CreateResponse(response=responses)
 
 

--- a/fixtures/room/room_analytics_bookings_count_fixtures.py
+++ b/fixtures/room/room_analytics_bookings_count_fixtures.py
@@ -57,30 +57,6 @@ get_bookings_count_monthly_response = {
     }
 }
 
-get_bookings_count_invalid_date_range = '''
-query {
-  bookingsAnalyticsCount(startDate:"Aug 1 2018", endDate:"Aug 30 2018"){
-   period
-   bookings
-  }
-}
-'''
-
-get_bookings_count_invalid_date_range_response = {
-    "errors": [{
-        "message":
-        "Kindly enter a valid date range(less than 15 days or greater than 90 days",  # noqa E501
-        "locations": [{
-            "line": 3,
-            "column": 3
-        }],
-        "path": ["bookingsAnalyticsCount"]
-    }],
-    "data": {
-        "bookingsAnalyticsCount": null
-    }
-}
-
 get_bookings_count_monthly_diff_years = '''
 query {
   bookingsAnalyticsCount(startDate:"Nov 1 2017", endDate:"May 1 2018"){

--- a/helpers/calendar/ratios_and_utilization.py
+++ b/helpers/calendar/ratios_and_utilization.py
@@ -1,5 +1,4 @@
 import dateutil.parser
-from graphql.error import GraphQLError
 
 from .credentials import Credentials
 from helpers.calendar.analytics_helper import (CommonAnalytics)
@@ -167,7 +166,7 @@ class RoomAnalyticsRatios(Credentials):
         end_dt = dateutil.parser.parse(day_after_end_date)
         number_of_days = (end_dt - start_dt).days
 
-        if number_of_days <= 15:
+        if number_of_days <= 30:
             dates = CommonAnalytics.get_list_of_dates(start, number_of_days)  # noqa E501
             for date in dates:
                 bookings = CommonAnalytics.get_total_bookings(self, query, date[0], date[1])  # noqa E501
@@ -175,15 +174,12 @@ class RoomAnalyticsRatios(Credentials):
                 output = BookingsAnalyticsCount(period=string_date, bookings=bookings) # noqa E501
                 results.append(output)
 
-        elif number_of_days >= 90:
+        else:
             dates = CommonAnalytics.get_list_of_month_dates(start_date, start_dt, day_after_end_date, end_dt)  # noqa E501
             for date in dates:
                 bookings = CommonAnalytics.get_total_bookings(self, query, date[0], date[1])  # noqa E501
                 string_month = dateutil.parser.parse(date[0]).strftime("%B")
                 output = BookingsAnalyticsCount(period=string_month, bookings=bookings) # noqa E501
                 results.append(output)
-
-        else:
-            raise GraphQLError("Kindly enter a valid date range(less than 15 days or greater than 90 days")  # noqa E501
 
         return results

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -31,8 +31,6 @@ from fixtures.room.room_analytics_bookings_count_fixtures import (
     get_bookings_count_daily_response,
     get_bookings_count_monthly,
     get_bookings_count_monthly_response,
-    get_bookings_count_invalid_date_range,
-    get_bookings_count_invalid_date_range_response,
     get_bookings_count_monthly_diff_years,
     get_bookings_count_monthly_diff_years_response,
 )
@@ -113,12 +111,6 @@ class QueryRoomsAnalytics(BaseTestCase):
         CommonTestCases.admin_token_assert_equal(
             self, get_bookings_count_monthly,
             get_bookings_count_monthly_response
-        )
-
-    def test_analytics_for_bookings_invalid_date_range(self):
-        CommonTestCases.admin_token_assert_equal(
-            self, get_bookings_count_invalid_date_range,
-            get_bookings_count_invalid_date_range_response
         )
 
     def test_analytics_for_monthly_bookings_diff_years(self):


### PR DESCRIPTION
#### What does this PR do?
Add pagination to room responses 

#### Description of Task to be completed?
This is to enable the admin to view the room feedback responses using a paginator, to enable quick scrolling

#### How should this be manually tested?
* Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
* git checkout to `ft-paginate-room-responses-163904284` and run the following mutation:

```
query{
  allRoomResponses(page:1, perPage:2){
   responses {
        roomName,
        totalResponses,
        response {
          responseId,
          rating,
          suggestion,
          missingItems
        }
      }
   hasNext
   hasPrevious
}
}
```

#### Any background context you want to provide?
The pagination does not only paginates all the data coming in the allRoomResponses query. Since it is a graphene object I had to create its own functionality as I could not use the existing Pagination function in the codebase. 

#### Screenshots
* On querying for room in first page
<img width="1440" alt="screenshot 2019-02-15 at 15 49 01" src="https://user-images.githubusercontent.com/26184534/52858328-d9981e00-313a-11e9-88d7-8a84005c6707.png">

* If there are no more responses
<img width="1440" alt="screenshot 2019-02-15 at 15 53 32" src="https://user-images.githubusercontent.com/26184534/52858314-d2711000-313a-11e9-8485-ed809cd57214.png">


#### What are the relevant pivotal tracker stories?
[#162242826](https://www.pivotaltracker.com/story/show/162242826)
