### PR TITLE
#164457495 Implement get node by id

### DIFF
--- a/api/office_structure/schema.py
+++ b/api/office_structure/schema.py
@@ -65,6 +65,20 @@ class DeleteNode(graphene.Mutation):
         return DeleteNode(node=node)
 
 
+class Query(graphene.ObjectType):
+    node = graphene.Field(
+        OfficeStructure,
+        node_id=graphene.Int()
+    )
+
+    def resolve_node(self, info, node_id):
+        query = OfficeStructure.get_query(info)
+        node = query.filter(OfficeStructureModel.id == node_id).first()
+        if not node:
+            raise GraphQLError("Node not found")
+        return node
+
+
 class Mutation(graphene.ObjectType):
     create_node = CreateNode.Field(
         description="Creates a level or node when given the arguments\

--- a/fixtures/office_structure/get_node_fixtures.py
+++ b/fixtures/office_structure/get_node_fixtures.py
@@ -1,0 +1,37 @@
+get_node_query = '''
+query {
+    node(nodeId: 1) {
+      name
+      level
+      left
+      right
+      id
+    }
+}
+'''
+
+get_node_query_response = {
+    "data": {
+        "node": {
+            "name": "location",
+            "level": 1,
+            "left": 1,
+            "right": 4,
+            "id": "1"
+        }
+    }
+}
+
+get_node_non_existant_id_query = '''
+query {
+    node(nodeId: 100) {
+      name
+      level
+      left
+      right
+      id
+    }
+}
+'''
+
+get_node_with_non_existant_id_response = "Node not found"

--- a/schema.py
+++ b/schema.py
@@ -30,6 +30,7 @@ class Query(
         api.response.schema.Query,
         api.response.schema_query.Query,
         api.question.schema.Query,
+        api.office_structure.schema.Query,
         api.structure.schema.Query
 ):
     """Root for converge Graphql queries"""

--- a/tests/test_office_structure/test_get_node.py
+++ b/tests/test_office_structure/test_get_node.py
@@ -1,0 +1,28 @@
+import json
+from tests.base import BaseTestCase
+from fixtures.office_structure.get_node_fixtures import (
+    get_node_query,
+    get_node_query_response,
+    get_node_non_existant_id_query,
+    get_node_with_non_existant_id_response
+)
+
+
+class TestQueryNode(BaseTestCase):
+    def test_get_node_query(self):
+        """
+        Test can get specific node by id
+        """
+        response = self.client.execute(get_node_query)
+        actual_response = json.loads(json.dumps(response))
+        self.assertEquals(actual_response, get_node_query_response)
+
+    def test_get_node_with_non_existant_id(self):
+        """
+        Test cannot get node with non-existant id
+        """
+        actual_response = self.client.execute(get_node_non_existant_id_query)
+        expected_response = get_node_with_non_existant_id_response
+        self.assertEquals(
+            actual_response["errors"][0]['message'], expected_response
+        )


### PR DESCRIPTION
#### Description
We currently have an endpoint to add a node to the office structure. This endpoint gets node when passed an ID.

#### Type of change
Feature (Get specific node by ID)

#### How Has This Been Tested?
- git pull and checkout branch `ft-get-single-node-164457495`
- run the query below.
````
query {
    node(nodeId: 1) {
      name
      level
      left
      right
      id
    }
}
````

#### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

#### What are the relevant pivotal tracker stories?
[#164457495](https://www.pivotaltracker.com/story/show/164457495)

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/12385482/54358098-9a44ea80-4670-11e9-8df6-52d01921402d.png)

