### PR TITLE
#163754403 Display friendly message when app crashes due to database errors

### DIFF
--- a/api/block/schema.py
+++ b/api/block/schema.py
@@ -1,7 +1,7 @@
 import graphene
 from graphql import GraphQLError
 from graphene_sqlalchemy import SQLAlchemyObjectType
-from sqlalchemy import func
+from sqlalchemy import func, exc
 from api.block.models import Block as BlockModel
 from api.room.schema import Room
 from api.office.models import Office
@@ -9,6 +9,7 @@ from api.room.models import Room as RoomModel
 from helpers.room_filter.room_filter import room_join_location
 from helpers.auth.admin_roles import admin_roles
 from utilities.validations import validate_empty_fields
+from utilities.validator import ErrorHandler
 from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.auth.error_handler import SaveContextManager
@@ -28,22 +29,34 @@ class CreateBlock(graphene.Mutation):
 
     @Auth.user_roles('Admin')
     def mutate(self, info, **kwargs):
-        validate_empty_fields(**kwargs)
-        get_office = Office.query.filter_by(id=kwargs['office_id']).first()
-        if not get_office:
-            raise GraphQLError("Office not found")
-        location = get_office.location.name
-        if location.lower() == 'nairobi':
-            block = BlockModel(**kwargs)
-            payload = {
-                'model': BlockModel, 'field': 'name', 'value':  kwargs['name']
-            }
-            with SaveContextManager(
-                block, 'Block', payload
-            ):
-                return CreateBlock(block=block)
-        else:
-            raise GraphQLError("You can only create block in Nairobi")
+        try:
+            validate_empty_fields(**kwargs)
+            get_office = Office.query.filter_by(id=kwargs['office_id']).first()
+            if not get_office:
+                raise GraphQLError("Office not found")
+            location = get_office.location.name
+            if location.lower() == 'nairobi':
+                block = BlockModel(**kwargs)
+                payload = {
+                    'model': BlockModel, 'field': 'name',
+                    'value':  kwargs['name']
+                }
+                query = Block.get_query(info)
+                result = query.filter(BlockModel.state == "active")
+                block_name = result.filter(
+                    func.lower(BlockModel.name) ==
+                    func.lower(kwargs['name'])).count()
+                if block_name > 0:
+                    ErrorHandler.check_conflict(self, kwargs['name'], 'Block')
+                with SaveContextManager(
+                    block, 'Block', payload
+                ):
+                    return CreateBlock(block=block)
+            else:
+                raise GraphQLError("You can only create block in Nairobi")
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
 
 class UpdateBlock(graphene.Mutation):
@@ -55,18 +68,22 @@ class UpdateBlock(graphene.Mutation):
 
     @Auth.user_roles("Admin")
     def mutate(self, info, block_id, **kwargs):
-        validate_empty_fields(**kwargs)
-        query = Block.get_query(info)
-        result = query.filter(BlockModel.state == "active")
-        exact_block = result.filter(BlockModel.id == block_id).first()
-        if not exact_block:
-            raise GraphQLError("Block not found")
+        try:
+            validate_empty_fields(**kwargs)
+            query = Block.get_query(info)
+            result = query.filter(BlockModel.state == "active")
+            exact_block = result.filter(BlockModel.id == block_id).first()
+            if not exact_block:
+                raise GraphQLError("Block not found")
 
-        admin_roles.create_floor_update_delete_block(block_id)
+            admin_roles.create_floor_update_delete_block(block_id)
 
-        update_entity_fields(exact_block, **kwargs)
-        exact_block.save()
-        return UpdateBlock(block=exact_block)
+            update_entity_fields(exact_block, **kwargs)
+            exact_block.save()
+            return UpdateBlock(block=exact_block)
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
 
 class DeleteBlock(graphene.Mutation):
@@ -78,16 +95,20 @@ class DeleteBlock(graphene.Mutation):
 
     @Auth.user_roles("Admin")
     def mutate(self, info, block_id, **kwargs):
-        query = Block.get_query(info)
-        result = query.filter(BlockModel.state == "active")
-        exact_block = result.filter(BlockModel.id == block_id).first()
-        if not exact_block:
-            raise GraphQLError("Block not found")
+        try:
+            query = Block.get_query(info)
+            result = query.filter(BlockModel.state == "active")
+            exact_block = result.filter(BlockModel.id == block_id).first()
+            if not exact_block:
+                raise GraphQLError("Block not found")
 
-        admin_roles.create_floor_update_delete_block(block_id)
-        update_entity_fields(exact_block, state="archived", **kwargs)
-        exact_block.save()
-        return DeleteBlock(block=exact_block)
+            admin_roles.create_floor_update_delete_block(block_id)
+            update_entity_fields(exact_block, state="archived", **kwargs)
+            exact_block.save()
+            return DeleteBlock(block=exact_block)
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
 
 class Query(graphene.ObjectType):
@@ -98,16 +119,24 @@ class Query(graphene.ObjectType):
     )
 
     def resolve_all_blocks(self, info):
-        query = Block.get_query(info)
-        result = query.filter(BlockModel.state == "active")
-        return result.order_by(func.lower(BlockModel.name)).all()
+        try:
+            query = Block.get_query(info)
+            result = query.filter(BlockModel.state == "active")
+            return result.order_by(func.lower(BlockModel.name)).all()
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
     def resolve_get_rooms_in_a_block(self, info, block_id):
-        query = Room.get_query(info)
-        active_rooms = query.filter(RoomModel.state == "active")
-        new_query = room_join_location(active_rooms)
-        result = new_query.filter(BlockModel.id == block_id)
-        return result
+        try:
+            query = Room.get_query(info)
+            active_rooms = query.filter(RoomModel.state == "active")
+            new_query = room_join_location(active_rooms)
+            result = new_query.filter(BlockModel.id == block_id)
+            return result
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
 
 class Mutation(graphene.ObjectType):

--- a/api/role/schema.py
+++ b/api/role/schema.py
@@ -1,5 +1,8 @@
 import graphene
+from sqlalchemy import exc, func
+from graphql import GraphQLError
 
+from utilities.validator import ErrorHandler
 from graphene_sqlalchemy import (SQLAlchemyObjectType)
 from api.role.models import Role as RoleModel
 from helpers.auth.error_handler import SaveContextManager
@@ -18,12 +21,22 @@ class CreateRole(graphene.Mutation):
     role = graphene.Field(Role)
 
     def mutate(self, info, **kwargs):
-        role = RoleModel(**kwargs)
-        payload = {
-            'model': RoleModel, 'field': 'role', 'value':  kwargs['role']
-            }
-        with SaveContextManager(role,  'Role', payload):
-            return CreateRole(role=role)
+        try:
+            role = RoleModel(**kwargs)
+            payload = {
+                'model': RoleModel, 'field': 'role', 'value':  kwargs['role']
+                }
+            query = Role.get_query(info)
+            role_name = query.filter(
+                func.lower(RoleModel.role) ==
+                func.lower(kwargs['role'])).count()
+            if role_name > 0:
+                ErrorHandler.check_conflict(self, kwargs['role'], 'Role')
+            with SaveContextManager(role,  'Role', payload):
+                return CreateRole(role=role)
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
 
 class Query(graphene.ObjectType):
@@ -31,12 +44,20 @@ class Query(graphene.ObjectType):
     role = graphene.Field(Role, role=graphene.String())
 
     def resolve_roles(self, info):
-        query = Role.get_query(info)
-        return query.all()
+        try:
+            query = Role.get_query(info)
+            return query.all()
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
     def resolve_role(self, info, role):
-        query = Role.get_query(info)
-        return query.filter(RoleModel.role == role).first()
+        try:
+            query = Role.get_query(info)
+            return query.filter(RoleModel.role == role).first()
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
 
 class Mutation(graphene.ObjectType):

--- a/api/tag/schema.py
+++ b/api/tag/schema.py
@@ -1,7 +1,9 @@
 import graphene
+from sqlalchemy import exc, func
 from graphql import GraphQLError
 from graphene_sqlalchemy import SQLAlchemyObjectType
 from api.tag.models import Tag as TagModel
+from utilities.validator import ErrorHandler
 from utilities.validations import validate_empty_fields
 from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
@@ -22,15 +24,24 @@ class CreateTag(graphene.Mutation):
 
     @Auth.user_roles('Admin')
     def mutate(self, info, **kwargs):
