### PR TITLE
#163754403 Display friendly message when app crashes due to database errors

### DIFF
--- a/fixtures/location/create_location_fixtures.py
+++ b/fixtures/location/create_location_fixtures.py
@@ -8,6 +8,26 @@ create_location_query = '''
 }
 '''
 
+create_location_query_wrong_country = '''
+    mutation {
+  createLocation(name: "New", abbreviation: "KLA", country: "Tanzania", timeZone: "EAST_AFRICA_TIME", imageUrl:"https://lala.com") {   # noqa E501
+    location {
+      name
+    }
+  }
+}
+'''
+
+create_location_query_wrong_time_zone = '''
+    mutation {
+  createLocation(name: "New", abbreviation: "KLA", country: "Uganda", timeZone: "EAST_TIME", imageUrl:"https://lala.com") {   # noqa E501
+    location {
+      name
+    }
+  }
+}
+'''
+
 create_location_response = {
     "data": {
         "createLocation": {

--- a/helpers/auth/authentication.py
+++ b/helpers/auth/authentication.py
@@ -102,7 +102,10 @@ class Authentication:
                 if type(user_data) is dict:
                     self.save_user()
                     email = user_data['email']
-                    user = User.query.filter_by(email=email).first()
+                    try:
+                        user = User.query.filter_by(email=email).first()
+                    except Exception:
+                        raise GraphQLError("The database cannot be reached")
                     headers = {"Authorization": 'Bearer ' + self.get_token()}
                     try:
                         if(os.getenv('APP_SETTINGS') == "testing"):

--- a/templates/office_success.html
+++ b/templates/office_success.html
@@ -54,7 +54,7 @@
                 <div class="contact" style="box-sizing: border-box;height: 54.32px;width: 490px;font-family: 'DINPro', 'Roboto', sans-serif, sans-serif;color: #000000;font-size: 16px;line-height: 27px;padding-top: 39px;padding-bottom: 39px;margin: auto;text-align: center;">
                     <p style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;">
                         Have a question?
-                        <br style="box-sizing: border-box;"> <a href="#" style="box-sizing: border-box;color: #007bff;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
+                        <br style="box-sizing: border-box;"> <a href="mailto:support@converge.com" style="box-sizing: border-box;color: #007bff;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
                             support@converge.com</a>
                     </p>
                 </div>

--- a/tests/test_block/test_create_delete_update_block_error.py
+++ b/tests/test_block/test_create_delete_update_block_error.py
@@ -1,0 +1,36 @@
+import sys
+import os
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.block.create_block_fixtures import (
+    create_block_query,
+    update_block,
+    delete_block,
+)
+
+
+sys.path.append(os.getcwd())
+
+
+class TestCreateBlockError(BaseTestCase):
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_block_query,
+            "The database cannot be reached"
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_block,
+            "The database cannot be reached"
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_block,
+            "The database cannot be reached"
+        )

--- a/tests/test_devices/test_create_device.py
+++ b/tests/test_devices/test_create_device.py
@@ -42,3 +42,13 @@ class TestCreateDevice(BaseTestCase):
             create_device_query_invalid_room,
             "Room not found"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        headers = {"Authorization": "Bearer" + " " + ADMIN_TOKEN}
+        query = self.app_test.post(devices_query, headers=headers)
+        self.assertIn("The database cannot be reached", str(query.data))

--- a/tests/test_devices/test_update_device.py
+++ b/tests/test_devices/test_update_device.py
@@ -1,4 +1,5 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.devices.devices_fixtures import (
     update_device_query,
     query_with_non_existant_id,
@@ -18,4 +19,29 @@ class TestUpdateDevices(BaseTestCase):
             self,
             query_with_non_existant_id,
             "DeviceId not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_device_query,
+            "The database cannot be reached"
+        )
+
+    def test_update_device_without_devices_model(self):
+        """
+        test a user cannot update a device when the device model is missing
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE devices CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_device_query,
+            "does not exist"
         )

--- a/tests/test_events/test_event_checkin.py
+++ b/tests/test_events/test_event_checkin.py
@@ -124,3 +124,27 @@ class TestEventCheckin(BaseTestCase):
             checkin_mutation_for_event_existing_in_db,
             response_for_event_existing_in_db_checkin
         )
+
+    def test_checkin_without_events_model(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            event_checkin_mutation,
+            "does not exist",
+        )
+
+    def test_cancel_without_events_model(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            cancel_event_mutation,
+            "does not exist",
+        )

--- a/tests/test_events/test_events_ratios.py
+++ b/tests/test_events/test_events_ratios.py
@@ -46,3 +46,25 @@ class TestEventRatios(BaseTestCase):
             event_ratio_per_room_query,
             event_ratio_per_room_response
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            event_ratio_query,
+            "The database cannot be reached"
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            event_ratio_for_one_day_query,
+            "The database cannot be reached"
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            event_ratio_per_room_query,
+            "The database cannot be reached"
+        )

--- a/tests/test_floors/test_create_floor.py
+++ b/tests/test_floors/test_create_floor.py
@@ -1,5 +1,6 @@
 from tests.base import BaseTestCase, CommonTestCases
 
+from helpers.database import engine, db_session
 from fixtures.floor.create_floor_fixtures import (
     create_floor_mutation, create_floor_mutation_response,
     floor_name_empty_mutation, floor_mutation_duplicate_name,
@@ -48,3 +49,28 @@ class TestCreateFloor(BaseTestCase):
             self,
             create_with_nonexistent_block_id,
             "Block not found")
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_floor_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_create_floors_without_floors_relation(self):
+        """
+        Test a user cannot create a floor without floor relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE floors CASCADE")
+        CommonTestCases.admin_token_assert_in(
+          self,
+          create_floor_mutation,
+          "does not exist"
+        )

--- a/tests/test_floors/test_delete_floor.py
+++ b/tests/test_floors/test_delete_floor.py
@@ -1,5 +1,6 @@
 from tests.base import BaseTestCase, CommonTestCases
 
+from helpers.database import engine, db_session
 from fixtures.floor.delete_floor_fixtures import (
     delete_floor_mutation,
     delete_with_nonexistent_floor_id,
@@ -26,4 +27,29 @@ class TestDeleteRoom(BaseTestCase):
             self,
             delete_with_nonexistent_floor_id,
             "Floor not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_floor_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_delete_floors_without_floors_relation(self):
+        """
+        Test a user cannot delete a floor without floor relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE floors CASCADE")
+        CommonTestCases.admin_token_assert_in(
+          self,
+          delete_floor_mutation,
+          "does not exist"
         )

--- a/tests/test_floors/test_update_floor.py
+++ b/tests/test_floors/test_update_floor.py
@@ -1,5 +1,6 @@
 from tests.base import BaseTestCase, CommonTestCases
 
+from helpers.database import engine, db_session
 from fixtures.floor.update_floor_fixtures import (
     update_floor_mutation,
     update_with_empty_field,
@@ -42,3 +43,28 @@ class TestUpdateFloor(BaseTestCase):
             self,
             update_floor_mutation,
             "You are not authorized to make changes in Kampala")
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_floor_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_update_floors_without_floors_relation(self):
+        """
+        Test a user cannot delete a floor without floor relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE floors CASCADE")
+        CommonTestCases.admin_token_assert_in(
+          self,
+          update_floor_mutation,
+          "does not exist"
+        )

--- a/tests/test_location/test_create_location.py
+++ b/tests/test_location/test_create_location.py
@@ -1,10 +1,13 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.location.create_location_fixtures import (
     create_location_query,
     create_location_response,
     create_location_with_invalid_url,
     create_duplicate_location_query,
-    create_location_with_invalid_timezone)
+    create_location_with_invalid_timezone,
+    create_location_query_wrong_country,
+    create_location_query_wrong_time_zone)
 
 import sys
 import os
@@ -46,3 +49,48 @@ class TestCreateLocation(BaseTestCase):
             self,
             create_duplicate_location_query,
             'Kampala Location already exists')
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_location_query,
+            "The database cannot be reached"
+            )
+
+    def test_location_creation_with_invalid_country(self):
+        """
+        Test a location cannot be created with invalid country
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_location_query_wrong_country,
+            "Not a valid country"
+        )
+
+    def test_location_creation_with_invalid_time_zone(self):
+        """
+        Test a location cannot be created with invalid zone
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_location_query_wrong_time_zone,
+            "Not a valid time zone"
+        )
+
+    def test_create_location_without_locations_model(self):
+        """
+        Test a user cannot create a location without location relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_location_query,
+            "does not exist"
+        )

--- a/tests/test_location/test_delete_location.py
+++ b/tests/test_location/test_delete_location.py
@@ -1,4 +1,5 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.location.delete_location_fixtures import (
     delete_location_query,
     delete_location_response,
@@ -19,4 +20,29 @@ class TestDeleteLocation(BaseTestCase):
             self,
             delete_non_existent_location,
             "location not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_location_query,
+            "The database cannot be reached"
+            )
+
+    def test_delete_location_without_location_relation(self):
+        """
+        Test a user cannot delete a location without location relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+        CommonTestCases.admin_token_assert_in(
+          self,
+          delete_location_query,
+          "does not exist"
         )

