### PR TITLE
#163904284 Add Pagination to all room responses query

### DIFF
--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -233,3 +233,73 @@ filter_by_response_data = {
         }
     }
 }
+
+query_paginated_responses = '''
+    query{
+  allRoomResponses(page:1, perPage:2){
+   responses {
+        roomName,
+        totalResponses,
+        response {
+          responseId,
+          rating,
+          suggestion,
+          missingItems
+        }
+      }
+   hasNext
+   hasPrevious
+   pages
+}
+}
+'''
+
+query_paginated_responses_response = {
+    "data": {
+        "allRoomResponses": {
+            "responses": [
+                {
+                    "roomName": "Entebbe",
+                    "totalResponses": 2,
+                    "response": [
+                        {
+                            "responseId": 2,
+                            "rating": None,
+                            "suggestion": None,
+                            "missingItems": ['Markers']
+                        },
+                        {
+                            "responseId": 1,
+                            "rating": 2,
+                            "suggestion": None,
+                            "missingItems": []
+                        }
+                    ]
+                }
+            ],
+            "hasNext": False,
+            "hasPrevious": False,
+            "pages": 1
+        }
+    }
+}
+
+query_paginated_responses_empty_page = '''
+    query{
+  allRoomResponses(page:5, perPage:2){
+   responses {
+        roomName,
+        totalResponses,
+        response {
+          responseId,
+          rating,
+          suggestion,
+          missingItems
+        }
+      }
+   hasNext
+   hasPrevious
+   pages
+}
+}
+'''

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -15,6 +15,9 @@ from fixtures.response.room_response_fixture import (
    filter_by_response_query,
    filter_by_response_invalid_query,
    filter_by_response_data,
+   query_paginated_responses,
+   query_paginated_responses_response,
+   query_paginated_responses_empty_page
 )
 
 
@@ -131,4 +134,24 @@ class TestRoomResponse(BaseTestCase):
             self,
             search_response_by_room_beyond_limits_query,
             "No response for this room at this range"
+        )
+
+    def test_get_paginated_responses(self):
+        """
+        Test for paginated responses
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_paginated_responses,
+            query_paginated_responses_response
+        )
+
+    def test_get_paginated_responses_empty_page(self):
+        """
+        Test for paginated responses for empty page
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            query_paginated_responses_empty_page,
+            "Page does not exist"
         )


### PR DESCRIPTION
#### What does this PR do?
Add pagination to room responses 

#### Description of Task to be completed?
This is to enable the admin to view the room feedback responses using a paginator, to enable quick scrolling

#### How should this be manually tested?
* Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
* git checkout to `ft-paginate-responses-163904284` and run the following mutation:

```
query{
  allRoomResponses(page:1, perPage:2){
   responses {
        roomName,
        totalResponses,
        response {
          responseId,
          rating,
          suggestion,
          missingItems
        }
      }
   hasNext
   hasPrevious
   pages
}
}
```

#### Any background context you want to provide?
The pagination uses the ListPaginate helper function. 

#### Screenshots
* On querying for room in first page
<img width="1440" alt="screenshot 2019-02-18 at 11 41 30" src="https://user-images.githubusercontent.com/26184534/52938227-36c9e480-3372-11e9-8d30-46d5c202ac34.png">

* If there are no more responses
<img width="1440" alt="screenshot 2019-02-19 at 10 58 43" src="https://user-images.githubusercontent.com/26184534/52998958-989f5280-3435-11e9-956c-4e827a706c7f.png">


#### What are the relevant pivotal tracker stories?
[#163904284](https://www.pivotaltracker.com/story/show/163904284)
