### PR TITLE
#163783849 Add cascading effect on soft-delete feature

### DIFF
--- a/api/block/models.py
+++ b/api/block/models.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import relationship, validates
 from sqlalchemy.schema import Sequence
 
 from helpers.database import Base
-from utilities.utility import Utility, StateType
+from utilities.utility import Utility, StateType, cascade_soft_delete
 from api.office.models import Office  # noqa: F401
 
 
@@ -29,3 +29,8 @@ class Block(Base, Utility):
     @validates('name')
     def convert_upper(self, key, value):
         return value.title()
+
+
+cascade_soft_delete(
+    Block, 'floor', 'block_id'
+)

--- a/api/floor/models.py
+++ b/api/floor/models.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import relationship, validates
 from sqlalchemy.schema import Sequence
 
 from helpers.database import Base
-from utilities.utility import Utility, StateType
+from utilities.utility import Utility, StateType, cascade_soft_delete
 from api.block.models import Block   # noqa: F401
 
 
@@ -33,3 +33,11 @@ class Floor(Base, Utility):
     @validates('name')
     def convert_capitalize(self, key, value):
         return value.capitalize()
+
+
+cascade_soft_delete(
+    Floor, 'room', 'floor_id'
+)
+cascade_soft_delete(
+    Floor, 'wing', 'floor_id'
+)

--- a/api/location/models.py
+++ b/api/location/models.py
@@ -4,8 +4,7 @@ from sqlalchemy.schema import Sequence
 
 from helpers.database import Base
 
-
-from utilities.utility import Utility, StateType
+from utilities.utility import Utility, StateType, cascade_soft_delete
 import enum
 
 
@@ -43,3 +42,11 @@ class Location(Base, Utility):
                 unique=True,
                 postgresql_where=(state == 'active')),
         )
+
+
+cascade_soft_delete(
+    Location, 'room', 'location_id'
+)
+cascade_soft_delete(
+    Location, 'office', 'location_id'
+)

--- a/api/office/models.py
+++ b/api/office/models.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 
 from helpers.database import Base
-from utilities.utility import Utility, StateType
+from utilities.utility import Utility, StateType, cascade_soft_delete
 from api.location.models import Location  # noqa: F401
 from api.block import models
 from helpers.database import db_session
@@ -40,3 +40,8 @@ def receive_after_insert(mapper, connection, target):
         if check_office_name(target.name):
             session.add(models.Block(name=target.name, office_id=target.id))
         pass
+
+
+cascade_soft_delete(
+    Office, 'block', 'office_id'
+)

--- a/api/room/models.py
+++ b/api/room/models.py
@@ -6,7 +6,7 @@ from graphql import GraphQLError
 from sqlalchemy.schema import Sequence
 
 from helpers.database import Base, db_session
-from utilities.utility import Utility, StateType
+from utilities.utility import Utility, StateType, cascade_soft_delete
 from api.floor.models import Floor  # noqa: F401
 from api.wing.models import Wing  # noqa: F401
 from api.events.models import Events  # noqa: F401
@@ -73,3 +73,11 @@ def receive_before_insert(mapper, connection, target):
         if not verify_calendar_id(target.calendar_id):
             raise GraphQLError("Room calendar Id is invalid")
         pass
+
+
+cascade_soft_delete(
+    Room, 'room_resource', 'room_id'
+)
+cascade_soft_delete(
+    Room, 'events', 'room_id'
+)

--- a/api/wing/models.py
+++ b/api/wing/models.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import relationship, validates
 from sqlalchemy.schema import Sequence
 
 from helpers.database import Base
-from utilities.utility import Utility, StateType
+from utilities.utility import Utility, StateType, cascade_soft_delete
 from api.floor.models import Floor  # noqa: F401
 
 
@@ -29,3 +29,8 @@ class Wing(Base, Utility):
     @validates('name')
     def convert_upper(self, key, value):
         return value.title()
+
+
+cascade_soft_delete(
+    Wing, 'room', 'wing_id'
+)

--- a/fixtures/room/room_analytics_bookings_count_fixtures.py
+++ b/fixtures/room/room_analytics_bookings_count_fixtures.py
@@ -49,7 +49,7 @@ get_bookings_count_monthly_response = {
             'bookings': 38
         }, {
             'period': 'October',
-            'bookings': 65
+            'bookings': 64
         }, {
             'period': 'November',
             'bookings': 3

--- a/utilities/utility.py
+++ b/utilities/utility.py
@@ -1,5 +1,7 @@
-from helpers.database import db_session
 import enum
+import api
+from helpers.database import db_session
+from sqlalchemy import event
 
 
 def update_entity_fields(entity, **kwargs):
@@ -12,6 +14,41 @@ def update_entity_fields(entity, **kwargs):
     for key in keys:
         exec("entity.{0} = kwargs['{0}']".format(key))
     return entity
+
+
+def cascade_soft_delete(parent_model, child, parent_id):
+    @event.listens_for(parent_model, 'after_update')
+    def receive_after_update(mapper, connection, target):
+        listen_for_after_flush_event(target, child, parent_id)
+
+
+def listen_for_after_flush_event(target, child, parent_id):
+    @event.listens_for(db_session, "after_flush", once=True)
+    def receive_after_flush(session, context):
+        """
+        Function to update related child data after a delete
+        mutation has been run.
+        The check statement on line 42 caters for the difference
+        in naming of room_resource folder and Resource class
+            :param session:
+            :param context:
+        """
+        if target.state == 'archived':
+            child_model = getattr(api, child)
+            child_object = getattr(
+                child_model.models,
+                'Resource' if child.capitalize() == 'Room_resource'
+                else child.capitalize()
+            )
+            id_of_parent = getattr(child_object, parent_id)
+            session.query(
+                child_object
+            ).filter(
+                id_of_parent == target.id
+            ).update(
+                {child_object.state: target.state}
+            )
+        pass
 
 
 class Utility(object):


### PR DESCRIPTION
#### What does this PR do?
The PR enables the deletion of related data if a delete mutation is used

#### Description of Task to be completed?
When deletions are done, related data is not included in the deletion/archiving. As an example, deleting a location will leave the rooms for that particular location still available. This PR enables this to be carried out automatically.

#### How should this be manually tested?
Pull the branch and run a deletion query such as the one of locations below.

``` 
mutation {
  deleteLocation(locationId: 1) {
    location {
      name
    }
  }
}
```

Any offices and rooms related to the location will also be deleted/archived.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#163977386](https://www.pivotaltracker.com/story/show/163977386)

#### Screenshots (if appropriate)
N/A