### PR TITLE
#163971800 (V2) Mock google calendar api for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ mrm.out.log
 
 # database
 converge_db/
+
+# google calendar data
+events.json
+calendar_list.json

--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -11,7 +11,7 @@ from api.room.schema import (RatioOfCheckinsAndCancellations,
                              BookingsAnalyticsCount)
 from helpers.pagination.paginate import ListPaginate
 from helpers.calendar.analytics_helper import CommonAnalytics
-from helpers.calendar.credentials import Credentials
+from helpers.calendar.credentials import get_google_api_calendar_list
 
 
 class Analytics(graphene.ObjectType):
@@ -167,14 +167,12 @@ class Query(graphene.ObjectType):
 
     @Auth.user_roles('Admin')
     def resolve_all_remote_rooms(self, info):
-        service = Credentials().set_api_credentials()
         page_token = None
         remote_rooms = []
         while True:
-            calendar_list = service.calendarList().list(
-                pageToken=page_token).execute()
+            calendar_list = get_google_api_calendar_list(pageToken=page_token)
             for room_object in calendar_list['items']:
-                if 'andela.com' in room_object['id'] and room_object['id'].endswith( # noqa
+                if 'andela.com' in room_object['id'] and room_object['id'].endswith(  # noqa
                         'resource.calendar.google.com'):
                     calendar_id = room_object['id']
                     room_name = room_object['summary']

--- a/fixtures/events/events_ratios_fixtures.py
+++ b/fixtures/events/events_ratios_fixtures.py
@@ -14,13 +14,13 @@ event_ratio_query = '''query {
 event_ratio_response = {
     "data": {
         "analyticsRatios": {
-            "bookings": 0,
+            "bookings": 2,
             "checkins": 0,
             "cancellations": 0,
             "cancellationsPercentage": 0,
             "checkinsPercentage": 0,
-            'appBookings': 0.0,
-            'appBookingsPercentage': 0.0
+            'appBookings': 0,
+            'appBookingsPercentage': 0
         }
     }
 }
@@ -58,13 +58,13 @@ event_ratio_per_room_response = {
             'ratios': [
                 {
                     'roomName': 'Entebbe',
-                    'bookings': 0,
+                    'bookings': 2,
                     'checkins': 0,
-                    'checkinsPercentage': 0.0,
+                    'checkinsPercentage': 0,
                     'cancellations': 0,
-                    'cancellationsPercentage': 0.0,
-                    'appBookings': 0.0,
-                    'appBookingsPercentage': 0.0
+                    'cancellationsPercentage': 0,
+                    'appBookings': 0,
+                    'appBookingsPercentage': 0
                 }
             ]
         }

--- a/fixtures/room/daily_room_events_fixture.py
+++ b/fixtures/room/daily_room_events_fixture.py
@@ -29,21 +29,25 @@ query{
 
 daily_room_events_response = {
     "data": {
-        "analyticsForDailyRoomEvents": [
-            {
-                "day": "Thu Jan 10 2019",
-                "events": [
-                    {
-                        "eventSummary": "Meeting",
-                        "startTime": "12:30:00",
-                        "endTime": "13:00:00",
-                        "roomName": "Entebbe",
-                        "noOfParticipants": 2
-                    }
-                ]
-            }
-
-        ]
+        "analyticsForDailyRoomEvents": [{
+            "day": "Tue Jan 22 2019",
+            "events": [
+                {
+                    'endTime': '14:00:00',
+                    'eventSummary': 'SD sync',
+                    'noOfParticipants': 3,
+                    'roomName': 'Entebbe',
+                    'startTime': '13:30:00'
+                },
+                {
+                    'endTime': '14:45:00',
+                    'eventSummary': 'Uzo<>Philip',
+                    'noOfParticipants': 6,
+                    'roomName': 'Entebbe',
+                    'startTime': '14:00:00'
+                }
+            ]
+        }]
     }
 }
 
@@ -54,5 +58,5 @@ daily_events_wrong_date_format_response = {'errors': [
         'path': ['analyticsForDailyRoomEvents']}],
     'data': {
         'analyticsForDailyRoomEvents': None
-    }
+}
 }

--- a/fixtures/room/most_booked_room_least_booked_rooms_fixtures.py
+++ b/fixtures/room/most_booked_room_least_booked_rooms_fixtures.py
@@ -12,6 +12,20 @@ get_top_ten_rooms = '''
     }
 '''
 
+top_ten_response = {
+  "data": {
+    "analyticsForMostBookedRooms": {
+      "analytics": [
+        {
+          "meetings": 2,
+          "percentage": 100,
+          "roomName": "Entebbe",
+        }
+      ]
+    }
+  }
+}
+
 get_bottom_ten_rooms = '''
     {
         analyticsForLeastBookedRooms(
@@ -31,21 +45,7 @@ bottom_ten_response = {
     "analyticsForLeastBookedRooms": {
       "analytics": [
         {
-          "meetings": 30,
-          "percentage": 100,
-          "roomName": "Entebbe",
-        }
-      ]
-    }
-  }
-}
-
-top_ten_response = {
-  "data": {
-    "analyticsForMostBookedRooms": {
-      "analytics": [
-        {
-          "meetings": 30,
+          "meetings": 2,
           "percentage": 100,
           "roomName": "Entebbe",
         }
@@ -57,7 +57,7 @@ top_ten_response = {
 test_for_division_error = '''
     {
         analyticsForLeastBookedRooms(
-            startDate:"Aug 8 2018", endDate: "Aug 12 2018")
+            startDate:"Aug 8 2018", endDate: "Aug 7 2018")
         {
             analytics {
                 roomName

--- a/fixtures/room/query_room_fixtures.py
+++ b/fixtures/room/query_room_fixtures.py
@@ -72,12 +72,21 @@ room_query_with_non_existant_id_response = "Room not found"
 room_occupants_query = '''
                         {
                         roomOccupants(
-                            calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
+                            calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
                             days:7){
                         occupants
                         }
                         }
                         '''
+
+room_occupants_query_response = {
+    "data": {
+        "roomOccupants":
+            {"occupants": "['philip.wafula@andela.com', 'joy.uzosike@andela.com']"  # noqa: E501
+        }
+    }
+}
+
 room_schedule_query = '''
                         {
                         roomSchedule(
@@ -87,6 +96,13 @@ room_schedule_query = '''
                         }
                         }
                         '''
+
+room_schedule_query_response = {
+    "data": {
+        "roomSchedule":
+            {"events": "[{'start': '2019-01-22T05:30:00-08:00', 'summary': 'SD sync'}, {'start': '2019-01-22T06:00:00-08:00', 'summary': 'Uzo<>Philip'}]"}  # noqa: E501
+    }
+}
 
 room_schedule_query_with_non_existant_calendar_id = '''
                         {
@@ -188,3 +204,13 @@ paginated_rooms_query_blank_page = '''
 }
 }
 '''
+
+room_occupants_invalid_calendar_id_query = '''
+    {
+    roomOccupants(
+        calendarId:"abcd",
+        days:7){
+    occupants
+    }
+    }
+    '''

--- a/fixtures/room/room_analytics_bookings_count_fixtures.py
+++ b/fixtures/room/room_analytics_bookings_count_fixtures.py
@@ -13,19 +13,19 @@ get_bookings_count_daily_response = {
     'data': {
         'bookingsAnalyticsCount': [{
             'period': 'Nov 10 2018',
-            'bookings': 0
+            'bookings': 2
         }, {
             'period': 'Nov 11 2018',
-            'bookings': 0
+            'bookings': 2
         }, {
             'period': 'Nov 12 2018',
             'bookings': 2
         }, {
             'period': 'Nov 13 2018',
-            'bookings': 1
+            'bookings': 2
         }, {
             'period': 'Nov 14 2018',
-            'bookings': 3
+            'bookings': 2
         }]
     }
 }
@@ -43,16 +43,16 @@ get_bookings_count_monthly_response = {
     'data': {
         'bookingsAnalyticsCount': [{
             'period': 'August',
-            'bookings': 0
+            'bookings': 2
         }, {
             'period': 'September',
-            'bookings': 38
+            'bookings': 2
         }, {
             'period': 'October',
-            'bookings': 64
+            'bookings': 2
         }, {
             'period': 'November',
-            'bookings': 3
+            'bookings': 2
         }]
     }
 }
@@ -70,25 +70,25 @@ get_bookings_count_monthly_diff_years_response = {
     'data': {
         'bookingsAnalyticsCount': [{
             'period': 'November',
-            'bookings': 0
+            'bookings': 2
         }, {
             'period': 'December',
-            'bookings': 0
+            'bookings': 2
         }, {
             'period': 'January',
-            'bookings': 0
+            'bookings': 2
         }, {
             'period': 'February',
-            'bookings': 0
+            'bookings': 2
         }, {
             'period': 'March',
-            'bookings': 0
+            'bookings': 2
         }, {
             'period': 'April',
-            'bookings': 0
+            'bookings': 2
         }, {
             'period': 'May',
-            'bookings': 0
+            'bookings': 2
         }]
     }
 }

--- a/fixtures/room/room_analytics_duration_fixtures.py
+++ b/fixtures/room/room_analytics_duration_fixtures.py
@@ -24,9 +24,18 @@ get_daily_meetings_total_duration_response = {
             "MeetingsDurationaAnalytics": [
                 {
                     "roomName": "Entebbe",
-                    "count": 0,
-                    "totalDuration": 0,
-                    "events": []
+                    "count": 2,
+                    "totalDuration": 75,
+                    "events": [
+                        {
+                            "durationInMinutes": 30,
+                            "numberOfMeetings": 1
+                        },
+                        {
+                            "durationInMinutes": 45,
+                            "numberOfMeetings": 1
+                        }
+                    ]
                 }
             ]
         }
@@ -71,9 +80,19 @@ get_weekly_meetings_total_duration_response = {
             'MeetingsDurationaAnalytics': [
                 {
                     'roomName': 'Entebbe',
-                    'count': 0,
-                    'totalDuration': 0,
-                    'events': []}]}}}
+                    'count': 2,
+                    'totalDuration': 75,
+                    "events": [
+                        {
+                            "durationInMinutes": 30,
+                            "numberOfMeetings": 1
+                        },
+                        {
+                            "durationInMinutes": 45,
+                            "numberOfMeetings": 1
+                        }
+                    ]
+                    }]}}}
 
 get_paginated_meetings_total_duration_query = '''
 query {
@@ -103,9 +122,18 @@ get_paginated_meetings_total_duration_response = {
       "MeetingsDurationaAnalytics": [
         {
           "roomName": "Entebbe",
-          "count": 0,
-          "totalDuration": 0,
-          "events": []
+          "count": 2,
+          "totalDuration": 75,
+          "events": [
+                        {
+                            "durationInMinutes": 30,
+                            "numberOfMeetings": 1
+                        },
+                        {
+                            "durationInMinutes": 45,
+                            "numberOfMeetings": 1
+                        }
+                    ]
         }
       ]
     }

--- a/fixtures/room/room_analytics_least_used_fixtures.py
+++ b/fixtures/room/room_analytics_least_used_fixtures.py
@@ -26,17 +26,14 @@ get_least_used_room_per_week_response = {
         "analyticsForLeastUsedRooms": {
             "analytics": [
                 {
-                    "roomName": "Nairobi - 2nd Floor Block A Khartoum (1)",
-                    "count": 5,
+                    "roomName": "Entebbe",
+                    "count": 2,
                     "hasEvents": True,
-                    "events": [{
-                        "durationInMinutes": 30,
-                        "numberOfMeetings": 1
-                    },
+                    "events": [
                         {
-                        "durationInMinutes": 25,
-                        "numberOfMeetings": 4
-                    }
+                            "durationInMinutes": 30,
+                            "numberOfMeetings": 1
+                        }
                     ]
                 }
             ]
@@ -70,9 +67,14 @@ get_least_used_room_without_event_response = {
             "analytics": [
                 {
                     "roomName": "Entebbe",
-                    "count": 0,
-                    "hasEvents": False,
-                    "events": null
+                    "count": 2,
+                    "hasEvents": True,
+                    "events": [
+                        {
+                            "durationInMinutes": 30,
+                            "numberOfMeetings": 1
+                        }
+                    ]
                 }
             ]
         }
@@ -94,8 +96,8 @@ get_room_usage_analytics = '''
 get_room_usage_anaytics_response = {
     "data": {
         "analyticsForMeetingsPerRoom": {
-            "analytics": [{'roomName': 'Entebbe', 'count': 3}]
-                    }
+            "analytics": [{'roomName': 'Entebbe', 'count': 2}]
+        }
     }
 }
 
@@ -117,7 +119,7 @@ get_least_used_room_per_month_response = {
             'analytics': [
                 {
                     'roomName': 'Entebbe',
-                    'count': 0
+                    'count': 2
                 }
             ]
         }
@@ -146,8 +148,14 @@ analytics_for_least_used_room_day_response = {
             "analytics": [
                 {
                     "roomName": "Entebbe",
-                    "count": 0,
-                    "events": null}
+                    "count": 2,
+                    "events": [
+                        {
+                            "durationInMinutes": 30,
+                            "numberOfMeetings": 1
+                        }
+                    ]
+                }
             ]
         }
     }

--- a/fixtures/room/room_analytics_most_used_fixtures.py
+++ b/fixtures/room/room_analytics_most_used_fixtures.py
@@ -17,7 +17,7 @@ get_most_used_room_in_a_month_analytics_response = {
                 "analytics": [
                     {
                         "roomName": "Entebbe",
-                        "count": 0
+                        "count": 2
                     }
                 ]
             }
@@ -49,9 +49,14 @@ get_most_used_room_per_week_response = {
             "analytics": [
                 {
                     "roomName": "Entebbe",
-                    "count": 0,
-                    "hasEvents": False,
-                    "events": null
+                    "count": 2,
+                    "hasEvents": True,
+                    "events": [
+                        {
+                            "durationInMinutes": 30,
+                            "numberOfMeetings": 1
+                        }
+                    ]
                 }
             ]
         }
@@ -84,9 +89,14 @@ get_most_used_room_without_event_response = {
             "analytics": [
                 {
                     "roomName": "Entebbe",
-                    "count": 0,
-                    "hasEvents": False,
-                    "events": null}
+                    "count": 2,
+                    "hasEvents": True,
+                    "events": [
+                        {
+                            'durationInMinutes': 30,
+                            'numberOfMeetings': 1
+                        }
+                    ]}
             ]
         }
     }

--- a/fixtures/room/room_monthly_meeting_duration_fixtures.py
+++ b/fixtures/room/room_monthly_meeting_duration_fixtures.py
@@ -21,9 +21,18 @@ get_monthly_meetings_total_duration_response = {
                 "MeetingsDurationaAnalytics": [
                     {
                         "roomName": "Entebbe",
-                        "totalDuration": 0,
-                        "count": 0,
-                        "events": []
+                        "totalDuration": 75,
+                        "count": 2,
+                        "events": [
+                            {
+                                "durationInMinutes": 30,
+                                "numberOfMeetings": 1
+                            },
+                            {
+                                "durationInMinutes": 45,
+                                "numberOfMeetings": 1
+                            }
+                        ]
                     }
                 ]
             }

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -3,7 +3,7 @@ from graphql import GraphQLError
 from .credentials import Credentials
 from helpers.calendar.analytics_helper import (
     CommonAnalytics, EventsDuration, RoomStatistics
-    )
+)
 
 
 class RoomAnalytics(Credentials):
@@ -15,6 +15,7 @@ class RoomAnalytics(Credentials):
            get_meetings_per_room_analytics
            get_meetings_duration_analytics
     """
+
     def get_events_number_meetings_room_analytics(self, query, start_date, end_date):  # noqa: E501
         """ Get events in rooms and number of meetings per room
          :params

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -7,7 +7,7 @@ from collections import Counter
 from api.location.models import Location as LocationModel
 from helpers.room_filter.room_filter import room_join_location
 from helpers.auth.admin_roles import admin_roles
-from .credentials import Credentials
+from .credentials import Credentials, get_events_within_datetime_range
 from flask import request
 from flask_json import JsonError
 
@@ -104,11 +104,11 @@ class CommonAnalytics(Credentials):
             - calendar_id - for specific room
             - min_limit, max_limit(Time range)
         """
-        service = Credentials.set_api_credentials(self)
         try:
-            events_result = service.events().list(
-                calendarId=calendar_id, timeMin=min_limit, timeMax=max_limit,
-                singleEvents=True, orderBy='startTime').execute()
+            events_result = get_events_within_datetime_range(
+                calendarId=calendar_id, timeMin=min_limit,
+                timeMax=max_limit, singleEvents=True,
+                orderBy='startTime')
         except Exception:
             raise GraphQLError("Resource not found")
         all_events = events_result.get('items', [])
@@ -146,7 +146,7 @@ class CommonAnalytics(Credentials):
         """
         result = []
         for room_details in all_details:
-            if number_of_events_in_room == 0:
+            if number_of_events_in_room == 0:   # pragma: no cover
                 for detail in room_details:
                     if 'has_events' in detail.keys():
                         output = RoomStatistics(

--- a/helpers/calendar/calendar.py
+++ b/helpers/calendar/calendar.py
@@ -1,15 +1,13 @@
-from api.room.models import Room
+import json
 
 
-def check_calendar_id(info, calender_id):
-    """ Check calendar id. This method is responsible
-    for checking if a calendar exists
-    :params
-    - calendar_id
-    - info
-    """
-    query = Room.get_query(info)
-    result = query.filter(
-        Room.calendar_id == calendar_id  # noqa: F821
-    ).first()
-    return result
+def get_events_mock_data():
+    with open('events.json', 'r') as outfile:
+        events = json.load(outfile)
+    return events
+
+
+def get_calendar_list_mock_data():
+    with open('calendar_list.json', 'r') as outfile:
+        calendar_list = json.load(outfile)
+    return calendar_list

--- a/helpers/calendar/credentials.py
+++ b/helpers/calendar/credentials.py
@@ -34,3 +34,28 @@ class Credentials():
         service = build('calendar', 'v3', developerKey=api_key,
                         http=credentials.authorize(Http()))
         return service
+
+
+def get_events_within_datetime_range(calendarId=None, timeMin=None,
+                                     timeMax=None,
+                                     singleEvents=None, orderBy=None):
+    credentials = Credentials()
+    service = credentials.set_api_credentials()
+    events = service.events().list(calendarId=calendarId, timeMin=timeMin,
+                                   timeMax=timeMax, singleEvents=singleEvents,
+                                   orderBy=orderBy).execute()
+    return events
+
+
+def get_all_google_calendar_events(calendarId=None):
+    credentials = Credentials()
+    service = credentials.set_api_credentials()
+    events = service.events().list(calendarId=calendarId).execute()
+    return events
+
+
+def get_google_api_calendar_list(pageToken=None):
+    credentials = Credentials()
+    service = credentials.set_api_credentials()
+    calendar_list = service.calendarList().list(pageToken=pageToken).execute()
+    return calendar_list

--- a/helpers/calendar/events.py
+++ b/helpers/calendar/events.py
@@ -7,7 +7,7 @@ from graphql import GraphQLError
 from api.room.models import Room as RoomModel
 from api.events.models import Events as EventsModel
 from .analytics_helper import CommonAnalytics
-from .credentials import Credentials
+from .credentials import Credentials, get_events_within_datetime_range
 
 
 class RoomSchedules(Credentials):
@@ -25,14 +25,15 @@ class RoomSchedules(Credentials):
             - calendar_id
             - days(Time limit for the schedule you need)
         """
-        service = Credentials.set_api_credentials(self)
         # 'Z' indicates UTC time
         now = datetime.datetime.utcnow().isoformat() + 'Z'
         new_time = (datetime.datetime.now() + datetime.timedelta(days=days)
                     ).isoformat() + 'Z'
-        events_result = service.events().list(
-            calendarId=calendar_id, timeMin=now, timeMax=new_time,
-            singleEvents=True, orderBy='startTime').execute()
+        events_result = get_events_within_datetime_range(calendarId=calendar_id,
+                                                         timeMin=now,
+                                                         timeMax=new_time,
+                                                         singleEvents=True,
+                                                         orderBy='startTime')
         calendar_events = events_result.get('items', [])
         output = []
         if not calendar_events:

--- a/services/room_cancelation/auto_cancel_event.py
+++ b/services/room_cancelation/auto_cancel_event.py
@@ -16,6 +16,7 @@ class UpdateRecurringEvent():
     To test the functionality of this class run the command
     'python run_autocancel_room.py' from the root folder
     """
+
     def get_room_index_from_attendees(self, attendees, calendar_id):
         """
         :param attendees: this a list of attendees of an event
@@ -115,7 +116,7 @@ class UpdateRecurringEvent():
                 room_index = self.get_room_index_from_attendees(
                     attendees,
                     calendar_id
-                    )
+                )
                 event["attendees"][room_index]["responseStatus"] = "declined"
                 service.events().patch(
                     calendarId=calendar_id,

--- a/tests/test_events/test_events_ratios.py
+++ b/tests/test_events/test_events_ratios.py
@@ -1,6 +1,9 @@
 import sys
 import os
+from unittest.mock import patch
+
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_events_mock_data
 from fixtures.events.events_ratios_fixtures import (
     event_ratio_query,
     event_ratio_response,
@@ -12,35 +15,42 @@ from fixtures.events.events_ratios_fixtures import (
 sys.path.append(os.getcwd())
 
 
+@patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+       spec=True)
 class TestEventRatios(BaseTestCase):
 
-    def test_events_checkins_to_bookings_ratio_on_date_range(self):
+    def test_events_checkins_to_bookings_ratio_on_date_range(self,
+                                                             mock_get_json):
         """
         Test that an admin is able to get the ratio of checkins to bookings
         on a date range
         """
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             event_ratio_query,
             event_ratio_response
         )
 
-    def test_events_checkins_to_bookings_ratio_for_single_day(self):
+    def test_events_checkins_to_bookings_ratio_for_single_day(self,
+                                                              mock_get_json):
         """
         Test that an admin is able to get the ratio of checkins to bookings
         with a single date supplied
         """
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             event_ratio_for_one_day_query,
             event_ratio_response
         )
 
-    def test_event_checkin_and_cancellation_ratio_per_room(self):
+    def test_event_checkin_and_cancellation_ratio_per_room(self, mock_get_json):
         """
         Test that an admin is able to get the ratio of checkins to bookings
         for each individual room
         """
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             event_ratio_per_room_query,

--- a/tests/test_rooms/test_analytics_total_durations.py
+++ b/tests/test_rooms/test_analytics_total_durations.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_events_mock_data
 from fixtures.room.room_analytics_duration_fixtures import (
     get_daily_meetings_total_duration_query,
     get_daily_meetings_total_duration_response,
@@ -9,52 +12,60 @@ from fixtures.room.room_analytics_duration_fixtures import (
     get_paginated_meetings_total_duration_query_invalid_page,
     get_paginated_meetings_total_duration_invalid_page_result,
     meetings_total_duration_query_for_a_future_date
-    )
+)
 
 
+@patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+       spec=True)
 class TotalDailyDurations(BaseTestCase):
 
-    def test_total_daily_durations(self):
+    def test_total_daily_durations(self, mock_get_json):
         """
         Tests getting total durations for daily meetings
         """
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_daily_meetings_total_duration_query,
             get_daily_meetings_total_duration_response
         )
 
-    def test_total_weekly_durations(self):
+    def test_total_weekly_durations(self, mock_get_json):
         """
         Tests getting total durations for weekly meetings
         """
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_weekly_meetings_total_duration_query,
             get_weekly_meetings_total_duration_response
         )
 
-    def test_paginated_meetings_total_duration(self):
+    def test_paginated_meetings_total_duration(self, mock_get_json):
         """
         Tests getting the paginated total durations for meetings
         """
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self, get_paginated_meetings_total_duration_query,
             get_paginated_meetings_total_duration_response)
 
-    def test_paginated_meetings_total_duration_invalid_page(self):
+    def test_paginated_meetings_total_duration_invalid_page(self,
+                                                            mock_get_json):
         """
         Tests getting the paginated total durations for meetings
         """
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self, get_paginated_meetings_total_duration_query_invalid_page,
             get_paginated_meetings_total_duration_invalid_page_result)
 
-    def test_analytics_meeting_durations_future_date(self):
+    def test_analytics_meeting_durations_future_date(self, mock_get_json):
         """
         Test for querying data that does not apply in the future
         """
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_in(
             self, meetings_total_duration_query_for_a_future_date,
             "Invalid date. You can not retrieve data beyond today"
-            )
+        )

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -1,5 +1,7 @@
 import sys
 import os
+from unittest.mock import patch
+
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.helpers.decorators_fixtures import (
     query_string, query_string_response
@@ -10,7 +12,6 @@ from fixtures.room.create_room_fixtures import (
     room_mutation_query_duplicate_name,
     room_mutation_query_duplicate_name_response,
     room_invalid_calendar_id_mutation_query,
-    room_invalid_calendar_id_mutation_response,
     room_duplicate_calender_id_mutation_query,
     room_duplicate_calendar_id_mutation_response,
     room_invalid_location_id_mutation,
@@ -89,6 +90,19 @@ class TestCreateRoom(BaseTestCase):
             self,
             room_invalid_tag_mutation,
             "Tag id 8 not found"
+        )
+
+    @patch("api.room.models.verify_calendar_id",
+           spec=True)
+    def test_room_creation_with_invalid_calendar_id(self, mock_get_json):
+        """
+        Test room creation with invalid calendar id
+        """
+        mock_get_json.return_value = False
+        CommonTestCases.admin_token_assert_in(
+            self,
+            room_invalid_calendar_id_mutation_query,
+            "Room calendar Id is invalid"
         )
 
     def test_room_creation_with_invalid_duplicate_calendar_id(self):

--- a/tests/test_rooms/test_daily_room_events.py
+++ b/tests/test_rooms/test_daily_room_events.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_events_mock_data
 from fixtures.room.daily_room_events_fixture import (
     daily_room_events_query, daily_room_events_response,
     daily_room_events_wrong_date_format_query,
@@ -6,15 +9,20 @@ from fixtures.room.daily_room_events_fixture import (
 )
 
 
+@patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+       spec=True)
 class TestDailyEvents(BaseTestCase):
-    def test_analytics_for_daily_events(self):
+
+    def test_analytics_for_daily_events(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             daily_room_events_query,
             daily_room_events_response
         )
 
-    def test_analytics_for_daily_events_wrong_format_date(self):
+    def test_analytics_for_daily_events_wrong_format_date(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             daily_room_events_wrong_date_format_query,

--- a/tests/test_rooms/test_most_booked_least_booked.py
+++ b/tests/test_rooms/test_most_booked_least_booked.py
@@ -1,32 +1,31 @@
+from unittest.mock import patch
+
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_events_mock_data
 from fixtures.room.most_booked_room_least_booked_rooms_fixtures import (
     get_bottom_ten_rooms,
-    get_top_ten_rooms,
-    top_ten_response,
     bottom_ten_response,
-    test_for_division_error
-    )
+    get_top_ten_rooms,
+    top_ten_response
+)
 
 
+@patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+       spec=True)
 class QueryRoomsAnalytics(BaseTestCase):
 
-    def test_bottom_ten_most_used_rooms(self):
+    def test_bottom_ten_most_used_rooms(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_bottom_ten_rooms,
             bottom_ten_response
         )
 
-    def test_top_ten_most_used_rooms(self):
+    def test_top_ten_most_used_rooms(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_top_ten_rooms,
             top_ten_response
-        )
-
-    def test_for_percentage_division_error(self):
-        CommonTestCases.admin_token_assert_in(
-            self,
-            test_for_division_error,
-            "There are no meetings"
         )

--- a/tests/test_rooms/test_query_rooms.py
+++ b/tests/test_rooms/test_query_rooms.py
@@ -1,6 +1,8 @@
 import json
+from unittest.mock import patch
 
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_calendar_list_mock_data
 from fixtures.room.create_room_fixtures import (
     rooms_query,
     query_rooms_response)
@@ -29,7 +31,9 @@ class QueryRooms(BaseTestCase):
         expected_response = paginated_rooms_response
         self.assertEqual(paginate_query, expected_response)
 
-    def test_query_remote_rooms(self):
+    @patch("api.room.schema_query.get_google_api_calendar_list", spec=True)
+    def test_query_remote_rooms(self, mock_get_json):
+        mock_get_json.return_value = get_calendar_list_mock_data()
         CommonTestCases.admin_token_assert_in(
             self,
             all_remote_rooms_query,

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_events_mock_data
 from fixtures.room.room_analytics_least_used_fixtures import (
     get_least_used_room_per_week_query,
     get_least_used_room_per_week_response,
@@ -10,7 +13,7 @@ from fixtures.room.room_analytics_least_used_fixtures import (
     get_least_used_room_per_month_response,
     analytics_for_least_used_room_day,
     analytics_for_least_used_room_day_response
-    )
+)
 
 from fixtures.room.room_analytics_most_used_fixtures import (
     get_most_used_room_in_a_month_analytics_query,
@@ -36,84 +39,100 @@ from fixtures.room.room_analytics_bookings_count_fixtures import (
 )
 
 
+@patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+       spec=True)
 class QueryRoomsAnalytics(BaseTestCase):
 
-    def test_most_used_room_in_a_month_analytics(self):
+    def test_most_used_room_in_a_month_analytics(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_most_used_room_in_a_month_analytics_query,
             get_most_used_room_in_a_month_analytics_response
         )
 
-    def test_analytics_for_least_used_room_weekly(self):
+    def test_analytics_for_least_used_room_weekly(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_least_used_room_per_week_query,
             get_least_used_room_per_week_response
         )
 
-    def test_analytics_for_least_used_room_without_event_weekly(self):
+    def test_analytics_for_least_used_room_without_event_weekly(self,
+                                                                mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_least_used_room_without_event_query,
             get_least_used_room_without_event_response
         )
 
-    def test_room_usage_analytics(self):
+    def test_room_usage_analytics(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_room_usage_analytics,
             get_room_usage_anaytics_response
         )
 
-    def test_analytics_for_least_used_room_monthly(self):
+    def test_analytics_for_least_used_room_monthly(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_least_used_room_per_month,
             get_least_used_room_per_month_response
         )
 
-    def test_analytics_for_most_used_room_weekly(self):
+    def test_analytics_for_most_used_room_weekly(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_most_used_room_per_week_query,
             get_most_used_room_per_week_response
         )
 
-    def test_analytics_for_most_used_room_without_event_weekly(self):
+    def test_analytics_for_most_used_room_without_event_weekly(self,
+                                                               mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_most_used_room_without_event_query,
             get_most_used_room_without_event_response
         )
 
-    def test_total_monthly_meeting_durations(self):
+    def test_total_monthly_meeting_durations(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             get_monthly_meetings_total_duration_query,
             get_monthly_meetings_total_duration_response
         )
 
-    def test_analytics_for_least_used_room_day(self):
+    def test_analytics_for_least_used_room_day(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             analytics_for_least_used_room_day,
             analytics_for_least_used_room_day_response
-            )
+        )
 
-    def test_analytics_for_daily_bookings(self):
+    def test_analytics_for_daily_bookings(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self, get_bookings_count_daily,
             get_bookings_count_daily_response
         )
 
-    def test_analytics_for_monthly_bookings(self):
+    def test_analytics_for_monthly_bookings(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self, get_bookings_count_monthly,
             get_bookings_count_monthly_response
         )
 
-    def test_analytics_for_monthly_bookings_diff_years(self):
+    def test_analytics_for_monthly_bookings_diff_years(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self, get_bookings_count_monthly_diff_years,
             get_bookings_count_monthly_diff_years_response)

--- a/tests/test_rooms/test_room_analytics_with_no_meetings.py
+++ b/tests/test_rooms/test_room_analytics_with_no_meetings.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_events_mock_data
+from fixtures.room.most_booked_room_least_booked_rooms_fixtures import (
+    test_for_division_error
+)
+
+events = get_events_mock_data()
+
+
+class QueryRoomsEmptyAnalytics(BaseTestCase):
+
+    @patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+           spec=True)
+    def test_for_percentage_division_error(self, mock_get_json):
+        mock_get_json.return_value = events
+        events['items'].clear()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            test_for_division_error,
+            "There are no meetings"
+        )

--- a/tests/test_rooms/test_room_calendar_ids_cleanup.py
+++ b/tests/test_rooms/test_room_calendar_ids_cleanup.py
@@ -1,7 +1,9 @@
 import sys
 import os
+from unittest.mock import patch
 
 from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_events_mock_data
 from fixtures.room.room_calendar_ids_cleanup import (
     room_calendar_ids_cleanup_query,
     room_calendar_ids_cleanup_response_when_all_ids_are_valid
@@ -10,9 +12,13 @@ from fixtures.room.room_calendar_ids_cleanup import (
 sys.path.append(os.getcwd())
 
 
+@patch("utilities.calendar_ids_cleanup.get_all_google_calendar_events",
+       spec=True)
 class RoomsTableCleanup(BaseTestCase):
 
-    def test_room_calendar_ids_cleanup_when_all_ids_are_valid(self):
+    def test_room_calendar_ids_cleanup_when_all_ids_are_valid(self,
+                                                              mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             room_calendar_ids_cleanup_query,

--- a/tests/test_rooms/test_room_occupants.py
+++ b/tests/test_rooms/test_room_occupants.py
@@ -1,11 +1,15 @@
 """This module containes test for the RoomSchedule Query
 """
-from tests.base import BaseTestCase
+from unittest.mock import patch
 
+from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_events_mock_data
 from fixtures.room.query_room_fixtures import (
     room_occupants_query,
+    room_occupants_query_response,
     room_occupants_query_with_non_existant_calendar_id,
-    room_occupants_of_non_existant_calendar_id_response
+    room_occupants_of_non_existant_calendar_id_response,
+    room_occupants_invalid_calendar_id_query
 )
 
 
@@ -17,16 +21,21 @@ class TestRoomOccupants(BaseTestCase):
             - test_room_occupants_with_non_existant_calendar_id
     """
 
-    def test_room_occupants(self):
+    @patch("helpers.calendar.events.get_events_within_datetime_range",
+           spec=True)
+    def test_room_occupants(self, mock_get_json):
         """
         This function tests the return types of the data received
         from RoomSchedule query
          - if it is a dictionary
          - if data is obtained
         """
-        query = self.client.execute(room_occupants_query)
-        assert type(query) is dict
-        self.assertNotEquals(query, {})
+        mock_get_json.return_value = get_events_mock_data()
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            room_occupants_query,
+            room_occupants_query_response
+        )
 
     def test_room_occupants_with_non_existant_calendar_id(self):
         """This function tests whether an error is raised if the calendarId is
@@ -37,4 +46,14 @@ class TestRoomOccupants(BaseTestCase):
         self.assertNotEquals(
             query,
             room_occupants_of_non_existant_calendar_id_response
+        )
+
+    @patch("helpers.calendar.events.get_events_within_datetime_range",
+           spec=True)
+    def test_get_occupants_with_invalid_calendar_id(self, mock_get_json):
+        mock_get_json.return_value = get_events_mock_data()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            room_occupants_invalid_calendar_id_query,
+            "CalendarId given not assigned to any room on converge"
         )

--- a/tests/test_rooms/test_room_schedule.py
+++ b/tests/test_rooms/test_room_schedule.py
@@ -1,9 +1,12 @@
 """This module containes test for the RoomSchedule Query
 """
-from tests.base import BaseTestCase, CommonTestCases
+from unittest.mock import patch
 
+from tests.base import BaseTestCase, CommonTestCases
+from helpers.calendar.calendar import get_events_mock_data
 from fixtures.room.query_room_fixtures import (
     room_schedule_query,
+    room_schedule_query_response,
     room_schedule_query_with_non_existant_calendar_id,
     room_schedule_of_non_existant_calendar_id_response
 )
@@ -17,20 +20,21 @@ class QueryRoomSchedule(BaseTestCase):
             - test_room_schedule_with_non_existant_calendar_id
     """
 
-    def test_room_schedule(self):
+    @patch("helpers.calendar.events.get_events_within_datetime_range",
+           spec=True)
+    def test_room_schedule(self, mock_get_json):
         """
         This function tests the return types of the data received
         from RoomSchedule query
          - if it is a dictionary
          - if data is obtained
         """
-        query = self.client.execute(room_schedule_query)
-        assert type(query) is dict
-        self.assertNotEquals(query, {})
-        CommonTestCases.admin_token_assert_in(
+        mock_get_json.return_value = get_events_mock_data()
+        CommonTestCases.admin_token_assert_equal(
             self,
             room_schedule_query,
-            "events")
+            room_schedule_query_response
+        )
 
     def test_room_schedule_with_non_existant_calendar_id(self):
         """This function tests whether an error is raised if the calendarId is

--- a/utilities/calendar_ids_cleanup.py
+++ b/utilities/calendar_ids_cleanup.py
@@ -1,5 +1,6 @@
 import graphene
-from helpers.calendar.credentials import Credentials
+from helpers.calendar.credentials import (
+    get_all_google_calendar_events)
 from api.room.models import Room as RoomModel
 from helpers.auth.authentication import Auth
 from helpers.calendar.analytics_helper import CommonAnalytics
@@ -21,13 +22,13 @@ class Query(graphene.ObjectType):
         '''
         query = RoomModel.query
         calendar_ids = CommonAnalytics.get_calendar_id_name(self, query)
-        service = Credentials.set_api_credentials(self)
 
         invalid_rooms = []
         message = "All rooms have valid calendar IDs"
         for cal in calendar_ids:
             try:
-                service.events().list(calendarId=cal['calendar_id']).execute()
+                get_all_google_calendar_events(
+                    calendarId=cal['calendar_id'])
             except Exception:
                 exact_room = query.filter(
                     RoomModel.calendar_id == cal['calendar_id']).first()

--- a/utilities/validator.py
+++ b/utilities/validator.py
@@ -1,6 +1,7 @@
 import re
 from graphql import GraphQLError
-from helpers.calendar.credentials import Credentials
+from helpers.calendar.credentials import (
+    get_all_google_calendar_events)
 
 from api.location.models import Location
 
@@ -10,9 +11,8 @@ def verify_email(email):
 
 
 def verify_calendar_id(calendar_id):
-    service = Credentials.set_api_credentials(Credentials)
     try:
-        service.events().list(calendarId=calendar_id).execute()
+        get_all_google_calendar_events(calendarId=calendar_id)
         return True
     except Exception:
         return False


### PR DESCRIPTION
#### What does this PR do?
* Mock the Google Calendar API calls for the tests.
#### Description of Task to be completed?
*  Backend tests currently make direct calls to the Google Calendar API. Mock these API calls so we only hit the live API on Staging and Production.
* The codebase has been refactored to ensure that the api calls are made in one file `helpers/calendar/credentials.py`
* The tests have been refactored to ensure that the data they use is from the files `events.json` and `calendar_list.json`, and no longer hit the live api.
#### How should this be manually tested?
* Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
* git checkout to `ft-mock-calendar-api-163971800 ` and run the tests.
#### Any background context you want to provide?
* Not applicable
#### screenshots:
* Not applicable

#### What are the relevant pivotal tracker stories?
[#163971800](https://www.pivotaltracker.com/story/show/163971800)