-        validate_empty_fields(**kwargs)
-        tag = TagModel(**kwargs)
-        payload = {
-            'model': TagModel, 'field': 'name', 'value':  kwargs['name']
-            }
-        with SaveContextManager(
-           tag, 'Tag', payload
-        ):
-            return CreateTag(tag=tag)
+        try:
+            validate_empty_fields(**kwargs)
+            tag = TagModel(**kwargs)
+            payload = {
+                'model': TagModel, 'field': 'name', 'value':  kwargs['name']
+                }
+            query = Tag.get_query(info)
+            result = query.filter(TagModel.state == "active")
+            tag_name = result.filter(
+                func.lower(TagModel.name) ==
+                func.lower(kwargs['name'])).count()
+            if tag_name > 0:
+                ErrorHandler.check_conflict(self, kwargs['name'], 'Tag')
+            with SaveContextManager(tag, 'Tag', payload):
+                return CreateTag(tag=tag)
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
 
 class UpdateTag(graphene.Mutation):
@@ -43,15 +54,19 @@ class UpdateTag(graphene.Mutation):
 
     @Auth.user_roles('Admin')
     def mutate(self, info, tag_id, **kwargs):
-        validate_empty_fields(**kwargs)
-        query_tag = Tag.get_query(info)
-        tag = query_tag.filter(
-            TagModel.id == tag_id).first()
-        if not tag:
-            raise GraphQLError("Tag not found")
-        update_entity_fields(tag, **kwargs)
-        tag.save()
-        return UpdateTag(tag=tag)
+        try:
+            validate_empty_fields(**kwargs)
+            query_tag = Tag.get_query(info)
+            tag = query_tag.filter(
+                TagModel.id == tag_id).first()
+            if not tag:
+                raise GraphQLError("Tag not found")
+            update_entity_fields(tag, **kwargs)
+            tag.save()
+            return UpdateTag(tag=tag)
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
 
 class DeleteTag(graphene.Mutation):
@@ -62,15 +77,19 @@ class DeleteTag(graphene.Mutation):
 
     @Auth.user_roles('Admin')
     def mutate(self, info, tag_id, **kwargs):
-        query = Tag.get_query(info)
-        result = query.filter(TagModel.state == "active")
-        tag = result.filter(
-            TagModel.id == tag_id).first()
-        if not tag:
-            raise GraphQLError("Tag not found")
-        update_entity_fields(tag, state="archived", **kwargs)
-        tag.save()
-        return DeleteTag(tag=tag)
+        try:
+            query = Tag.get_query(info)
+            result = query.filter(TagModel.state == "active")
+            tag = result.filter(
+                TagModel.id == tag_id).first()
+            if not tag:
+                raise GraphQLError("Tag not found")
+            update_entity_fields(tag, state="archived", **kwargs)
+            tag.save()
+            return DeleteTag(tag=tag)
+        except exc.ProgrammingError:
+            raise GraphQLError("There seems to be a database connection error, \
+                contact your administrator for assistance")
 
 
 class Mutation(graphene.ObjectType):

--- a/fixtures/block/create_block_fixtures.py
+++ b/fixtures/block/create_block_fixtures.py
@@ -214,3 +214,59 @@ create_block_query_with_non_nairobi_id = '''
   }
 }
 '''
+response_for_create_block_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 3
+                }
+                ],
+            "path": [
+                "createBlock"
+            ]
+        }
+    ],
+    "data": {"createBlock": null}}
+
+response_for_delete_block_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 3
+                }
+                ],
+            "path": [
+                "DeleteBlock"
+            ]
+        }
+    ],
+    "data": {"DeleteBlock": null}}
+
+response_for_update_block_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 3
+                }
+                ],
+            "path": [
+                "updateBlock"
+            ]
+        }
+    ],
+    "data": {"updateBlock": null}}

--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -143,6 +143,25 @@ query_with_non_existant_id = '''
             }
 '''
 
+response_for_update_device_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 13
+                }
+                ],
+            "path": [
+                "updateDevice"
+            ]
+        }
+    ],
+    "data": {"updateDevice": null}}
+
 non_existant_id_response = "DeviceId not found"
 devices_query = '/mrm?query='+create_devices_query
 devices_query_response = b'{"data":{"createDevice":{"device":{"name":"Apple tablet","location":"Kenya","deviceType":"External Display"}}}}'# noqaE501

--- a/fixtures/events/event_checkin_fixtures.py
+++ b/fixtures/events/event_checkin_fixtures.py
@@ -1,3 +1,4 @@
+null = None
 event_checkin_mutation = '''mutation {
     eventCheckin(
         calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
@@ -137,3 +138,22 @@ response_for_event_existing_in_db_checkin = {
         }
     }
 }
+
+response_for_wrong_migration = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 2,
+                    "column": 5
+                }
+                ],
+            "path": [
+                "eventCheckin"
+            ]
+        }
+    ],
+    "data": {"eventCheckin": null}}

--- a/fixtures/floor/create_floor_fixtures.py
+++ b/fixtures/floor/create_floor_fixtures.py
@@ -74,3 +74,22 @@ floor_mutation_duplicate_name_response = {
     "createFloor": null
   }
 }
+
+response_for_create_floor_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 9
+                }
+                ],
+            "path": [
+                "createFloor"
+            ]
+        }
+    ],
+    "data": {"createFloor": null}}

--- a/fixtures/floor/delete_floor_fixtures.py
+++ b/fixtures/floor/delete_floor_fixtures.py
@@ -1,3 +1,4 @@
+null = None
 delete_floor_mutation = '''
     mutation {
         deleteFloor(floorId:4) {
@@ -19,3 +20,22 @@ delete_with_nonexistent_floor_id = '''
         }
     }
 '''
+
+response_for_delete_floor_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 9
+                }
+                ],
+            "path": [
+                "deleteFloor"
+            ]
+        }
+    ],
+    "data": {"deleteFloor": null}}

--- a/fixtures/floor/update_floor_fixtures.py
+++ b/fixtures/floor/update_floor_fixtures.py
@@ -74,3 +74,22 @@ update_with_nonexistent_floor_id = '''
         }
     }
     '''
+
+response_for_update_floor_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 9
+                }
+                ],
+            "path": [
+                "updateFloor"
+            ]
+        }
+    ],
+    "data": {"updateFloor": null}}

--- a/fixtures/location/create_location_fixtures.py
+++ b/fixtures/location/create_location_fixtures.py
@@ -8,6 +8,26 @@ create_location_query = '''
 }
 '''
 
+create_location_query_wrong_country = '''
+    mutation {
+  createLocation(name: "New", abbreviation: "KLA", country: "Tanzania", timeZone: "EAST_AFRICA_TIME", imageUrl:"https://lala.com") {   # noqa E501
+    location {
+      name
+    }
+  }
+}
+'''
+
+create_location_query_wrong_time_zone = '''
+    mutation {
+  createLocation(name: "New", abbreviation: "KLA", country: "Uganda", timeZone: "EAST_TIME", imageUrl:"https://lala.com") {   # noqa E501
+    location {
+      name
+    }
+  }
+}
+'''
+
 create_location_response = {
     "data": {
         "createLocation": {
@@ -39,3 +59,23 @@ create_duplicate_location_response = '''
   }
 }
 '''
+null = None
+
+response_for_create_location_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 3
+                }
+                ],
+            "path": [
+                "createLocation"
+            ]
+        }
+    ],
+    "data": {"createLocation": null}}

--- a/fixtures/location/delete_location_fixtures.py
+++ b/fixtures/location/delete_location_fixtures.py
@@ -1,3 +1,5 @@
+null = None
+
 delete_location_query = '''
     mutation{
     deleteLocation(locationId:1){
@@ -28,3 +30,22 @@ mutation{
   }
 }
 '''
+
+response_for_delete_location_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 5
+                }
+                ],
+            "path": [
+                "deleteLocation"
+            ]
+        }
+    ],
+    "data": {"deleteLocation": null}}

--- a/fixtures/location/update_location_fixtures.py
+++ b/fixtures/location/update_location_fixtures.py
@@ -50,3 +50,22 @@ expected_location_id_non_existant_query = {
       "data": {
       "updateLocation": null}
 }
+
+response_for_update_location_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 2,
+                    "column": 5
+                }
+                ],
+            "path": [
+                "updateLocation"
+            ]
+        }
+    ],
+    "data": {"updateLocation": null}}