--- a/tests/test_location/test_update_location.py
+++ b/tests/test_location/test_update_location.py
@@ -1,5 +1,6 @@
 from tests.base import BaseTestCase, CommonTestCases
 
+from helpers.database import engine, db_session
 from fixtures.location.update_location_fixtures import (
     query_update_all_fields, query_location_id_non_existant,
     expected_query_update_all_fields, expected_location_id_non_existant_query,
@@ -31,5 +32,29 @@ class TestUpdateLocation(BaseTestCase):
         CommonTestCases.admin_token_assert_in(
             self,
             query_update_location_invalid_image_url,
-            "Please enter a valid image url"
+            "Please enter a valid image url")
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            query_update_all_fields,
+            "The database cannot be reached"
+            )
+
+    def test_update_location_without_location_relation(self):
+        """
+        Test a user cannot update a location without location relation
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE locations CASCADE")
+        CommonTestCases.admin_token_assert_in(
+          self,
+          query_update_all_fields,
+          "does not exist"
         )

--- a/tests/test_office/test_create_delete_update_office_database_error.py
+++ b/tests/test_office/test_create_delete_update_office_database_error.py
@@ -1,0 +1,49 @@
+from helpers.database import engine, db_session
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.office.update_delete_office_fixture import (
+    delete_office_mutation,
+    update_office_query,
+)
+from fixtures.office.office_fixtures import (
+    office_mutation_query)
+
+
+class TestDeleteOffice(BaseTestCase):
+    def test_delete_office_without_office_model(self):
+        """
+        test for unsuccessful floor deletion without office model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE offices CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_office_mutation,
+            "does not exist"
+        )
+
+    def test_update_office_without_office_model(self):
+        """
+        test for unsuccessful floor update without office model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE offices CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_office_query,
+            "does not exist"
+        )
+
+    def test_create_office_without_office_model(self):
+        """
+        test for unsuccessful floor creation without office model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE offices CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            office_mutation_query,
+            "does not exist"
+        )

