### PR TITLE
#164101018 (V2) Restrict Query Remote Rooms by Location 

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -7,11 +7,15 @@ from api.room.schema import (PaginatedRooms, Calendar, Room)
 from helpers.calendar.events import RoomSchedules
 from helpers.calendar.analytics import RoomStatistics  # noqa: E501
 from api.room.models import Room as RoomModel
+from helpers.auth.user_details import get_user_from_db
+from helpers.remote_rooms.remote_rooms_location import (
+     map_remote_room_location_to_filter
+)
+from helpers.calendar.credentials import get_google_api_calendar_list
 from api.room.schema import (RatioOfCheckinsAndCancellations,
                              BookingsAnalyticsCount)
 from helpers.pagination.paginate import ListPaginate
 from helpers.calendar.analytics_helper import CommonAnalytics
-from helpers.calendar.credentials import get_google_api_calendar_list
 
 
 class Analytics(graphene.ObjectType):
@@ -65,7 +69,11 @@ class Query(graphene.ObjectType):
         room_id=graphene.Int()
     )
 
-    all_remote_rooms = graphene.Field(AllRemoteRooms)
+    all_remote_rooms = graphene.Field(
+        AllRemoteRooms,
+        description="Returns a list of all remote rooms",
+        return_all=graphene.Boolean()
+        )
 
     get_room_by_name = graphene.List(
         Room,
@@ -166,14 +174,19 @@ class Query(graphene.ObjectType):
         return response
 
     @Auth.user_roles('Admin')
-    def resolve_all_remote_rooms(self, info):
+    def resolve_all_remote_rooms(self, info, return_all=None):
         page_token = None
+        filter = map_remote_room_location_to_filter()
+        location = 'all' if return_all else get_user_from_db().location
         remote_rooms = []
         while True:
             calendar_list = get_google_api_calendar_list(pageToken=page_token)
             for room_object in calendar_list['items']:
-                if 'andela.com' in room_object['id'] and room_object['id'].endswith(  # noqa
-                        'resource.calendar.google.com'):
+                if 'andela.com' in room_object['id'] and room_object['id'].endswith( # noqa
+                    'resource.calendar.google.com') and filter.get(location)(
+                        room_object[
+                            'summary'
+                        ]):
                     calendar_id = room_object['id']
                     room_name = room_object['summary']
                     remote_room = RemoteRoom(

--- a/helpers/calendar/credentials.py
+++ b/helpers/calendar/credentials.py
@@ -2,6 +2,7 @@ import os
 
 from apiclient.discovery import build
 from httplib2 import Http
+from graphql import GraphQLError
 from oauth2client import file, client, tools  # noqa
 from oauth2client.client import OAuth2WebServerFlow  # noqa
 
@@ -46,8 +47,19 @@ def get_google_calendar_events(calendarId=None, timeMin=None,
     return events
 
 
-def get_google_api_calendar_list(pageToken=None):
+def get_all_google_calendar_events(calendarId=None):
     credentials = Credentials()
     service = credentials.set_api_credentials()
-    calendar_list = service.calendarList().list(pageToken=pageToken).execute()
-    return calendar_list
+    events = service.events().list(calendarId=calendarId).execute()
+    return events
+
+
+def get_google_api_calendar_list(pageToken=None):
+    credentials = Credentials()
+    try:
+        service = credentials.set_api_credentials()
+        calendars_list = service.calendarList().list(
+            pageToken=pageToken).execute()
+    except Exception as exception:
+        raise GraphQLError(exception)
+    return calendars_list

--- a/helpers/remote_rooms/remote_rooms_location.py
+++ b/helpers/remote_rooms/remote_rooms_location.py
@@ -1,0 +1,12 @@
+
+def map_remote_room_location_to_filter():
+    '''
+        map filters for room location
+    '''
+    return {
+            'Nairobi': lambda remote_room: remote_room.startswith('Nairobi'),
+            'Lagos': lambda remote_room: remote_room.find('ET-') != -1,
+            'Kampala': lambda remote_room: remote_room.find('Kampala') != -1
+            and not remote_room.startswith('Nairobi'),
+            'all': lambda remote_room: True  # return True for all rooms
+        }

--- a/tests/test_rooms/test_query_rooms.py
+++ b/tests/test_rooms/test_query_rooms.py
@@ -1,6 +1,5 @@
 import json
 from unittest.mock import patch
-
 from tests.base import BaseTestCase, CommonTestCases
 from helpers.calendar.calendar import get_calendar_list_mock_data
 from fixtures.room.create_room_fixtures import (
@@ -16,6 +15,7 @@ from fixtures.room.query_room_fixtures import (
     all_remote_rooms_query,
     paginated_rooms_query_blank_page
 )
+from helpers.calendar.credentials import get_google_api_calendar_list
 
 
 class QueryRooms(BaseTestCase):
@@ -31,14 +31,23 @@ class QueryRooms(BaseTestCase):
         expected_response = paginated_rooms_response
         self.assertEqual(paginate_query, expected_response)
 
-    @patch("api.room.schema_query.get_google_api_calendar_list", spec=True)
+    @patch("api.room.schema_query.get_google_api_calendar_list", spec=True,
+           return_value=get_calendar_list_mock_data())
     def test_query_remote_rooms(self, mock_get_json):
-        mock_get_json.return_value = get_calendar_list_mock_data()
         CommonTestCases.admin_token_assert_in(
             self,
             all_remote_rooms_query,
             "calendar.google.com"
         )
+
+    @patch("helpers.calendar.credentials.Credentials")
+    def test_calendar_list_function(self, mocked_method):
+        '''
+            mock calender API service and
+            test if it was called atleast once
+        '''
+        get_google_api_calendar_list()
+        assert mocked_method.called
 
     def test_query_room_with_id(self):
         query = self.client.execute(room_query_by_id)


### PR DESCRIPTION
 ### What does this PR do?
Restrict query remote rooms by location.
### Description of the task to be completed?
When all remote rooms are queried, the result should be displayed only rooms available in the user location.
### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `git checkout ft-restrict-query-remote-rooms-by-location-v2-164101018`
 - Perform the query below. Remember to provide the desired location access token.
```
query {
   allRemoteRooms {
    rooms {
      calendarId
      name
    }
  }
}
```
 - To return all the remote rooms available, use the `returnAll: true` flag:
```
query {
   allRemoteRooms(returnAll: true) {
    rooms {
      calendarId
      name
    }
  }
}
```
The query returns only the rooms in the admin location. 

### Any background context you want to provide?
N/A
### What are the relevant pivotal tracker stories?
[#164101018](https://www.pivotaltracker.com/story/show/164101018)
### Screenshots
 - #### Query remote rooms by Kampala admin.
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/38049235/53319946-27ecb000-38e5-11e9-8b0c-3e9fa5806d56.png">

 - #### Query remote rooms by Lagos admin.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/38049235/53320571-17d5d000-38e7-11e9-9380-b8f480c13ea7.png">

 - #### Query remote rooms by Nairobi admin.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/38049235/53320651-48b60500-38e7-11e9-9c68-221c0def761e.png">

 - #### Query all remote rooms regardless of the location of the admin.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/38049235/53724715-85e83d00-3e7b-11e9-8323-94b7e067890f.png">
