### PR TITLE
164399894 Fix data returned using data range in `analyticsForDailyRoomEvents` query

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -335,7 +335,7 @@ class Query(graphene.ObjectType):
     def resolve_analytics_for_least_used_rooms(self, info, start_date, end_date=None):  # noqa: E501
         query = Room.get_query(info)
         room_analytics = RoomAnalytics.get_least_used_rooms_analytics(
-            self, query, start_date, end_date
+            self, query.filter_by(state='active'), start_date, end_date
         )
         return Analytics(
             analytics=room_analytics
@@ -345,7 +345,7 @@ class Query(graphene.ObjectType):
     def resolve_analytics_for_most_used_rooms(self, info, start_date, end_date=None):  # noqa: E501
         query = Room.get_query(info)
         room_analytics = RoomAnalytics.get_most_used_rooms_analytics(
-            self, query, start_date, end_date
+            self, query.filter_by(state='active'), start_date, end_date
         )
         room_most_used_per_week = Analytics(
             analytics=room_analytics
@@ -356,7 +356,7 @@ class Query(graphene.ObjectType):
     def resolve_analytics_for_meetings_per_room(self, info, start_date, end_date=None):  # noqa: E501
         query = Room.get_query(info)
         meeting_summary = RoomAnalytics.get_meetings_per_room_analytics(
-            self, query, start_date, end_date
+            self, query.filter_by(state='active'), start_date, end_date
         )
         return Analytics(
             analytics=meeting_summary
@@ -365,7 +365,7 @@ class Query(graphene.ObjectType):
     @Auth.user_roles('Admin', 'Default User')
     def resolve_analytics_for_meetings_durations(self, info, start_date, end_date=None, per_page=None, page=None):  # noqa: E501
         query = Room.get_query(info)
-        results = RoomAnalytics.get_meetings_duration_analytics(self, query, start_date, end_date)  # noqa: E501
+        results = RoomAnalytics.get_meetings_duration_analytics(self, query.filter_by(state='active'), start_date, end_date)  # noqa: E501
         if page and per_page:
             paginated_results = ListPaginate(iterable=results, per_page=per_page, page=page)  # noqa: E501
             current_page = paginated_results.current_page
@@ -380,7 +380,7 @@ class Query(graphene.ObjectType):
             self, info, start_date, end_date=None):
         query = Room.get_query(info)
         ratio = RoomAnalyticsRatios.get_analytics_ratios(
-            self, query, start_date, end_date)
+            self, query.filter_by(state='active'), start_date, end_date)
         return ratio
 
     @Auth.user_roles('Admin', 'Default User')
@@ -388,7 +388,7 @@ class Query(graphene.ObjectType):
         room_id = kwargs.get('room_id')
         query = Room.get_query(info)
         ratio = RoomAnalyticsRatios.get_analytics_ratios_per_room(
-            self, query, **kwargs)
+            self, query.filter_by(state='active'), **kwargs)
         if room_id:
             exact_room = query.filter(RoomModel.id == room_id).first()
             if not exact_room:
@@ -398,11 +398,14 @@ class Query(graphene.ObjectType):
 
     @Auth.user_roles('Admin', 'Default User')
     def resolve_bookings_analytics_count(
-            self, info, start_date, end_date, room_id=None):
+        self, info, start_date, end_date, room_id=None
+    ):
         # Getting booking analytics count
         query = Room.get_query(info)
         analytics = RoomAnalyticsRatios.get_bookings_analytics_count(
-            self, query, start_date, end_date, room_id=room_id)
+            self, query.filter_by(state='active'), start_date,
+            end_date, room_id=room_id
+        )
         return analytics
 
     def resolve_analytics_for_daily_room_events(
@@ -413,7 +416,7 @@ class Query(graphene.ObjectType):
         )
         query = Room.get_query(info)
         all_events, all_dates = RoomSchedules().get_all_room_schedules(
-            query, start_date, end_date
+            query.filter_by(state='active'), start_date, end_date
         )
         all_days_events = []
         for date in set(all_dates):

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -3,6 +3,7 @@ from .credentials import Credentials
 from helpers.calendar.analytics_helper import (
     CommonAnalytics, EventsDuration, RoomStatistics
 )
