### PR TITLE
#164266195 Remove node(level) from structure tree

### DIFF
--- a/fixtures/office_structure/delete_level_fixtures.py
+++ b/fixtures/office_structure/delete_level_fixtures.py
@@ -1,0 +1,51 @@
+delete_level_fixtures = '''
+mutation{
+    deleteLevel(id:2){
+        node{
+        id
+        }
+    }
+    }
+'''
+
+delete_level_response = {
+  "data": {
+    "deleteLevel": {
+      "node": {
+        "id": "2"
+      }
+    }
+  }
+}
+
+delete_level_fixtures_non_existant_id = '''
+mutation{
+    deleteLevel(id:40){
+        node{
+        id
+        }
+    }
+    }
+'''
+
+delete_level_fixtures_non_existant_id_response = '''
+{
+  "errors": [
+    {
+      "message": "Level not found",
+      "locations": [
+        {
+          "line": 2,
+          "column": 5
+        }
+      ],
+      "path": [
+        "deleteLevel"
+      ]
+    }
+  ],
+  "data": {
+    "deleteLevel": null
+  }
+}
+'''

--- a/tests/base.py
+++ b/tests/base.py
@@ -61,12 +61,10 @@ class BaseTestCase(TestCase):
             role.save()
             admin_user.roles.append(role)
             lagos_admin.roles.append(role)
-
             root_node = OfficeStructure(name='location')
             root_node.save()
             leaf_node = OfficeStructure(name='wings', parent_id=1)
             leaf_node.save()
-
             location = Location(name='Kampala', abbreviation='KLA')
             location.save()
             location_two = Location(name='Nairobi', abbreviation='NBO')

--- a/tests/test_office_structure/test_delete_level.py
+++ b/tests/test_office_structure/test_delete_level.py
@@ -1,0 +1,23 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.office_structure.delete_level_fixtures import (
+  delete_level_fixtures, delete_level_response,
+  delete_level_fixtures_non_existant_id
+)
+
+
+class TestDeleteLevel(BaseTestCase):
+    def test_delete_level_works(self):
+        """Test admin can delete level"""
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_level_fixtures,
+            delete_level_response
+        )
+
+    def test_delete_level_with_nonexistant_id(self):
+        """Test admin cannot delete level with nonexistent id"""
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_level_fixtures_non_existant_id,
+            "Level not found"
+        )


### PR DESCRIPTION
#### What does this PR do?
Remove node/level from structure tree

#### Description of Task to be completed?
- Currently, when a node is added, it can not be deleted. This PR adds the endpoint for deleting the node


#### How should this be manually tested?
- Pull this branch 
- Run the following query
```
mutation{
    deleteLevel(id:1){
        node{
        id
        }
    }
    }
```
You should be able to delete the node.

#### Any background context you want to provide?
Please note that this is a task for `v2`.  
#### What are the relevant pivotal tracker stories?
[#164266195](https://www.pivotaltracker.com/story/show/164266195)

#### Screenshots (if appropriate)
<img width="1127" alt="screen shot 2019-03-03 at 1 54 24 pm" src="https://user-images.githubusercontent.com/22786444/53694161-e9ab3100-3dbb-11e9-856d-286345b53aa7.png">

**if the level doesn't exist**
 
<img width="1074" alt="screen shot 2019-03-03 at 1 54 36 pm" src="https://user-images.githubusercontent.com/22786444/53694165-f9c31080-3dbb-11e9-8315-c95b447a773d.png">

