### PR TITLE
#164462422 Make location_id a required field

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -103,7 +103,7 @@ class CreateRoom(graphene.Mutation):
         room_type = graphene.String()
         capacity = graphene.Int(required=True)
         image_url = graphene.String()
-        location_id = graphene.Int()
+        location_id = graphene.Int(required=True)
         floor_id = graphene.Int(required=True)
         calendar_id = graphene.String()
         office_id = graphene.Int(required=True)

--- a/fixtures/room/create_room_fixtures.py
+++ b/fixtures/room/create_room_fixtures.py
@@ -285,7 +285,7 @@ room_mutation_query_duplicate_name_response = {
 room_duplicate_calender_id_mutation_query = '''
     mutation {
         createRoom(
-            name: "Mbarara", roomType: "Meeting", capacity: 4, floorId: 4, officeId: 1,
+            name: "Mbarara", roomType: "Meeting", capacity: 4, floorId: 4, officeId: 1, locationId:1,
             calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
             imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
             room {


### PR DESCRIPTION
#### What does this PR do?
The PR ensures addition of location id during room creation.

#### Description of Task to be completed?
The location id has now been set to required, that is one cannot create a room without it.

#### How should this be manually tested?
* Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
* git checkout to `chore/164462422-set-location-id-required` and run the following mutation:

```
mutation {
        createRoom(
            name: "Hello", roomType: "Meeting", capacity: 4, floorId:2, officeId:1, locationId:1,
       calendarId:"andela.com_2d3237333239383832343333@resource.calendar.google.com",
imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {
            room {
                name
                roomType
               locationId
                capacity
                imageUrl
            }
        }
    }
```
* Check db to ensure the room created has a location id.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#164462422](https://www.pivotaltracker.com/story/show/164462422)

#### Screenshots (if appropriate)
N/A