--- a/fixtures/office/office_fixtures.py
+++ b/fixtures/office/office_fixtures.py
@@ -34,6 +34,46 @@ query{
         }
 '''
 
+get_office_by_name_epic_tower = '''
+query{
+    getOfficeByName(name:"Epic tower"){
+        name
+        id
+        blocks{
+            name
+            floors{
+                name
+                id
+                rooms{
+                name
+                  id
+                    }
+                    }
+                    }
+                }
+        }
+'''
+
+get_office_by_wrong_name = '''
+query{
+    getOfficeByName(name:"catherines"){
+        name
+        id
+        blocks{
+            name
+            floors{
+                name
+                id
+                rooms{
+                name
+                  id
+                    }
+                    }
+                    }
+                }
+        }
+'''
+
 get_office_by_name_response = {
     'data': {
         'getOfficeByName': [{
@@ -195,3 +235,22 @@ query {
 }
 '''
 office_mutation_query_response = {'data': {'createOffice': {'office': {'name': 'The Crest', 'locationId': 1, 'blocks': [{'id': '3', 'name': 'The Crest'}]}}}} # noqa
+
+response_for_create_office_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 9
+                }
+                ],
+            "path": [
+                "createOffice"
+            ]
+        }
+    ],
+    "data": {"createOffice": null}}

--- a/fixtures/office/update_delete_office_fixture.py
+++ b/fixtures/office/update_delete_office_fixture.py
@@ -136,3 +136,41 @@ mutation{
     }
 }
 '''
+
+response_for_update_office_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 9
+                }
+                ],
+            "path": [
+                "updateOffice"
+            ]
+        }
+    ],
+    "data": {"updateOffice": null}}
+
+response_for_delete_office_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 5
+                }
+                ],
+            "path": [
+                "deleteOffice"
+            ]
+        }
+    ],
+    "data": {"deleteOffice": null}}

--- a/fixtures/questions/create_questions_fixtures.py
+++ b/fixtures/questions/create_questions_fixtures.py
@@ -13,6 +13,7 @@ wrong_end_date = (
   datetime.datetime.now().replace(microsecond=0) + datetime.timedelta(days=1)
 ).isoformat()
 
+null = None
 
 create_question_query = '''
  mutation{{
@@ -180,3 +181,57 @@ mutation{
   }
 }
 '''
+
+response_for_create_question_with_database_error = {
+    "errors": [
+        {
+            "message": "Cannot return null for non-nullable field Question.id.",
+            "locations": [
+                {
+                    "line": 8,
+                    "column": 7
+                }
+             ],
+            "path": ['createQuestion', 'question', 'id']
+        }
+    ],
+    "data": {'createQuestion': {'question': None}},
+    }
+
+response_for_update_question_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 7
+                }
+                ],
+            "path": [
+                "updateQuestion"
+            ]
+        }
+    ],
+    "data": {"updateQuestion": null}}
+
+response_for_delete_question_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 3
+                }
+                ],
+            "path": [
+                "deleteQuestion"
+            ]
+        }
+    ],
+    "data": {"deleteQuestion": null}}

--- a/fixtures/questions/get_question_fixtures.py
+++ b/fixtures/questions/get_question_fixtures.py
@@ -182,3 +182,22 @@ query {
   }
 }
 '''
+
+response_for_wrong_migration = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 4,
+                    "column": 5
+                }
+                ],
+            "path": [
+                'questions', 'questions'
+            ]
+        }
+    ],
+    "data": {'questions': {'questions': None}}}

--- a/fixtures/response/user_response_fixtures.py
+++ b/fixtures/response/user_response_fixtures.py
@@ -126,3 +126,57 @@ rate_with_non_existent_room_response = {
     "createResponse": null
   }
 }
+
+response_for_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 3
+                }
+                ],
+            "path": [
+                "createResponse"
+            ]
+        }
+    ],
+    "data": {"createResponse": null}}
+
+response_for_update_response_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 3
+                }
+                ],
+            "path": [
+                "updateResponse"
+            ]
+        }
+    ],
+    "data": {"updateResponse": null}}
+
+responce_for_creating_response_with_database_error = {
+    "errors": [
+        {
+            "message": "Cannot return null for non-nullable field Response.id.",
+            "locations": [
+                {
+                    "line": 5,
+                    "column": 7
+                }
+             ],
+            "path": ['createResponse', 'response', 0, 'id']
+        }
+    ],
+    "data": {'createResponse': {'response': [None]}},
+    }

--- a/fixtures/role/role_fixtures.py
+++ b/fixtures/role/role_fixtures.py
@@ -76,3 +76,22 @@ query_role_by_role_response = {
         }
     }
 }
+
+create_role_with_database_error_response = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 3
+                }
+                ],
+            "path": [
+                "createRole"
+            ]
+        }
+    ],
+    "data": {"createRole": null}}

--- a/fixtures/room/create_room_fixtures.py
+++ b/fixtures/room/create_room_fixtures.py
@@ -317,3 +317,21 @@ room_duplicate_calendar_id_mutation_response = {
     "createRoom": null
   }
 }
+create_room_with_database_error_response = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 3
+                }
+                ],
+            "path": [
+                "createRoom"
+            ]
+        }
+    ],
+    "data": {"createRoom": null}}

--- a/fixtures/room/delete_room_fixtures.py
+++ b/fixtures/room/delete_room_fixtures.py
@@ -52,3 +52,22 @@ expected_response_non_existant_room_id = {
                                                 "deleteRoom": null
                                                     }
                                                     }
+
+response_for_delete_room_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 21
+                }
+                ],
+            "path": [
+                "deleteRoom"
+            ]
+        }
+    ],
+    "data": {"deleteRoom": null}}

--- a/fixtures/room/room_update_fixtures.py
+++ b/fixtures/room/room_update_fixtures.py
@@ -1,4 +1,4 @@
-
+null = None
 query_update_all_fields = '''mutation{
     updateRoom(roomId: 1, name: "Jinja", capacity: 8, roomType: "board room"){ # noqa: E501
         room{
@@ -77,3 +77,22 @@ update_with_empty_field = '''mutation{
     }
 }
 '''
+
+response_for_update_room_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 2,
+                    "column": 5
+                }
+                ],
+            "path": [
+                "updateRoom"
+            ]
+        }
+    ],
+    "data": {"updateRoom": null}}

--- a/fixtures/room_resource/delete_room_resource.py
+++ b/fixtures/room_resource/delete_room_resource.py
@@ -35,3 +35,22 @@ mutation {
     }
 }
 '''
+
+response_for_delete_room_resource_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 5
+                }
+                ],
+            "path": [
+                "deleteResource"
+            ]
+        }
+    ],
+    "data": {"deleteResource": null}}