--- a/tests/test_office/test_create_office.py
+++ b/tests/test_office/test_create_office.py
@@ -53,3 +53,15 @@ class TestCreateOffice(BaseTestCase):
             office_mutation_query_duplicate_name,
             office_mutation_query_duplicate_name_responce
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            office_mutation_query,
+            "The database cannot be reached"
+            )

--- a/tests/test_office/test_delete_office.py
+++ b/tests/test_office/test_delete_office.py
@@ -31,3 +31,15 @@ class TestDeleteOffice(BaseTestCase):
                                       headers=headers)
         expected_response = json.loads(response.data)
         self.assertIn("You are not authorized to make changes in Nairobi", expected_response['errors'][0]['message'])  # noqa: E501
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_office_mutation,
+            "The database cannot be reached"
+            )

--- a/tests/test_office/test_update_office.py
+++ b/tests/test_office/test_update_office.py
@@ -53,3 +53,15 @@ class TestUpdateOffice(BaseTestCase):
             update_office_in_another_location_query,
             "You are not authorized to make changes in"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_office_query,
+            "The database cannot be reached"
+            )

--- a/tests/test_questions/test_create_question.py
+++ b/tests/test_questions/test_create_question.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.questions.create_questions_fixtures import (
    create_question_query,
    create_question_response,
@@ -58,4 +59,29 @@ class TestCreateBlock(BaseTestCase):
             self,
             create_question_query_with_early_endDate,
             'endDate should be at least a day after startDate'
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_question_query,
+            "The database cannot be reached"
+            )
+
+    def test_create_question_without_question_model(self):
+        """
+        test question cannot be created without questions model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE questions CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_question_query,
+            "does not exist"
         )

--- a/tests/test_questions/test_delete_question.py
+++ b/tests/test_questions/test_delete_question.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.questions.create_questions_fixtures import (
    delete_question_mutation,
    delete_question_response,
@@ -32,4 +33,29 @@ class TestDeleteQuestion(BaseTestCase):
             self,
             delete_question_invalidId,
             "Question not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_question_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_delete_question_without_question_model(self):
+        """
+        test question cannot be deleted without questions model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE questions CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_question_mutation,
+            "does not exist"
         )

