### PR TITLE
#164167409 Enable admin to query feedback responses based on date range

### DIFF
--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -32,6 +32,67 @@ get_room_response_query_data = {
     }
 }
 
+get_room_response_query_by_date = '''
+query{
+    allRoomResponses(startDate: "2019 feb 20",
+     endDate: "2019 feb 25" ){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+get_room_response_query_with_invalid_date = '''
+query{
+    allRoomResponses(startDate: "2019 Dec 20",
+     endDate: "2019 Dec 25" ){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+get_room_response_query_with_higher_lower_limit = '''
+query{
+    allRoomResponses(startDate: "2019 feb 20",
+     endDate: "2019 feb 1" ){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+get_room_response_query_by_date_query = {
+  "data": {
+    "allRoomResponses": {
+      "responses": [
+        {
+          "totalResponses": 2,
+          "roomName": "Entebbe",
+          "response": []
+        }
+      ]
+    }
+  }
+}
+
+
 get_room_response_non_existence_room_id = '''{
     roomResponse(roomId:15) {
         roomName,
@@ -91,7 +152,7 @@ summary_room_response_data = {
 
 filter_by_response_query = '''
 query{
-    allRoomResponses(upperLimit: 2, lowerLimit: 0 ){
+    allRoomResponses(upperLimitCount: 3, lowerLimitCount: 0 ){
         responses{
             totalResponses
             roomName
@@ -106,7 +167,7 @@ query{
 
 filter_by_response_invalid_query = '''
 query{
-    allRoomResponses(upperLimit: 2){
+    allRoomResponses(upperLimitCount: 2){
         responses{
             totalResponses
             roomName
@@ -120,8 +181,8 @@ query{
 '''
 
 search_response_by_room_query = '''
-query{
-    allRoomResponses(upperLimit: 2, lowerLimit: 0, room:"Entebbe"){
+ query{
+    allRoomResponses(lowerLimitCount: 1, upperLimitCount: 3, room:"Entebbe"){
         responses{
             totalResponses
             roomName
@@ -136,7 +197,7 @@ query{
 
 search_response_by_room_beyond_limits_query = '''
 query{
-    allRoomResponses(upperLimit: 7, lowerLimit: 5, room:"Entebbe"){
+    allRoomResponses(upperLimitCount: 7, lowerLimitCount: 5, room:"Entebbe"){
         responses{
             totalResponses
             roomName
@@ -151,7 +212,7 @@ query{
 
 search_response_by_room_invalid_room_query = '''
 query{
-    allRoomResponses(upperLimit: 2, lowerLimit: 0, room:"Entebbes"){
+    allRoomResponses(upperLimitCount: 2, lowerLimitCount: 0, room:"Entebbes"){
         responses{
             totalResponses
             roomName
@@ -181,7 +242,7 @@ query{
 
 search_response_by_invalid_room = '''
 query{
-    allRoomResponses(room:"Entebbes"){
+    allRoomResponses(room:"Mubende"){
         responses{
             totalResponses
             roomName

--- a/helpers/response/query_response.py
+++ b/helpers/response/query_response.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from graphql import GraphQLError
+from utilities.validations import validate_date_range
+
+
+def filter_rooms_by_responses(
+    Query, info, upper_limit_count, lower_limit_count
+):
+    all_responses = Query().get_all_reponses(info)
+    filtered_responses = []
+    for response in all_responses:
+        reponse_count = response.total_responses
+        if lower_limit_count <= reponse_count <= upper_limit_count:
+            filtered_responses.append(response)
+    return filtered_responses
+
+
+def filter_response_by_date(Query, info, end_date, start_date):
+    all_responses = Query().get_all_reponses(info)
+    filtered_responses = []
+    for responses in all_responses:
+        for response in responses.response:
+            validate_response_dates(
+                response,
+                end_date, start_date, filtered_responses
+            )
+        setattr(responses, 'response', filtered_responses)
+        filtered_responses = []
+    return all_responses
+
+
+def validate_response_dates(
+    response, end_date, start_date, filtered_responses
+):
+    end_date = datetime.strptime(end_date, '%Y %b %d')
+    start_date = datetime.strptime(start_date, '%Y %b %d')
+    validate_date_range(
+        end_date=end_date, start_date=start_date
+    )
+    if (response.created_date < end_date and
+            response.created_date > start_date):
+        filtered_responses.append(response)
+    return filtered_responses
+
+
+def check_limits_are_provided(lower_limit, upper_limit, typ):
+    if (
+      (isinstance(lower_limit, typ)
+          and not isinstance(upper_limit, typ))
+      or (isinstance(upper_limit, typ)
+            and not isinstance(lower_limit, typ))):
+        raise GraphQLError(
+            "Provide upper and lower limits to filter")
+
+
+def validate_responses_by_room(obj, function, **kwargs):
+    if ((isinstance(kwargs['upper_limit'], obj)) and kwargs['upper_limit']
+            and kwargs['lower_limit']):
+        filtered_response = function(
+            kwargs['Query'], kwargs['info'], kwargs['upper_limit'],
+            kwargs['lower_limit'])
+        for room_response in filtered_response:
+            if room_response.room_name.lower() == kwargs['room'].lower():
+                kwargs['filtered_search'].append(room_response)
+        if kwargs['filtered_search']:
+            return kwargs['filtered_search']
+        else:
+            raise GraphQLError(
+                "No response for this room at this range")
+
+
+def check_response_and_room(*args):
+    typ, info, room, upper_limit, lower_limit, responses, Query = args
+    if (isinstance(upper_limit, typ)
+            and isinstance(lower_limit, typ) and room):
+        responses = Query().search_response_by_room(
+            info, upper_limit, lower_limit, room
+        )
+    return responses
+
+
+def filter_responses(typ, function, *args,):
+    upper_limit, lower_limit, Query, info, responses = args
+    if (isinstance(upper_limit, typ)
+            and isinstance(lower_limit, typ)):
+        responses = function(
+            Query, info, upper_limit,
+            lower_limit
+        )
+    return responses

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -4,6 +4,7 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.response.room_response_fixture import (
    get_room_response_query,
    get_room_response_query_data,
+   get_room_response_query_by_date,
    get_room_response_non_existence_room_id,
    search_response_by_room_invalid_room_query,
    search_response_by_room_query,
@@ -17,7 +18,10 @@ from fixtures.response.room_response_fixture import (
    filter_by_response_data,
    query_paginated_responses,
    query_paginated_responses_response,
-   query_paginated_responses_empty_page
+   query_paginated_responses_empty_page,
+   get_room_response_query_by_date_query,
+   get_room_response_query_with_invalid_date,
+   get_room_response_query_with_higher_lower_limit
 )
 
 
@@ -78,7 +82,7 @@ class TestRoomResponse(BaseTestCase):
         CommonTestCases.admin_token_assert_in(
             self,
             filter_by_response_invalid_query,
-            "Provide upper and lower limits to filter by response number"
+            "Provide upper and lower limits to filter"
         )
 
     def test_filter_search_response_room_name(self):
@@ -156,6 +160,36 @@ class TestRoomResponse(BaseTestCase):
             "Page does not exist"
         )
 
+    def test_room_response_with_date_range(self):
+        """
+        Testing for room response with date range
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_room_response_query_by_date,
+            get_room_response_query_by_date_query
+        )
+
+    def test_room_response_with_invalid_date(self):
+        """
+        Testing for room response with invalid/ future dates
+        """
+        CommonTestCases.admin_token_assert_in(
+                self,
+                get_room_response_query_with_invalid_date,
+                "Dates should be before today"
+            )
+
+    def test_room_with_invalid_date_difference(self):
+        """
+        Testing for room response with higher lower limit
+        """
+        CommonTestCases.admin_token_assert_in(
+                self,
+                get_room_response_query_with_higher_lower_limit,
+                "Earlier date should be lower than later date"
+            )
+
     def test_database_connection_error(self):
         """
         test a user friendly message is returned to a user when database
@@ -181,4 +215,4 @@ class TestRoomResponse(BaseTestCase):
             self,
             search_response_by_room_only,
             "The database cannot be reached"
-            )
+        )

--- a/utilities/validations.py
+++ b/utilities/validations.py
@@ -79,3 +79,17 @@ def validate_question_type(**kwargs):
         type = kwargs['question_type']
         if type.lower() not in question_types:
             raise AttributeError("Not a valid question type")
+
+
+def validate_date_range(**kwargs):
+    """
+    Function to validate the date range
+    :params kwargs
+    """
+    if (('end_date' and 'start_date' in kwargs) and
+        kwargs['end_date'] > datetime.datetime.now() or
+            kwargs['start_date'] > datetime.datetime.now()):
+        raise ValueError('Dates should be before today')
+    elif (('end_date' and 'start_date' in kwargs) and
+            kwargs['end_date'] < kwargs['start_date']):
+        raise ValueError('Earlier date should be lower than later date')


### PR DESCRIPTION
#### What does this PR do?
Enable admin to query feedback responses based on date range

#### Description of Task to be completed?
- Currently, when querying responses, one can not query responses by date. This PR allows an admin to query responses by date range. 
- The query can also be run with a `room`  as shown below
- The code has been refactored to cater for both `date range` and `count range` since the functionality is almost similar

#### How should this be manually tested?
- Pull this branch `ft-query-responses-with-data-range-164167409`
- Run the following query
```
query{
    allRoomResponses(startDate: "2019 feb 20", endDate: "2019 feb 25" ){
        responses{
            totalResponses
            roomName
            response{
                responseId
                missingItems
            }
        }
    }
}
```
or 

```
query{
    allRoomResponses(startDate: "2019 feb 20",  endDate: "2019 feb 25", room: "Entebbe" ){
        responses{
            totalResponses
            roomName
            response{
                responseId
                missingItems
            }
        }
    }
}
```
You should be able to query all the responses that fall between that date range.

#### Any background context you want to provide?
This is an extension to query all responses.

#### What are the relevant pivotal tracker stories?
[#164167409](https://www.pivotaltracker.com/story/show/164167409)

#### Screenshots (if appropriate)
**Before**
![screen shot 2019-02-28 at 6 44 21 am](https://user-images.githubusercontent.com/22786444/53539960-ae430500-3b24-11e9-92b0-178fd3fc0437.png)

**After**
![screen shot 2019-02-28 at 6 45 15 am](https://user-images.githubusercontent.com/22786444/53539971-b733d680-3b24-11e9-8ac3-cf1ebeb5a8ba.png)
 
This screenshot shows date range for a specific room
![screen shot 2019-02-28 at 8 35 53 pm](https://user-images.githubusercontent.com/22786444/53595652-dc6d2700-3bae-11e9-988a-49d011f25adb.png)