+from utilities.validations import remove_invalid_events
 
 
 class RoomAnalytics(Credentials):
@@ -35,6 +36,8 @@ class RoomAnalytics(Credentials):
                 number_of_meetings.append(0)
             else:
                 for event in all_events:
+                    if remove_invalid_events(event, all_events, start_date):
+                        continue
                     if event.get('attendees'):
                         event_details = CommonAnalytics.get_event_details(self, event, room['calendar_id'])  # noqa: E501
                         output.append(event_details)
@@ -103,6 +106,8 @@ class RoomAnalytics(Credentials):
                 continue
             events_duration = []
             for event in events:
+                if remove_invalid_events(event, events, start_date):
+                    continue
                 start = event['start'].get('dateTime', event['start'].get('date'))  # noqa: E501
                 end = event['end'].get('dateTime', event['end'].get('date'))
                 duration = CommonAnalytics.get_time_duration_for_event(self, start, end)  # noqa: E501

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -87,7 +87,7 @@ class CommonAnalytics(Credentials):
          :params
         """
         location_id = admin_roles.user_location_for_analytics_view()
-        exact_query = room_join_location(query)
+        exact_query = room_join_location(query.filter_by(state='active'))
         rooms_in_locations = exact_query.filter(
             LocationModel.id == location_id)
         if not rooms_in_locations.all():

--- a/helpers/calendar/events.py
+++ b/helpers/calendar/events.py
@@ -8,6 +8,7 @@ from api.room.models import Room as RoomModel
 from api.events.models import Events as EventsModel
 from .analytics_helper import CommonAnalytics
 from .credentials import Credentials, get_events_within_datetime_range
+from utilities.validations import remove_invalid_events
 
 
 class RoomSchedules(Credentials):
@@ -70,6 +71,8 @@ class RoomSchedules(Credentials):
             except GraphQLError:
                 continue
             for event in events_result:
+                if remove_invalid_events(event, events_result, start_date):
+                    continue
                 CommonAnalytics.format_date(event["start"]["dateTime"])
                 event_start_date = parser.parse(
                     event["start"]["dateTime"]).astimezone(pytz.utc)

--- a/utilities/validations.py
+++ b/utilities/validations.py
@@ -105,3 +105,18 @@ def validate_date_range(**kwargs):
     elif (('end_date' and 'start_date' in kwargs) and
             kwargs['end_date'] < kwargs['start_date']):
         raise ValueError('Earlier date should be lower than later date')
+
+
+def remove_invalid_events(event, events_result, start_date):
+    """
+    Function to remove an event that does not lie
+    in the date range passed
+    :params
+        - event
+        - events_result
+        - start_date
+    """
+    if event["start"]["dateTime"] < start_date:
+        events_result.remove(event)
+        return True
+    return False


### PR DESCRIPTION
#### Description
Currently, the data being returned by the application using that particular query does not exclude all data for a specified date range. The changes introduced here rectify this.

#### Type of change
Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
To recreate the bug;
 - Create a room with the calenderId posted on this [thread](https://andela.slack.com/archives/GAJJA2ETB/p1551788890003800).
- Run the query below on the develop branch;
```
query{
    analyticsForDailyRoomEvents(startDate:"jan 10 2019", endDate:"feb 15 2019"){
        day
        events{
            eventSummary
            startTime
            endTime
            roomName
            noOfParticipants
        }
    }
}
```
- The response returned will have data not part of the date range if one is to copy and paste it into the pages app and then search for 2018.
- Check out to the branch on which this PR has been raised.
- Rerunning the query will show that the data has been excluded

#### Any background context you want to provide?
To increase coverage, the events.json file will need to be adjusted such that data that matches what is being filtered out by these changes is included.

#### Checklist:
- [x] My code follows the style guidelines of this project

- [x] I have linted my code prior to submission

- [x] I have made the corresponding changes to the documentation

- [ ] My changes generate no new warnings 

- [ ] I have added tests that prove my feature works

- [x] New and existing unit tests pass locally with my changes


#### Pivotal Tracker
[#164399894](https://www.pivotaltracker.com/story/show/164399894)