--- a/tests/test_questions/test_update_question.py
+++ b/tests/test_questions/test_update_question.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.questions.create_questions_fixtures import (
    update_question_mutation,
    update_question_response,
@@ -50,4 +51,29 @@ class TestUpdateQuestion(BaseTestCase):
             self,
             query_update_total_views_of_questions,
             '2'
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_question_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_update_question_without_question_model(self):
+        """
+        test question cannot be updated without questions model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE questions CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_question_mutation,
+            "does not exist"
         )

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -155,3 +155,30 @@ class TestRoomResponse(BaseTestCase):
             query_paginated_responses_empty_page,
             "Page does not exist"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            get_room_response_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            summary_room_response_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            filter_by_response_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            search_response_by_room_only,
+            "The database cannot be reached"
+            )

--- a/tests/test_room_resource/test_create_delete_update_resource_database_error.py
+++ b/tests/test_room_resource/test_create_delete_update_resource_database_error.py
@@ -1,0 +1,54 @@
+from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
+from fixtures.room_resource.room_resource_fixtures import (
+    resource_mutation_query,
+)
+from fixtures.room_resource.update_resource_fixtures import (
+    update_room_resource_query,)
+from fixtures.room_resource.delete_room_resource import (
+  delete_resource,)
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestCreateRoomResourceError(BaseTestCase):
+    def test_create_resource_without_resourse_model(self):
+        """
+        test for unsuccessful resource creation without resource model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE resources CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            resource_mutation_query,
+            "does not exist"
+        )
+
+    def test_delete_resource_without_resourse_model(self):
+        """
+        test for unsuccessful resource deletion without resource model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE resources CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_resource,
+            "does not exist"
+        )
+
+    def test_update_resource_without_resourse_model(self):
+        """
+        test for unsuccessful resource update without resource model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE resources CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_room_resource_query,
+            "does not exist"
+        )

--- a/tests/test_room_resource/test_create_room_resource.py
+++ b/tests/test_room_resource/test_create_room_resource.py
@@ -50,3 +50,15 @@ class TestCreateRoomResource(BaseTestCase):
             resource_mutation_query,
             "You are not authorized to make changes in Kampala"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            resource_mutation_query,
+            "The database cannot be reached"
+            )

--- a/tests/test_room_resource/test_delete_resource.py
+++ b/tests/test_room_resource/test_delete_resource.py
@@ -4,7 +4,6 @@ import os
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room_resource.delete_room_resource import (  # noqa: F401
   delete_resource, expected_query_after_delete, delete_non_existant_resource)  # noqa: E501
-from helpers.database import db_session  # noqa: F401
 
 
 sys.path.append(os.getcwd())
@@ -39,3 +38,15 @@ class TestDeleteRoomResource(BaseTestCase):
             delete_resource,
             "You are not authorized to make changes in Kampala"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_resource,
+            "The database cannot be reached"
+            )

--- a/tests/test_room_resource/test_update_room_resource.py
+++ b/tests/test_room_resource/test_update_room_resource.py
@@ -38,3 +38,15 @@ class TestUpdateRoomResorce(BaseTestCase):
             update_room_resource_query,
             "You are not authorized to make changes in Kampala"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_room_resource_query,
+            "The database cannot be reached"
+            )

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -113,3 +113,14 @@ class TestCreateRoom(BaseTestCase):
             room_duplicate_calender_id_mutation_query,
             room_duplicate_calendar_id_mutation_response
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        headers = {"Authorization": "Bearer" + " " + ADMIN_TOKEN}
+
+        query = self.app_test.post(query_string, headers=headers)
+        self.assertIn("The database cannot be reached", str(query.data))

--- a/tests/test_rooms/test_delete_room.py
+++ b/tests/test_rooms/test_delete_room.py
@@ -27,3 +27,15 @@ class TestDeleteRoom(BaseTestCase):
             delete_room_query_non_existant_room_id,
             "Room not found"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_room_query,
+            "The database cannot be reached"
+            )