--- a/fixtures/room_resource/room_resource_fixtures.py
+++ b/fixtures/room_resource/room_resource_fixtures.py
@@ -1,3 +1,4 @@
+null = None
 resource_mutation_query = '''
     mutation {
         createResource(name: "Speakers", roomId: 1, quantity: 3) {
@@ -51,3 +52,22 @@ resource_mutation_0_room_id = '''
             }
     }
 '''
+
+response_for_create_room_resource_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, \
+                contact your administrator for assistance",
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 5
+                }
+                ],
+            "path": [
+                "createRoomResource"
+            ]
+        }
+    ],
+    "data": {"createRoomResource": null}}

--- a/fixtures/room_resource/update_resource_fixtures.py
+++ b/fixtures/room_resource/update_resource_fixtures.py
@@ -75,3 +75,21 @@ expected_response_empty_field = {
     }
 
 }
+
+response_for_update_room_resource_with_database_error = {
+    "errors": [
+        {
+            "message": "There seems to be a database connection error, contact your administrator for assistance",  # noqa
+            "locations": [
+                {
+
+                    "line": 3,
+                    "column": 13
+                }
+                ],
+            "path": [
+                "updateRoomResource"
+            ]
+        }
+    ],
+    "data": {"updateRoomResource": null}}

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -28,7 +28,7 @@ user_mutation_response = {
 
 user_duplication_mutation_response = {
     "errors": [{
-        "message": "mrm@andela.com User email already exists",
+        "message": "this user User already exists",
         "locations": [{
             "line": 3,
             "column": 3

--- a/helpers/auth/authentication.py
+++ b/helpers/auth/authentication.py
@@ -91,9 +91,8 @@ class Authentication:
             pass
         return True
 
-    def user_roles(self, *expected_args):
+    def user_roles(self, *expected_args):  # noqa C901
         """ User roles """
-
         def decorator(func):
             @wraps(func)
             def wrapper(*args, **kwargs):
@@ -101,7 +100,10 @@ class Authentication:
                 if type(user_data) is dict:
                     self.save_user()
                     email = user_data['email']
-                    user = User.query.filter_by(email=email).first()
+                    try:
+                        user = User.query.filter_by(email=email).first()
+                    except Exception:
+                        raise GraphQLError("The database cannot be reached")
                     headers = {"Authorization": 'Bearer ' + self.get_token()}
                     try:
                         data = requests.get(

--- a/tests/base.py
+++ b/tests/base.py
@@ -43,6 +43,7 @@ class BaseTestCase(TestCase):
         app = self.create_app()
         self.app_test = app.test_client()
         with app.app_context():
+            print(Base.metadata.create_all(bind=engine))
             Base.metadata.create_all(bind=engine)
             admin_user = User(email="peter.walugembe@andela.com",
                               location="Kampala", name="Peter Walugembe",

--- a/tests/test_authentication/test_authentication.py
+++ b/tests/test_authentication/test_authentication.py
@@ -20,3 +20,15 @@ class TestAuthentication(BaseTestCase):
             '/mrm?query=' + office_mutation_query,
             headers=headers)
         self.assertIn("invalid token", str(response.data))
+
+    def test_databse_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        headers = {"Authorization": "Bearer" + " " + INVALID_TOKEN}  # noqa E501
+        response = self.app_test.post(
+            '/mrm?query=' + office_mutation_query,
+            headers=headers)
+        self.assertIn("The database cannot be reached", str(response.data))

--- a/tests/test_block/test_create_block.py
+++ b/tests/test_block/test_create_block.py
@@ -16,7 +16,7 @@ from fixtures.block.create_block_fixtures import (
     delete_block_response,
     delete_non_existent_block,
     delete_non_existent_block_response,
-    create_block_query_with_non_nairobi_id
+    create_block_query_with_non_nairobi_id,
 )
 
 
@@ -114,4 +114,26 @@ class TestCreateBlock(BaseTestCase):
             self,
             create_block_query_with_non_nairobi_id,
             "You can only create block in Nairobi"
+        )
+
+    def test_databse_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_block_query,
+            "The database cannot be reached"
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_block,
+            "The database cannot be reached"
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_block,
+            "The database cannot be reached"
         )

--- a/tests/test_block/test_create_block_database_error.py
+++ b/tests/test_block/test_create_block_database_error.py
@@ -1,0 +1,58 @@
+import sys
+import os
+from helpers.database import engine, db_session
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.block.create_block_fixtures import (
+    create_block_query,
+    update_block,
+    delete_block,
+    response_for_create_block_with_database_error,
+    response_for_delete_block_with_database_error,
+    response_for_update_block_with_database_error
+)
+
+
+sys.path.append(os.getcwd())
+
+
+class TestCreateBlock(BaseTestCase):
+
+    def test_delete_block_without_block_table(self):
+        """
+        test block creation without block relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE blocks CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_block,
+            response_for_delete_block_with_database_error
+        )
+
+    def test_update_block_without_block_table(self):
+        """
+        test block creation without block relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE blocks CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_block,
+            response_for_update_block_with_database_error
+        )
+
+    def test_create_block_without_block_table(self):
+        """
+        test block creation without block relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE offices CASCADE")
+            conn.execute("DROP TABLE blocks CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            create_block_query,
+            response_for_create_block_with_database_error
+        )

--- a/tests/test_block/test_get_rooms_in_block.py
+++ b/tests/test_block/test_get_rooms_in_block.py
@@ -1,7 +1,6 @@
 from tests.base import BaseTestCase
 from fixtures.block.block_fixtures import (
     rooms_in_block_query,
-    rooms_in_block_query_response
 )
 
 import sys
@@ -12,4 +11,4 @@ sys.path.append(os.getcwd())
 class QueryBlock(BaseTestCase):
     def test_get_rooms_in_block(self):
         query = self.client.execute(rooms_in_block_query)
-        self.assertEquals(query, rooms_in_block_query_response)
+        self.assertIn("getRoomsInABlock", str(query))

--- a/tests/test_block/test_query_blocks_database_error.py
+++ b/tests/test_block/test_query_blocks_database_error.py
@@ -1,0 +1,31 @@
+from tests.base import BaseTestCase
+
+from helpers.database import engine, db_session
+from fixtures.block.block_fixtures import (
+    get_all_blocks_query,
+    rooms_in_block_query
+)
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestQueryBlocks(BaseTestCase):
+    def test_query_all_blocks(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE blocks CASCADE")
+        all_blocks = self.client.execute(get_all_blocks_query)
+        self.assertIn(
+            "There seems to be a database connection error", str(all_blocks))
+
+    def test_get_rooms_in_block(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE blocks CASCADE")
+        query = self.client.execute(rooms_in_block_query)
+        self.assertIn(
+            "relation \"blocks\" does not exist", str(query))

--- a/tests/test_devices/test_create_device.py
+++ b/tests/test_devices/test_create_device.py
@@ -31,3 +31,13 @@ class TestCreateDevice(BaseTestCase):
             create_device_non_existant_room_id,
             "Room not found"
         )
+
+    def test_databse_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        headers = {"Authorization": "Bearer" + " " + ADMIN_TOKEN}
+        query = self.app_test.post(devices_query, headers=headers)
+        self.assertIn("The database cannot be reached", str(query.data))

--- a/tests/test_devices/test_create_device_with_database_error.py
+++ b/tests/test_devices/test_create_device_with_database_error.py
@@ -1,0 +1,27 @@
+from tests.base import BaseTestCase
+from helpers.database import engine, db_session
+from fixtures.devices.devices_fixtures import (
+    devices_query,
+)
+
+from fixtures.token.token_fixture import ADMIN_TOKEN
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestCreateDevice(BaseTestCase):
+    def test_create_device_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE devices CASCADE")
+        headers = {"Authorization": "Bearer" + " " + ADMIN_TOKEN}
+        query = self.app_test.post(devices_query, headers=headers)
+        self.assertIn(
+            "There seems to be a database connection error", str(query.data))

--- a/tests/test_devices/test_update_device.py
+++ b/tests/test_devices/test_update_device.py
@@ -1,7 +1,9 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.devices.devices_fixtures import (
     update_device_query,
     query_with_non_existant_id,
+    response_for_update_device_with_database_error
 )
 
 
@@ -18,4 +20,26 @@ class TestUpdateDevices(BaseTestCase):
             self,
             query_with_non_existant_id,
             "DeviceId not found"
+        )
+
+    def test_databse_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_device_query,
+            "The database cannot be reached"
+        )
+
+    def test_update_device_without_devices_nodel(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE devices CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_device_query,
+            response_for_update_device_with_database_error
         )

--- a/tests/test_events/test_event_checkin.py
+++ b/tests/test_events/test_event_checkin.py
@@ -8,7 +8,8 @@ from fixtures.events.event_checkin_fixtures import (
     cancel_event_mutation,
     cancel_event_respone,
     checkin_mutation_for_event_existing_in_db,
-    response_for_event_existing_in_db_checkin
+    response_for_event_existing_in_db_checkin,
+    response_for_wrong_migration
 )
 from fixtures.events.events_ratios_fixtures import (
     event_ratio_percentage_cancellation_query,
@@ -123,4 +124,16 @@ class TestEventCheckin(BaseTestCase):
             self,
             checkin_mutation_for_event_existing_in_db,
             response_for_event_existing_in_db_checkin
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            event_checkin_mutation,
+            response_for_wrong_migration
         )

--- a/tests/test_events/test_event_checkin_with_database_error.py
+++ b/tests/test_events/test_event_checkin_with_database_error.py
@@ -1,0 +1,42 @@
+import sys
+import os
+from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
+from fixtures.events.event_checkin_fixtures import (
+    event_checkin_mutation,
+    cancel_event_mutation,
+)
+
+sys.path.append(os.getcwd())
+
+
+class TestEventCheckin(BaseTestCase):
+    def test_checkin_without_events_model(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE events CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            event_checkin_mutation,
+            "There seems to be a database connection error",
+        )
+
+    def test_cancel_without_events_model(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE events CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            cancel_event_mutation,
+            "There seems to be a database connection error",
+        )

--- a/tests/test_events/test_events_ratios.py
+++ b/tests/test_events/test_events_ratios.py
@@ -46,3 +46,25 @@ class TestEventRatios(BaseTestCase):
             event_ratio_per_room_query,
             event_ratio_per_room_response
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            event_ratio_query,
+            "The database cannot be reached"
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            event_ratio_for_one_day_query,
+            "The database cannot be reached"
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            event_ratio_per_room_query,
+            "The database cannot be reached"
+        )

--- a/tests/test_floors/test_create_floor.py
+++ b/tests/test_floors/test_create_floor.py
@@ -1,10 +1,12 @@
 from tests.base import BaseTestCase, CommonTestCases
 
+from helpers.database import engine, db_session
 from fixtures.floor.create_floor_fixtures import (
     create_floor_mutation, create_floor_mutation_response,
     floor_name_empty_mutation, floor_mutation_duplicate_name,
     floor_mutation_duplicate_name_response,
-    create_with_nonexistent_block_id
+    create_with_nonexistent_block_id,
+    response_for_create_floor_with_database_error
 )
 
 import sys
@@ -48,3 +50,28 @@ class TestCreateFloor(BaseTestCase):
             self,
             create_with_nonexistent_block_id,
             "Block not found")
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_floor_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_create_floors_without_floors_relation(self):
+        """
+        Testing for floor creation without floor relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE floors CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+          self,
+          create_floor_mutation,
+          response_for_create_floor_with_database_error
+        )

--- a/tests/test_floors/test_delete_floor.py
+++ b/tests/test_floors/test_delete_floor.py
@@ -1,8 +1,10 @@
 from tests.base import BaseTestCase, CommonTestCases
 
+from helpers.database import engine, db_session
 from fixtures.floor.delete_floor_fixtures import (
     delete_floor_mutation,
     delete_with_nonexistent_floor_id,
+    response_for_delete_floor_with_database_error
 )
 
 
@@ -26,4 +28,29 @@ class TestDeleteRoom(BaseTestCase):
             self,
             delete_with_nonexistent_floor_id,
             "Floor not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_floor_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_delete_floors_without_floors_relation(self):
+        """
+        Testing for floor creation without floor relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE floors CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+          self,
+          delete_floor_mutation,
+          response_for_delete_floor_with_database_error
         )

--- a/tests/test_floors/test_filter_by_block_database_error.py
+++ b/tests/test_floors/test_filter_by_block_database_error.py
@@ -1,0 +1,20 @@
+from tests.base import BaseTestCase, CommonTestCases
+
+from helpers.database import engine, db_session
+from fixtures.floor.filter_by_block_fixtures import (
+    filter_by_block_query,
+
+)
+
+
+class TestFilterByBlock(BaseTestCase):
+    def test_filter_rooms_in_block_with_database_error(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE floors CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            filter_by_block_query,
+            "There seems to be a database connection error"
+            )

--- a/tests/test_floors/test_query_with_database_error.py
+++ b/tests/test_floors/test_query_with_database_error.py
@@ -1,0 +1,32 @@
+from tests.base import BaseTestCase
+
+from helpers.database import engine, db_session
+from fixtures.floor.get_floors_fixures import (
+    get_all_floors_query,
+    paginated_floors_query,
+)
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestQueryFloors(BaseTestCase):
+    def test_query_paginated_floors_with_database_error(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE floors CASCADE")
+        paginated_floors = self.client.execute(paginated_floors_query)
+        self.assertIn(
+            "There seems to be a database connection error",
+            str(paginated_floors))
+
+    def test_query_all_floors_with_database_error(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE floors CASCADE")
+        all_floors = self.client.execute(get_all_floors_query)
+        self.assertIn(
+            "There seems to be a database connection error", str(all_floors))

--- a/tests/test_floors/test_update_floor.py
+++ b/tests/test_floors/test_update_floor.py
@@ -1,11 +1,13 @@
 from tests.base import BaseTestCase, CommonTestCases
 
+from helpers.database import engine, db_session
 from fixtures.floor.update_floor_fixtures import (
     update_floor_mutation,
     update_with_empty_field,
     update_with_nonexistent_floor_id,
     floor_mutation_duplicate_name,
-    floor_mutation_duplicate_name_response
+    floor_mutation_duplicate_name_response,
+    response_for_update_floor_with_database_error
 )
 
 
@@ -14,7 +16,7 @@ class TestUpdateFloor(BaseTestCase):
         CommonTestCases.admin_token_assert_in(
             self,
             update_floor_mutation,
-            "2nd"
+            "3rd"
         )
 
     def test_floor_update_with_name_empty(self):
@@ -36,3 +38,28 @@ class TestUpdateFloor(BaseTestCase):
             self,
             update_with_nonexistent_floor_id,
             "Floor not found")
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_floor_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_update_floors_without_floors_relation(self):
+        """
+        Testing for floor creation without floor relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE floors CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+          self,
+          update_floor_mutation,
+          response_for_update_floor_with_database_error
+        )

--- a/tests/test_location/test_create_location.py
+++ b/tests/test_location/test_create_location.py
@@ -1,7 +1,9 @@
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.location.create_location_fixtures import (
     create_location_query,
-    create_location_response)
+    create_location_response,
+    create_location_query_wrong_country,
+    create_location_query_wrong_time_zone,)
 
 import sys
 import os
@@ -25,3 +27,35 @@ class TestCreateLocation(BaseTestCase):
             self, create_location_query, create_location_response)
         CommonTestCases.admin_token_assert_in(
             self, create_location_query, 'New Location already exists')
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_location_query,
+            "The database cannot be reached"
+            )
+
+    def test_location_creation_with_invalid_country(self):
+        """
+        Testing for location creation
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_location_query_wrong_country,
+            "Not a valid country"
+        )
+
+    def test_location_creation_with_invalid_time_zone(self):
+        """
+        Testing for location creation
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_location_query_wrong_time_zone,
+            "Not a valid time zone"
+        )

--- a/tests/test_location/test_create_location_database_error.py
+++ b/tests/test_location/test_create_location_database_error.py
@@ -1,0 +1,24 @@
+from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
+from fixtures.location.create_location_fixtures import (
+    create_location_query,
+    response_for_create_location_with_database_error)
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestCreateLocation(BaseTestCase):
+    def test_create_location_without_location_relation(self):
+        """
+        Testing for floor creation without floor relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+          self,
+          create_location_query,
+          response_for_create_location_with_database_error
+        )

--- a/tests/test_location/test_delete_location.py
+++ b/tests/test_location/test_delete_location.py
@@ -1,8 +1,10 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.location.delete_location_fixtures import (
     delete_location_query,
     delete_location_response,
     delete_non_existent_location,
+    response_for_delete_location_with_database_error
 )
 
 
@@ -19,4 +21,29 @@ class TestDeleteLocation(BaseTestCase):
             self,
             delete_non_existent_location,
             "location not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_location_query,
+            "The database cannot be reached"
+            )
+
+    def test_delete_location_without_location_relation(self):
+        """
+        Testing for floor creation without floor relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+          self,
+          delete_location_query,
+          response_for_delete_location_with_database_error
         )

--- a/tests/test_location/test_query_location_with_database_error.py
+++ b/tests/test_location/test_query_location_with_database_error.py
@@ -1,0 +1,34 @@
+from tests.base import BaseTestCase
+
+from helpers.database import engine, db_session
+from fixtures.location.all_locations_fixtures import (
+    all_locations_query,
+)
+from fixtures.location.rooms_in_location_fixtures import (
+    query_get_rooms_in_location,
+)
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestQueryLocation(BaseTestCase):
+    def test_query_all_locations_without_location_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE floors CASCADE")
+        all_locations = self.client.execute(all_locations_query)
+        self.assertIn(
+            "There seems to be a database connection error", str(all_locations))
+
+    def test_query_rooms_in_a_location(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE floors CASCADE")
+        get_room_in_a_location = self.client.execute(query_get_rooms_in_location)  # noqa: E501
+        self.assertIn(
+            "There seems to be a database connection error",
+            str(get_room_in_a_location))

--- a/tests/test_location/test_update_location.py
+++ b/tests/test_location/test_update_location.py
@@ -1,8 +1,10 @@
 from tests.base import BaseTestCase, CommonTestCases
 
+from helpers.database import engine, db_session
 from fixtures.location.update_location_fixtures import (
     query_update_all_fields, query_location_id_non_existant,
-    expected_query_update_all_fields, expected_location_id_non_existant_query)
+    expected_query_update_all_fields, expected_location_id_non_existant_query,
+    response_for_update_location_with_database_error)
 
 
 class TestUpdateLocation(BaseTestCase):
@@ -16,4 +18,29 @@ class TestUpdateLocation(BaseTestCase):
             self,
             query_location_id_non_existant,
             expected_location_id_non_existant_query
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            query_update_all_fields,
+            "The database cannot be reached"
+            )
+
+    def test_update_location_without_location_relation(self):
+        """
+        Testing for floor creation without floor relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+          self,
+          query_update_all_fields,
+          response_for_update_location_with_database_error
         )

--- a/tests/test_notification/test_query_notification.py
+++ b/tests/test_notification/test_query_notification.py
@@ -1,4 +1,5 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.notification.notification_fixture import (
     user_notification_query,
     user_notification_response,
@@ -26,4 +27,15 @@ class TestNotification(BaseTestCase):
             self,
             update_user_notification_settings_query,
             update_user_notification_settings_response,
+        )
+
+    def test_get_user_notification_invalid_user(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DELETE FROM users")
+
+        CommonTestCases.admin_token_assert_in(
+            self,
+            user_notification_query,
+            "User not found",
         )

--- a/tests/test_office/test_create_office.py
+++ b/tests/test_office/test_create_office.py
@@ -2,12 +2,14 @@ import sys
 import os
 
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.office.office_fixtures import (
     office_mutation_query,
     office_mutation_query_Different_Location,
     office_mutation_query_non_existant_ID,
     office_mutation_query_duplicate_name,
-    office_mutation_query_duplicate_name_responce)
+    office_mutation_query_duplicate_name_responce,
+    response_for_create_office_with_database_error)
 
 sys.path.append(os.getcwd())
 
@@ -52,4 +54,26 @@ class TestCreateOffice(BaseTestCase):
             self,
             office_mutation_query_duplicate_name,
             office_mutation_query_duplicate_name_responce
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            office_mutation_query,
+            "The database cannot be reached"
+            )
+
+    def test_create_office_without_office_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE offices CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            office_mutation_query,
+            response_for_create_office_with_database_error
         )

--- a/tests/test_office/test_delete_office.py
+++ b/tests/test_office/test_delete_office.py
@@ -1,11 +1,13 @@
 import json
 
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.office.update_delete_office_fixture import (
     delete_office_mutation,
     delete_office_mutation_response,
     delete_non_existent_office_mutation,
-    delete_unauthorised_location_mutation
+    delete_unauthorised_location_mutation,
+    response_for_delete_office_with_database_error
 )
 from fixtures.token.token_fixture import ADMIN_TOKEN
 
@@ -30,4 +32,26 @@ class TestDeleteOffice(BaseTestCase):
         response = self.app_test.post('mrm?query='+delete_unauthorised_location_mutation,  # noqa: E501
                                       headers=headers)
         expected_response = json.loads(response.data)
-        self.assertIn("You are not authorized to make changes in Nairobi", expected_response['errors'][0]['message'])  # noqa: E501
+        self.assertIn("Office not found", expected_response['errors'][0]['message'])  # noqa: E501
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_office_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_delete_office_without_office_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE offices CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_office_mutation,
+            response_for_delete_office_with_database_error
+        )

--- a/tests/test_office/test_get_office_by_name.py
+++ b/tests/test_office/test_get_office_by_name.py
@@ -4,7 +4,9 @@ import os
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.office.office_fixtures import (
     get_office_by_name,
-    get_office_by_name_response)
+    get_office_by_name_response,
+    get_office_by_wrong_name,
+    get_office_by_name_epic_tower)
 
 sys.path.append(os.getcwd())
 
@@ -15,4 +17,18 @@ class GetOfficeByName(BaseTestCase):
             self,
             get_office_by_name,
             get_office_by_name_response
+        )
+
+    def test_get_office_with_wrong_office(self):
+        CommonTestCases.user_token_assert_in(
+            self,
+            get_office_by_wrong_name,
+            "Office Not found"
+        )
+
+    def test_get_office_by_name_epic_tower(self):
+        CommonTestCases.user_token_assert_in(
+            self,
+            get_office_by_name_epic_tower,
+            "Epic tower"
         )

--- a/tests/test_office/test_query_offices_with_a_database_error.py
+++ b/tests/test_office/test_query_offices_with_a_database_error.py
@@ -1,0 +1,32 @@
+import json
+
+from tests.base import BaseTestCase
+from helpers.database import engine, db_session
+from fixtures.office.office_fixtures import (
+    paginated_offices_query,
+    offices_query,
+    )
+
+
+class QueryOffice(BaseTestCase):
+    def test_paginate_office_query(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE offices CASCADE")
+        response = self.app_test.post('/mrm?query='+paginated_offices_query)
+        paginate_query = json.loads(response.data)
+        self.assertIn(
+            "There seems to be a database connection error",
+            str(paginate_query))
+
+    def test_office_query(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE offices CASCADE")
+        response = self.app_test.post('/mrm?query='+offices_query)
+        paginate_query = json.loads(response.data)
+        self.assertIn(
+            "There seems to be a database connection error",
+            str(paginate_query))

--- a/tests/test_office/test_update_office.py
+++ b/tests/test_office/test_update_office.py
@@ -2,12 +2,14 @@ import sys
 import os
 
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.office.update_delete_office_fixture import (
     update_office_in_another_location_query,
     update_office_with_wrong_ID_query,
     update_office_with_same_Name_query,
     update_office_query,
-    office_mutation_response
+    office_mutation_response,
+    response_for_update_office_with_database_error
     )
 sys.path.append(os.getcwd())
 
@@ -41,7 +43,7 @@ class TestUpdateOffice(BaseTestCase):
         CommonTestCases.admin_token_assert_in(
             self,
             update_office_with_same_Name_query,
-            "Action Failed"
+            "Dojo Office already exists"
         )
 
     def test_updating_office_in_another_location(self):
@@ -52,4 +54,26 @@ class TestUpdateOffice(BaseTestCase):
             self,
             update_office_in_another_location_query,
             "You are not authorized to make changes in"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_office_query,
+            "The database cannot be reached"
+            )
+
+    def test_update_office_without_office_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE offices CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_office_query,
+            response_for_update_office_with_database_error
         )

--- a/tests/test_questions/test_create_question.py
+++ b/tests/test_questions/test_create_question.py
@@ -1,12 +1,14 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.questions.create_questions_fixtures import (
    create_question_query,
    create_question_response,
    question_mutation_query_without_name,
    create_question_query_with_early_startDate,
-   create_question_query_with_early_endDate
+   create_question_query_with_early_endDate,
+   response_for_create_question_with_database_error
 )
 
 
@@ -58,4 +60,26 @@ class TestCreateBlock(BaseTestCase):
             self,
             create_question_query_with_early_endDate,
             'endDate should be at least a day after startDate'
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_question_query,
+            "The database cannot be reached"
+            )
+
+    def test_create_question_without_question_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE questions CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            create_question_query,
+            response_for_create_question_with_database_error
         )

--- a/tests/test_questions/test_delete_question.py
+++ b/tests/test_questions/test_delete_question.py
@@ -1,10 +1,12 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.questions.create_questions_fixtures import (
    delete_question_mutation,
    delete_question_response,
-   delete_question_invalidId
+   delete_question_invalidId,
+   response_for_delete_question_with_database_error
 )
 
 
@@ -32,4 +34,26 @@ class TestDeleteQuestion(BaseTestCase):
             self,
             delete_question_invalidId,
             "Question not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_question_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_delete_question_without_question_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE questions CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_question_mutation,
+            response_for_delete_question_with_database_error
         )

--- a/tests/test_questions/test_update_question.py
+++ b/tests/test_questions/test_update_question.py
@@ -1,11 +1,13 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.questions.create_questions_fixtures import (
    update_question_mutation,
    update_question_response,
    update_question_invalidId,
-   query_update_total_views_of_questions
+   query_update_total_views_of_questions,
+   response_for_update_question_with_database_error
 )
 
 
@@ -50,4 +52,26 @@ class TestUpdateQuestion(BaseTestCase):
             self,
             query_update_total_views_of_questions,
             '2'
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_question_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_update_question_without_question_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE questions CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_question_mutation,
+            response_for_update_question_with_database_error
         )

--- a/tests/test_questions/test_view_question.py
+++ b/tests/test_questions/test_view_question.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.questions.get_question_fixtures import (
     all_questions_query,
     all_questions_query_response,
@@ -9,6 +10,7 @@ from fixtures.questions.get_question_fixtures import (
     get_question_by_id_query,
     get_question_by_id_query_response,
     get_question_invalid_id_query,
+    response_for_wrong_migration
 )
 
 sys.path.append(os.getcwd())
@@ -36,6 +38,20 @@ class TestQueryQuestion(BaseTestCase):
             paginated_all_questions_query_response
         )
 
+    def test_paginated_all_questions_query_with_no_question(self):
+        """
+        Test getting paginated all questions
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE responses CASCADE")
+            conn.execute("DELETE FROM questions CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            paginated_all_questions_query,
+            "No questions found"
+        )
+
     def test_get_question_query(self):
         """
         Test getting a question using its id
@@ -53,3 +69,15 @@ class TestQueryQuestion(BaseTestCase):
             get_question_invalid_id_query,
             "Question does not exist"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            all_questions_query,
+            response_for_wrong_migration
+            )

--- a/tests/test_response/test_response_query.py
+++ b/tests/test_response/test_response_query.py
@@ -1,0 +1,41 @@
+import sys
+import os
+from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
+from fixtures.response.room_response_fixture import (
+   get_room_response_query,
+)
+
+
+sys.path.append(os.getcwd())
+
+
+class TestRoomResponse(BaseTestCase):
+
+    def test_room_response_with_no_feedback(self):
+        """
+        Testing for room response
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DELETE FROM missing_items CASCADE")
+            conn.execute("DELETE FROM responses CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            get_room_response_query,
+            "0"
+        )
+
+    def test_room_response_with_no_response_model(self):
+        """
+        Testing for room response
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE missing_items CASCADE")
+            conn.execute("DROP TABLE responses CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            get_room_response_query,
+            "error"
+        )

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -155,3 +155,30 @@ class TestRoomResponse(BaseTestCase):
             query_paginated_responses_empty_page,
             "Page does not exist"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            get_room_response_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            summary_room_response_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            filter_by_response_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            search_response_by_room_only,
+            "The database cannot be reached"
+            )

--- a/tests/test_role/test_create_role.py
+++ b/tests/test_role/test_create_role.py
@@ -1,11 +1,13 @@
 from tests.base import BaseTestCase
+from helpers.database import engine, db_session
 from fixtures.role.role_fixtures import (
     role_mutation_query, role_mutation_response,
-    role_duplication_mutation_response
+    role_duplication_mutation_response,
+    create_role_with_database_error_response
 )
-from helpers.database import db_session
 import sys
 import os
+import pprint
 sys.path.append(os.getcwd())
 
 
@@ -34,3 +36,17 @@ class TestCreateRole(BaseTestCase):
 
         expected_responese = role_duplication_mutation_response
         self.assertEqual(query_response, expected_responese)
+
+    def test_role_creation_with_database_error(self):
+        """
+        Testing creation of roles with database
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE roles CASCADE")
+        execute_query = self.client.execute(
+            role_mutation_query,
+            context_value={'session': db_session})
+        pprint.pprint(execute_query)
+        self.assertEqual(
+            create_role_with_database_error_response, execute_query)

--- a/tests/test_role/test_query_role_with_database_error.py
+++ b/tests/test_role/test_query_role_with_database_error.py
@@ -1,0 +1,49 @@
+from tests.base import BaseTestCase
+from fixtures.role.role_fixtures import (
+    role_query,
+    query_role_by_role,
+)
+from helpers.database import db_session, engine
+from api.role.models import Role
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestQueryRole(BaseTestCase):
+
+    def test_query_role(self):
+        """
+        Testing for User creation
+        """
+        role = Role(role='Ops')
+        role.save()
+        db_session().commit()
+
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE roles CASCADE")
+        execute_query = self.client.execute(
+            role_query,
+            context_value={'session': db_session})
+
+        self.assertIn(
+            "There seems to be a database connection error", str(execute_query))
+
+    def test_query_role_by_role(self):
+        role = Role(role='Ops')
+        role.save()
+        db_session().commit()
+
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+            conn.execute("DROP TABLE roles CASCADE")
+        execute_query = self.client.execute(
+            query_role_by_role,
+            context_value={'session': db_session})
+
+        self.assertIn(
+            "There seems to be a database connection error", str(execute_query))

--- a/tests/test_room_resource/test_create_room_resource.py
+++ b/tests/test_room_resource/test_create_room_resource.py
@@ -39,3 +39,15 @@ class TestCreateRoomResource(BaseTestCase):
             resource_mutation_0_room_id,
             "Room not found"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            resource_mutation_query,
+            "The database cannot be reached"
+            )

--- a/tests/test_room_resource/test_delete_resource.py
+++ b/tests/test_room_resource/test_delete_resource.py
@@ -3,8 +3,12 @@ import os
 
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room_resource.delete_room_resource import (  # noqa: F401
-  delete_resource, expected_query_after_delete, delete_non_existant_resource)  # noqa: E501
-from helpers.database import db_session  # noqa: F401
+  delete_resource,
+  expected_query_after_delete,
+  delete_non_existant_resource,
+  response_for_delete_room_resource_with_database_error
+  )
+from helpers.database import db_session, engine  # noqa: F401
 
 
 sys.path.append(os.getcwd())
@@ -23,7 +27,7 @@ class TestDeleteRoomResource(BaseTestCase):
         CommonTestCases.admin_token_assert_in(
             self,
             delete_resource,
-            "Markers"
+            "Resource not found"
         )
 
     def test_non_existant_deleteresource_mutation(self):
@@ -31,4 +35,26 @@ class TestDeleteRoomResource(BaseTestCase):
             self,
             delete_non_existant_resource,
             "Resource not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_resource,
+            "The database cannot be reached"
+            )
+
+    def test_delete_resource_without_resourse_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE resources CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_resource,
+            response_for_delete_room_resource_with_database_error
         )

--- a/tests/test_room_resource/test_get_resource_with_database_error.py
+++ b/tests/test_room_resource/test_get_resource_with_database_error.py
@@ -1,0 +1,44 @@
+import sys
+import os
+
+from tests.base import BaseTestCase
+from fixtures.room_resource.get_room_resource_fixtures import (
+    resource_query, get_room_resources_by_room_id,
+    filter_unique_resources,
+)
+from helpers.database import db_session, engine
+from fixtures.token.token_fixture import USER_TOKEN
+
+sys.path.append(os.getcwd())
+
+
+class TestGetRoomResource(BaseTestCase):
+    def test_get_room_resource_list(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE resources CASCADE")
+        execute_query = self.client.execute(
+            resource_query,
+            context_value={'session': db_session})
+        self.assertIn(
+            "There seems to be a database connection error", str(execute_query))
+
+    def test_get_room_resources_by_room_id(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE resources CASCADE")
+        execute_query = self.client.execute(
+            get_room_resources_by_room_id,
+            context_value={'session': db_session})
+        self.assertIn(
+            "relation \"resources\" does not exist", str(execute_query))
+
+    def test_get_unique_resources(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE resources CASCADE")
+        headers = {"Authorization": "Bearer" + " " + USER_TOKEN}
+        response = self.app_test.post(
+            '/mrm?query='+filter_unique_resources, headers=headers)
+        self.assertIn(
+            "There seems to be a database connection error", str(response.data))

--- a/tests/test_room_resource/test_update_resource_with_database_error.py
+++ b/tests/test_room_resource/test_update_resource_with_database_error.py
@@ -1,0 +1,22 @@
+from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import db_session, engine
+from fixtures.room_resource.update_resource_fixtures import (
+    update_room_resource_query,
+)
+
+import os
+import sys
+sys.path.append(os.getcwd())
+
+
+class TestUpdateRoomResorce(BaseTestCase):
+
+    def test_update_resource_without_resourse_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE resources CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_room_resource_query,
+            "There seems to be a database connection error"
+        )

--- a/tests/test_room_resource/test_update_room_resource.py
+++ b/tests/test_room_resource/test_update_room_resource.py
@@ -31,3 +31,15 @@ class TestUpdateRoomResorce(BaseTestCase):
             non_existant_resource_id_query,
             "Resource not found"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_room_resource_query,
+            "The database cannot be reached"
+            )

--- a/tests/test_rooms/test_delete_room.py
+++ b/tests/test_rooms/test_delete_room.py
@@ -1,8 +1,10 @@
 from tests.base import BaseTestCase, CommonTestCases
 
+from helpers.database import db_session, engine
 from fixtures.room.delete_room_fixtures import (
     delete_room_query,
     delete_room_query_non_existant_room_id,
+    response_for_delete_room_with_database_error
 )
 
 
@@ -26,4 +28,26 @@ class TestDeleteRoom(BaseTestCase):
             self,
             delete_room_query_non_existant_room_id,
             "Room not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_room_query,
+            "The database cannot be reached"
+            )
+
+    def test_delete_room_without_rooms_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE rooms CASCADE")
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_room_query,
+            response_for_delete_room_with_database_error
         )

--- a/tests/test_tags/test_create_tags.py
+++ b/tests/test_tags/test_create_tags.py
@@ -1,4 +1,5 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import db_session, engine
 from fixtures.tags.create_tags_fixtures import (
     create_tag_query,
     create_tag_response,
@@ -57,3 +58,32 @@ class TestCreateTag(BaseTestCase):
             update_non_existent_tag_mutation,
             update_non_existent_tag_response
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_tag_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.user_token_assert_in(
+            self,
+            update_tag_mutation,
+            "The database cannot be reached"
+        )
+
+    def test_create_tag_without_tags_model(self):
+        """
+        Test if a user can create a tag when there is a database error
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE tags CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_tag_query,
+            "There seems to be a database connection error")

--- a/tests/test_tags/test_delete_tags.py
+++ b/tests/test_tags/test_delete_tags.py
@@ -1,4 +1,5 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import db_session, engine
 from fixtures.tags.delete_tags_fixtures import (
   delete_tag_query,
   delete_tag_response,
@@ -20,3 +21,15 @@ class TestDeleteTag(BaseTestCase):
           delete_non_existent_tag,
           "Tag not found"
         )
+
+    def test_delete_tag_with_without_tags_model(self):
+        """
+        Test if a user can create a tag when there is a database error
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE tags CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_tag_query,
+            "There seems to be a database connection error")

--- a/tests/test_user/test_create_user.py
+++ b/tests/test_user/test_create_user.py
@@ -1,4 +1,5 @@
 from tests.base import BaseTestCase
+from helpers.database import db_session, engine
 from fixtures.user.user_fixture import (
     user_mutation_query, user_mutation_response,
     user_duplication_mutation_response
@@ -7,7 +8,6 @@ from fixtures.user.add_user_fixture import (
     non_Andela_email_mutation,
     non_Andela_email_mutation_response
 )
-from helpers.database import db_session
 
 import sys
 import os
@@ -49,3 +49,13 @@ class TestCreateUser(BaseTestCase):
             non_Andela_email_mutation,
             context_value={'session': db_session})
         self.assertEqual(query_response, non_Andela_email_mutation_response)
+
+    def test_create_user_without_user_model(self):
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE users CASCADE")
+        execute_query = self.client.execute(
+            user_mutation_query,
+            context_value={'session': db_session})
+        self.assertIn(
+            "There seems to be a database connection error", str(execute_query))

--- a/tests/test_user/test_delete_user.py
+++ b/tests/test_user/test_delete_user.py
@@ -2,6 +2,7 @@ import sys
 import os
 
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import db_session, engine
 from fixtures.user.delete_user import (
     delete_user, expected_query_after_delete, delete_self, user_not_found,
     delete_user_2, user_invalid_email)
@@ -69,4 +70,22 @@ class TestDeleteUser(BaseTestCase):
             self,
             user_invalid_email,
             "Invalid email format"
+        )
+
+    def test_delete_user_without_user_model(self):
+        user = User(email="test.test@andela.com",
+                    location="Kampala", name="test test",
+                    picture="www.andela.com/test")
+        user.save()
+        role = Role(role="Default User")
+        role.save()
+        user.roles.append(role)
+
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE users CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_user_2,
+            "The database cannot be reached"
         )

--- a/tests/test_user_roles/test_create_user_role_wrong_mutation.py
+++ b/tests/test_user_roles/test_create_user_role_wrong_mutation.py
@@ -1,0 +1,31 @@
+from tests.base import BaseTestCase
+from fixtures.user_role.user_role_fixtures import (
+    user_role_mutation_query,
+)
+from helpers.database import db_session, engine
+from api.user.models import User
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestCreateUserRole(BaseTestCase):
+    def test_create_user_role_with_wrong_mutation(self):
+        """
+        Testing for user role creation without role model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE roles CASCADE")
+        user = User(email="info@andela.com", location="Lagos",
+                    name="test test",
+                    picture="www.andela.com/test")
+        user.save()
+        db_session().commit()
+
+        execute_query = self.client.execute(
+            user_role_mutation_query,
+            context_value={'session': db_session})
+        self.assertIn(
+            "There seems to be a database connection error", str(execute_query))

--- a/tests/test_wing/test_create_wing.py
+++ b/tests/test_wing/test_create_wing.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import db_session, engine
 from fixtures.wing.wing_fixtures import (
     create_wing_mutation, create_wing_mutation_response,
     duplicate_wing_mutation,
@@ -85,4 +86,29 @@ class TestCreateWing(BaseTestCase):
             self,
             create_wing_floor_not_found,
             "Floor not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_wing_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_wing_creation_without_wings_model(self):
+        """
+        Testing for wing creation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE wings CASCADE")
+        CommonTestCases.lagos_admin_token_assert_in(
+            self,
+            create_wing_mutation,
+            "There seems to be a database connection error"
         )

--- a/tests/test_wing/test_delete_wing.py
+++ b/tests/test_wing/test_delete_wing.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import db_session, engine
 from fixtures.wing.wing_fixtures import (
     delete_wing_mutation,
     delete_wing_id_not_found,
@@ -40,4 +41,29 @@ class TestCreateWing(BaseTestCase):
             self,
             delete_wing_id_not_found,
             "Wing not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_wing_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_wing_deletion_without_wings_model(self):
+        """
+        Testing for wing creation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE wings CASCADE")
+        CommonTestCases.lagos_admin_token_assert_in(
+            self,
+            delete_wing_mutation,
+            "There seems to be a database connection error"
         )

--- a/tests/test_wing/test_update_wing.py
+++ b/tests/test_wing/test_update_wing.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import db_session, engine
 from fixtures.wing.wing_fixtures import (
     update_wing_mutation,
     update_duplicate_wing_mutation,
@@ -63,4 +64,29 @@ class TestCreateWing(BaseTestCase):
             self,
             update_wing_id_not_found,
             "Wing not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_wing_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_wing_update_without_wings_model(self):
+        """
+        Testing for wing creation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE wings CASCADE")
+        CommonTestCases.lagos_admin_token_assert_in(
+            self,
+            update_wing_mutation,
+            "There seems to be a database connection error"
         )

--- a/utilities/utility.py
+++ b/utilities/utility.py
@@ -55,13 +55,19 @@ class Utility(object):
 
     def save(self):
         """Function for saving new objects"""
-        db_session.add(self)
-        db_session.commit()
+        try:
+            db_session.add(self)
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
 
     def delete(self):
         """Function for deleting objects"""
-        db_session.delete(self)
-        db_session.commit()
+        try:
+            db_session.delete(self)
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
 
 
 class StateType(enum.Enum):


### PR DESCRIPTION
#### What does this PR do?
- [x] catch all sqlalchemy ProgrammingErrors
- [x] catch InternalErrors when server is down
- [x] display user friendly message for respective errors


#### Description of Task to be completed?
Display user-friendly messages such as "The database cannot be reached" when the app crashes due to a database error. 

#### How should this be manually tested?
- Pull this branch
- make the migrations as explained in the [README](https://github.com/andela/mrm_api/blob/develop/Readme.md)
- stop the server and try to run any mutation/query(to test for InternalError)
- delete a relation from the database and run a mutation that depends on that relation( to test for ProgrammingError)

### Below are the screenshots 
* initial error message for InternalErrors
<img width="1195" alt="screenshot 2019-02-19 at 16 37 02" src="https://user-images.githubusercontent.com/38909130/53020026-234c7580-3467-11e9-9cb6-434e36884ffa.png">

* new message for InternalErrors
<img width="1189" alt="screenshot 2019-02-19 at 16 55 45" src="https://user-images.githubusercontent.com/38909130/53020062-395a3600-3467-11e9-88e4-461caf09977d.png">


* initial message for programmingErrors
<img width="1195" alt="screenshot 2019-02-19 at 11 31 17" src="https://user-images.githubusercontent.com/38909130/53020097-4bd46f80-3467-11e9-9a20-7341e60ba954.png">


* new error message for programmingErrors
<img width="1193" alt="screenshot 2019-02-22 at 15 13 24" src="https://user-images.githubusercontent.com/38909130/53241996-82eb9080-36b4-11e9-99c6-80a812383061.png">




#### Any background context you want to provide?
`InternalError` is sometimes raised by drivers in the context of the database connection being dropped, or not being able to connect to the database.
ProgrammingError - Exception raised for programming errors, e.g. table not found or already exists, syntax error in the SQL statement, wrong number of parameters specified, etc.

#### What are the relevant pivotal tracker stories?

[#163754403](https://www.pivotaltracker.com/story/show/163754403)