### PR TITLE
#163971253 Mock Andela Api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ html_coverage_report/
 # credentials
 credentials.json
 
+# test users
+users.json
+
 # redis
 /redis-stable
 dump.rdb

--- a/tests/test_authentication/test_authentication.py
+++ b/tests/test_authentication/test_authentication.py
@@ -15,8 +15,21 @@ class TestAuthentication(BaseTestCase):
         Test that an error message is returned when a user
         has an invalid token
         """
-        headers = {"Authorization": "Bearer" + " " + INVALID_TOKEN}  # noqa E501
+        headers = {"Authorization": "Bearer" + " " + "INVALID_TOKEN"}
         response = self.app_test.post(
             '/mrm?query=' + office_mutation_query,
             headers=headers)
-        self.assertIn("invalid token", str(response.data))
+        self.assertIn("Invalid token. Please Provide a valid token!",
+                      str(response.data))
+
+    def test_unauthorised_token_returns_error_message(self):
+        """
+        Test that an error message is returned when a user
+        has an unauthorised token
+        """
+        headers = {"Authorization": "Bearer" + " " + INVALID_TOKEN}
+        response = self.app_test.post(
+            '/mrm?query=' + office_mutation_query,
+            headers=headers)
+        self.assertIn("You are not authorized to perform this action",
+                      str(response.data))


### PR DESCRIPTION
#### What does this PR do?
* Mock Andela Api instead of making actual requests to it during testing. 
#### Description of Task to be completed?
*  Since we are using static users, added `users.py` which has the expected data of the users used during testing.
* Added a check to see if the app is testing mode or development mode. This is done in `helpers/auth/authentication.py`.
#### How should this be manually tested?
* Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
* git checkout to `ft-mock-auth-api-endpoint-for-tests-163971253 ` and go to `helpers/auth/authentication.py` comment out `api_url` and run tests. They should pass without calling the Andela Api.
#### Any background context you want to provide?
* Not applicable
#### screenshots:
* Not applicable

#### What are the relevant pivotal tracker stories?
[#163971253](https://www.pivotaltracker.com/n/projects/2154921/stories/163971253)