--- a/tests/test_rooms/test_update_room.py
+++ b/tests/test_rooms/test_update_room.py
@@ -41,3 +41,15 @@ class TestUpdateRoom(BaseTestCase):
             self,
             update_with_empty_field,
             "name is required field")
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            query_update_all_fields,
+            "The database cannot be reached"
+            )

--- a/tests/test_tags/test_create_tags.py
+++ b/tests/test_tags/test_create_tags.py
@@ -1,4 +1,5 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.tags.create_tags_fixtures import (
     create_tag_query,
     create_tag_response,
@@ -57,3 +58,32 @@ class TestCreateTag(BaseTestCase):
             update_non_existent_tag_mutation,
             update_non_existent_tag_response
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_tag_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.user_token_assert_in(
+            self,
+            update_tag_mutation,
+            "The database cannot be reached"
+        )
+
+    def test_create_tag_without_tags_model(self):
+        """
+        Test a user cannot create a tag when a tags model is missing
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE tags CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_tag_query,
+            "does not exist")

--- a/tests/test_tags/test_delete_tags.py
+++ b/tests/test_tags/test_delete_tags.py
@@ -1,4 +1,5 @@
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.tags.delete_tags_fixtures import (
   delete_tag_query,
   delete_tag_response,
@@ -20,3 +21,27 @@ class TestDeleteTag(BaseTestCase):
           delete_non_existent_tag,
           "Tag not found"
         )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_tag_query,
+            "The database cannot be reached"
+            )
+
+    def test_delete_tag_without_tags_model(self):
+        """
+        Test if a user can create a tag when tags model is missing
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE tags CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_tag_query,
+            "does not exist")

--- a/tests/test_user/test_create_user.py
+++ b/tests/test_user/test_create_user.py
@@ -7,7 +7,7 @@ from fixtures.user.add_user_fixture import (
     non_Andela_email_mutation,
     non_Andela_email_mutation_response
 )
-from helpers.database import db_session
+from helpers.database import db_session, engine
 
 import sys
 import os
@@ -49,3 +49,16 @@ class TestCreateUser(BaseTestCase):
             non_Andela_email_mutation,
             context_value={'session': db_session})
         self.assertEqual(query_response, non_Andela_email_mutation_response)
+
+    def test_user_creation_without_user_model(self):
+        """
+        Test a user cannot be created without a user model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE users CASCADE")
+        execute_query = self.client.execute(
+            user_mutation_query,
+            context_value={'session': db_session})
+
+        self.assertIn("does not exist", str(execute_query))

--- a/tests/test_user/test_delete_user.py
+++ b/tests/test_user/test_delete_user.py
@@ -2,6 +2,7 @@ import sys
 import os
 
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.user.delete_user import (
     delete_user, expected_query_after_delete, delete_self, user_not_found,
     delete_user_2, user_invalid_email)
@@ -69,4 +70,25 @@ class TestDeleteUser(BaseTestCase):
             self,
             user_invalid_email,
             "Invalid email format"
+        )
+
+    def test_delete_user_without_user_model(self):
+        """
+        Test a user cannot be deleted without a user model
+        """
+        user = User(email="test.test@andela.com",
+                    location="Kampala", name="test test",
+                    picture="www.andela.com/test")
+        user.save()
+        role = Role(role="Default User")
+        role.save()
+        user.roles.append(role)
+
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE users CASCADE")
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_user_2,
+            "The database cannot be reached"
         )

--- a/tests/test_user_roles/test_create_user_with_database_error.py
+++ b/tests/test_user_roles/test_create_user_with_database_error.py
@@ -1,0 +1,31 @@
+from tests.base import BaseTestCase
+from fixtures.user_role.user_role_fixtures import (
+    user_role_mutation_query
+)
+from helpers.database import db_session, engine
+from api.user.models import User
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestCreateUserRole(BaseTestCase):
+    def test_user_role_creation_without_users_model(self):
+        """
+        Test a user role cannot be created without a users model
+        """
+        user = User(email="info@andela.com", location="Lagos",
+                    name="test test",
+                    picture="www.andela.com/test")
+        user.save()
+        db_session().commit()
+
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE users CASCADE")
+        execute_query = self.client.execute(
+            user_role_mutation_query,
+            context_value={'session': db_session})
+
+        self.assertIn("The database cannot be reached", str(execute_query))

--- a/tests/test_wing/test_create_wing.py
+++ b/tests/test_wing/test_create_wing.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.wing.wing_fixtures import (
     create_wing_mutation, create_wing_mutation_response,
     duplicate_wing_mutation,
@@ -85,4 +86,29 @@ class TestCreateWing(BaseTestCase):
             self,
             create_wing_floor_not_found,
             "Floor not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            create_wing_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_wing_creation_without_wings_model(self):
+        """
+        Test a wing cannot be created without a wings model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE wings CASCADE")
+        CommonTestCases.lagos_admin_token_assert_in(
+            self,
+            create_wing_mutation,
+            "does not exist"
         )

