### PR TITLE
#164101018 (V2) Restrict Query Remote Rooms by Location

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ omit =
 show_missing = True
 omit =
     */python?.?/*
+    */alembic/*
 
 [html]
 directory=html_coverage_report

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -21,7 +21,11 @@ import os
 import sys
 
 sys.path.append(os.getcwd())
-config.set_main_option('sqlalchemy.url', os.getenv('DEV_DATABASE_URL'))
+config.set_main_option(
+    'sqlalchemy.url',
+    os.getenv('TEST_DATABASE_URL') if os.getenv('APP_SETTINGS') == 'testing'
+    else os.getenv('DEV_DATABASE_URL')
+)
 
 from helpers.database import Base
 from api.location.models import Location

--- a/helpers/calendar/credentials.py
+++ b/helpers/calendar/credentials.py
@@ -2,6 +2,7 @@ import os
 
 from apiclient.discovery import build
 from httplib2 import Http
+from graphql import GraphQLError
 from oauth2client import file, client, tools  # noqa
 from oauth2client.client import OAuth2WebServerFlow  # noqa
 
@@ -34,3 +35,14 @@ class Credentials():
         service = build('calendar', 'v3', developerKey=api_key,
                         http=credentials.authorize(Http()))
         return service
+
+
+class CalendarApi:
+    def calendar_list(self, page_token):
+        try:
+            service = Credentials().set_api_credentials()
+            calendars = service.calendarList().list(
+                pageToken=page_token).execute()
+        except Exception as exception:
+            raise GraphQLError(exception)
+        return calendars

--- a/helpers/remote_rooms/remote_rooms_location.py
+++ b/helpers/remote_rooms/remote_rooms_location.py
@@ -1,0 +1,12 @@
+
+def map_remote_room_location_to_filter():
+    '''
+        map filters for room location
+    '''
+    return {
+            'Nairobi': lambda remote_room: remote_room.startswith('Nairobi - '),
+            'Lagos': lambda remote_room: remote_room.find('-ET-') != -1,
+            'Kampala': lambda remote_room: remote_room.find('Kampala') != -1
+            and not remote_room.startswith('Nairobi'),
+            'all': lambda remote_room: True  # return True for all rooms
+        }

--- a/mock_data/remote_rooms.json
+++ b/mock_data/remote_rooms.json
@@ -1,0 +1,38 @@
+
+ {"items": [
+    {
+        "kind": "calendar#calendarListEntry", "etag": "1539596112857000",
+        "id": "andela.com_37343037343034@resource.calendar.google.com",
+        "summary": "Kampala-3-New York-Bryant Park (6)",
+        "timeZone": "America/Los_Angeles", "colorId": "9",
+        "backgroundColor": "#7bd148", "foregroundColor": "#000000",
+        "accessRole": "owner", "defaultReminders": [],
+        "conferenceProperties":
+        {"allowedConferenceSolutionTypes": ["hangoutsMeet"]}
+    },
+    {
+        "kind": "calendar#calendarListEntry", "etag": "1544445005964000",
+        "id":
+        "andela.com_3331303233393133353334@resource.calendar.google.com",
+        "summary": "Nairobi - 1st Floor Block A Porto-Novo (2)",
+        "timeZone": "America/Los_Angeles", "colorId": "3",
+        "backgroundColor": "#f83a22", "foregroundColor": "#000000",
+        "accessRole": "owner", "defaultReminders": [],
+        "conferenceProperties": {
+            "allowedConferenceSolutionTypes": ["hangoutsMeet"]
+        }
+    },
+    {
+        "kind": "calendar#calendarListEntry", "etag": "1549043939574000",
+        "id":
+        "andela.com_2d3330393833383239323732@resource.calendar.google.com",
+        "summary": "(Meeting Room)-ET-4-Safari-Olumo (4)",
+        "timeZone": "America/Los_Angeles", "colorId": "11",
+        "backgroundColor": "#fbe983", "foregroundColor": "#000000",
+        "accessRole": "owner", "defaultReminders": [],
+        "conferenceProperties": {
+            "allowedConferenceSolutionTypes": ["hangoutsMeet"]
+        }
+    }
+ ]
+}


### PR DESCRIPTION
 ### What does this PR do?
Restrict query remote rooms by location.
### Description of the task to be completed?
When all remote rooms are queried, the result should be displayed only rooms available in the user location.
### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `git checkout ft-restrict-query-remote-rooms-by-location-164101018`
 - Perform the query below. Remember to provide the desired location access token.
```
query {
   allRemoteRooms {
    rooms {
      calendarId
      name
    }
  }
}
```
 - To return all the remote rooms available, use the `returnAll: true` flag:
```
query {
   allRemoteRooms(returnAll: true) {
    rooms {
      calendarId
      name
    }
  }
}
```
The query returns only the rooms in the admin location. 

### Any background context you want to provide?
N/A
### What are the relevant pivotal tracker stories?
[#164101018](https://www.pivotaltracker.com/story/show/164101018)
### Screenshots
 - #### Query remote rooms by Kampala admin.
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/38049235/53319946-27ecb000-38e5-11e9-8b0c-3e9fa5806d56.png">

 - #### Query remote rooms by Lagos admin.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/38049235/53320571-17d5d000-38e7-11e9-9380-b8f480c13ea7.png">

 - #### Query remote rooms by Nairobi admin.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/38049235/53320651-48b60500-38e7-11e9-9c68-221c0def761e.png">

 - #### Query all remote rooms regardless of the location of the admin.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/38049235/53724715-85e83d00-3e7b-11e9-8323-94b7e067890f.png">
