### PR TITLE
#164361872 Validate Questions Creation.

### DIFF
--- a/api/question/schema.py
+++ b/api/question/schema.py
@@ -6,7 +6,8 @@ from api.question.models import Question as QuestionModel
 from utilities.validations import (
     validate_empty_fields,
     validate_date_time_range,
-    validate_question_type
+    validate_question_type,
+    validate_question_length
     )
 from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
@@ -44,6 +45,7 @@ class CreateQuestion(graphene.Mutation):
     def mutate(self, info, **kwargs):
         validate_empty_fields(**kwargs)
         validate_question_type(**kwargs)
+        validate_question_length(kwargs['question_title'])
         validate_date_time_range(**kwargs)
         question = QuestionModel(**kwargs)
         payload = {

--- a/fixtures/questions/create_questions_fixtures.py
+++ b/fixtures/questions/create_questions_fixtures.py
@@ -53,6 +53,24 @@ create_question_response = {
   }
 }
 
+question_mutation_with_very_long_title = '''
+     mutation{{
+  createQuestion(questionType:"Rate",
+  questionTitle:"This is a very very long question title"
+  question:"How will you rate the brightness of the room",
+  startDate:"{}", endDate:"{}") {{
+    question{{
+      id
+      question
+      questionType
+      startDate
+      endDate
+      }}
+  }}
+}}
+'''.format(start_date, end_date)
+
+
 question_mutation_query_without_name = '''
      mutation{{
   createQuestion(questionType:"",
@@ -75,6 +93,23 @@ question_mutation_query_with_invalid_question_type = '''
   createQuestion(questionType:"Rates",
   questionTitle:"Rating Feedback",
   question:"How will you rate the cleanliness of the room",
+  startDate:"{}", endDate:"{}") {{
+    question{{
+      id
+      question
+      questionType
+      startDate
+      endDate
+      }}
+  }}
+}}
+'''.format(start_date, end_date)
+
+question_mutation_query_with_spaces_only_title = '''
+     mutation{{
+  createQuestion(questionType:"Rating",
+  questionTitle:"  "
+  question:"How will you rate the brightness of the room",
   startDate:"{}", endDate:"{}") {{
     question{{
       id

--- a/tests/test_questions/test_create_question.py
+++ b/tests/test_questions/test_create_question.py
@@ -6,9 +6,11 @@ from fixtures.questions.create_questions_fixtures import (
    create_question_query,
    create_question_response,
    question_mutation_query_without_name,
+   question_mutation_with_very_long_title,
    create_question_query_with_early_startDate,
    create_question_query_with_early_endDate,
-   question_mutation_query_with_invalid_question_type
+   question_mutation_query_with_invalid_question_type,
+   question_mutation_query_with_spaces_only_title
 )
 
 
@@ -26,6 +28,17 @@ class TestCreateBlock(BaseTestCase):
             self,
             create_question_query,
             create_question_response
+        )
+
+    def test_create_question_with_long_title(self):
+        """
+        Testing create question with title more
+        than 20 characters
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            question_mutation_with_very_long_title,
+            "questionTitle should be less that 20 characters"
         )
 
     def test_question_creation_with_name_empty(self):
@@ -46,6 +59,16 @@ class TestCreateBlock(BaseTestCase):
             self,
             question_mutation_query_with_invalid_question_type,
             "Not a valid question type"
+        )
+
+    def test_question_creation_with_spaces_only(self):
+        """
+        Test question creation with spaces only
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            question_mutation_query_with_spaces_only_title,
+            "question_title is required field"
         )
 
     def test_question_creation_with_wrong_startDate(self):

--- a/utilities/validations.py
+++ b/utilities/validations.py
@@ -22,8 +22,20 @@ def validate_empty_fields(**kwargs):
     """
     for field in kwargs:
         value = kwargs.get(field)
+        if isinstance(value, str):
+            value = value.strip()
         if not type(value) is bool and not value:
             raise AttributeError(field + " is required field")
+
+
+def validate_question_length(question_title):
+    """
+    Function to validate the question length is less than
+    20 characters
+    :params question
+    """
+    if not len(question_title) < 20:
+        raise AttributeError("questionTitle should be less that 20 characters")
 
 
 def validate_date_time_range(**kwargs):


### PR DESCRIPTION
#### Description
Currently, you can create a question with empty fields with just spaces. The PR strips these spaces so you don't create a question with empty fields

#### Type of change
Bug (validate question creation)

#### How Has This Been Tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `git checkout bg-validate-questions-creation-164361872`
 - Perform the mutation below with empty `quetionTitle`:
```
mutation {
  createQuestion(questionType:"1", questionTitle:"   ", question:"How would you rate the cleanliness of this room",
    startDate: "2019-03-12T14:25:00", endDate: "2019-03-19T14:25:37")
{
  question{
    id,
    questionTitle,
    questionType,
    question
  }
}
}
```
 - create Question with all the required:
```
mutation {
  createQuestion(questionType:"Ratings", questionTitle:"Room Tablets", question:"How would you rate the cleanliness of this room",
    startDate: "2019-03-12T14:25:00", endDate: "2019-03-19T14:25:37")
{
  question{
    id,
    questionTitle,
    questionType,
    question
  }
}
}
```
The mutation above create a new Question.

### What are the relevant pivotal tracker stories?
[#164361872](https://www.pivotaltracker.com/story/show/164361872)

#### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Screenshots
 - ## Before
 - #### create Question with empty field.
<img width="1205" alt="image" src="https://user-images.githubusercontent.com/38049235/54110498-a0c62e80-43f2-11e9-95d9-b032d641ec9d.png">

 - ## After
 - #### create Question with empty field.
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/38049235/54110278-0534be00-43f2-11e9-8bd6-f795310cef58.png">