--- a/tests/test_wing/test_delete_wing.py
+++ b/tests/test_wing/test_delete_wing.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.wing.wing_fixtures import (
     delete_wing_mutation,
     delete_wing_id_not_found,
@@ -40,4 +41,29 @@ class TestCreateWing(BaseTestCase):
             self,
             delete_wing_id_not_found,
             "Wing not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_wing_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_wing_deletion_without_wings_model(self):
+        """
+        Test a wing cannot be deleted without a wings model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE wings CASCADE")
+        CommonTestCases.lagos_admin_token_assert_in(
+            self,
+            delete_wing_mutation,
+            "does not exist"
         )

--- a/tests/test_wing/test_update_wing.py
+++ b/tests/test_wing/test_update_wing.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.database import engine, db_session
 from fixtures.wing.wing_fixtures import (
     update_wing_mutation,
     update_duplicate_wing_mutation,
@@ -63,4 +64,29 @@ class TestCreateWing(BaseTestCase):
             self,
             update_wing_id_not_found,
             "Wing not found"
+        )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_wing_mutation,
+            "The database cannot be reached"
+            )
+
+    def test_wing_update_without_wings_model(self):
+        """
+        Test awing cannot be updated without a wings model
+        """
+        db_session.remove()
+        with engine.begin() as conn:
+            conn.execute("DROP TABLE wings CASCADE")
+        CommonTestCases.lagos_admin_token_assert_in(
+            self,
+            update_wing_mutation,
+            "does not exist"
         )


### PR DESCRIPTION
#### What does this PR do?
- [x] create a custom context manager 
- [x] catch all sqlalchemy ProgrammingErrors
- [x] catch InternalErrors when server is down
- [x] display user friendly message for respective errors


#### Description of Task to be completed?
Display user-friendly messages such as "The database cannot be reached" when the app crashes due to a database error. 

#### How should this be manually tested?
- Pull this branch
- make the migrations as explained in the [README](https://github.com/andela/mrm_api/blob/develop/Readme.md)
- stop the server and try to run any mutation/query(to test for InternalError)
- delete a relation from the database and run a mutation that depends on that relation( to test for ProgrammingError)

### Below are the screenshots 
* initial error message for InternalErrors
<img width="1195" alt="screenshot 2019-02-19 at 16 37 02" src="https://user-images.githubusercontent.com/38909130/53020026-234c7580-3467-11e9-9cb6-434e36884ffa.png">

* new message for InternalErrors
<img width="1189" alt="screenshot 2019-02-19 at 16 55 45" src="https://user-images.githubusercontent.com/38909130/53020062-395a3600-3467-11e9-88e4-461caf09977d.png">


* initial message for programmingErrors
<img width="1195" alt="screenshot 2019-02-19 at 11 31 17" src="https://user-images.githubusercontent.com/38909130/53020097-4bd46f80-3467-11e9-9a20-7341e60ba954.png">


* new error message for programmingErrors in production/staging environment
<img width="1193" alt="screenshot 2019-02-22 at 15 13 24" src="https://user-images.githubusercontent.com/38909130/53241996-82eb9080-36b4-11e9-99c6-80a812383061.png">

* new error message for programmingErrors in testing/development environment
<img width="1193" alt="screenshot 2019-02-27 at 23 07 25" src="https://user-images.githubusercontent.com/38909130/53519834-3dc8c380-3ae5-11e9-8026-f7669b20e0fc.png">




#### Any background context you want to provide?
`InternalError` is sometimes raised by drivers in the context of the database connection being dropped, or not being able to connect to the database.
ProgrammingError - Exception raised for programming errors, e.g. table not found or already exists, syntax error in the SQL statement, wrong number of parameters specified, etc.

#### What are the relevant pivotal tracker stories?

[#163754403](https://www.pivotaltracker.com/story/show/163754403)