### PR TITLE
#164457514 Add tag id to addNode endpoint

### DIFF
--- a/api/office_structure/models.py
+++ b/api/office_structure/models.py
@@ -21,12 +21,12 @@ class OfficeStructure(Base, Utility, BaseNestedSets):
     def __repr__(self):
         return "<OfficeStructure {}>".format(self.name)
 
-    def add_node(self, name, parent_id=None):
+    def add_node(self, **kwargs):
         """Function for adding nodes"""
-        if parent_id is None:
-            db_session.add(OfficeStructure(name=name))
-        else:
-            db_session.add(OfficeStructure(name=name, parent_id=parent_id))
+        db_session.add(OfficeStructure(
+                name=kwargs['name'],
+                parent_id=kwargs.get('parent_id', None),
+                tag_id=kwargs.get('tag_id', None)))
 
         db_session.commit()
 

--- a/api/office_structure/schema.py
+++ b/api/office_structure/schema.py
@@ -9,6 +9,7 @@ from utilities.validations import (
     validate_empty_fields,
     validate_parent_node_id,
     )
+from utilities.validator import verify_tag_id
 
 
 class OfficeStructure(SQLAlchemyObjectType):
@@ -24,6 +25,7 @@ class CreateNode(graphene.Mutation):
     class Arguments:
         name = graphene.String(required=True)
         parent_id = graphene.Int(required=False)
+        tag_id = graphene.Int(required=False)
     node = graphene.Field(OfficeStructure)
 
     @Auth.user_roles('Admin')
@@ -31,6 +33,8 @@ class CreateNode(graphene.Mutation):
         validate_empty_fields(**kwargs)
         if 'parent_id' in kwargs:
             validate_parent_node_id(parent_id=kwargs['parent_id'])
+        if 'tag_id' in kwargs:
+            verify_tag_id(tag_id=kwargs['tag_id'])
         node = OfficeStructureModel(**kwargs)
         payload = {
             'model': OfficeStructureModel,

--- a/fixtures/office_structure/create_node_fixtures.py
+++ b/fixtures/office_structure/create_node_fixtures.py
@@ -1,6 +1,6 @@
 node_creation_mutation = '''
 mutation{
-  createNode(name:"floors", parentId:1){
+  createNode(name:"floors", parentId:1, tagId:1){
     node{
       name
       level
@@ -27,6 +27,19 @@ mutation{
 child_node_creation_mutation_with_non_existent_parent_id = '''
 mutation{
   createNode(name:"floors", parentId:5){
+    node{
+      name
+      level
+      left
+      right
+    }
+  }
+}
+'''
+
+node_creation_mutation_with_non_existent_tag_id = '''
+mutation{
+  createNode(name:"floors", tagId:5){
     node{
       name
       level

--- a/tests/base.py
+++ b/tests/base.py
@@ -62,7 +62,11 @@ class BaseTestCase(TestCase):
             role.save()
             admin_user.roles.append(role)
             lagos_admin.roles.append(role)
-            root_node = OfficeStructure(name='location')
+            tag = Tag(name='Block-B',
+                      color='green',
+                      description='The description')
+            tag.save()
+            root_node = OfficeStructure(name='location', tag_id=1)
             root_node.save()
             leaf_node = OfficeStructure(name='wings', parent_id=1)
             leaf_node.save()
@@ -79,10 +83,6 @@ class BaseTestCase(TestCase):
                                       abbreviation='LOS',
                                       structure_id=1)
             location_three.save()
-            tag = Tag(name='Block-B',
-                      color='green',
-                      description='The description')
-            tag.save()
             tag_two = Tag(name='Block-C',
                           color='blue',
                           description='The description')

--- a/tests/test_office_structure/test_add_node.py
+++ b/tests/test_office_structure/test_add_node.py
@@ -2,7 +2,8 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.office_structure.create_node_fixtures import (
     node_creation_mutation,
     duplicate_node_creation,
-    child_node_creation_mutation_with_non_existent_parent_id
+    child_node_creation_mutation_with_non_existent_parent_id,
+    node_creation_mutation_with_non_existent_tag_id
 )
 from api.office_structure.models import OfficeStructure
 
@@ -43,6 +44,18 @@ class TestAddNode(BaseTestCase):
             "Parent node ID Provided does not exist"
         )
 
+    def test_add_node_with_non_existent_tag_id(self):
+        """
+        Tests an admin can not create
+        a node with a non_existent
+        tagId
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            node_creation_mutation_with_non_existent_tag_id,
+            "Tag ID Provided does not exist"
+        )
+
     def test_add_node_method(self):
         """
         Tests a node can be
@@ -60,6 +73,8 @@ class TestAddNode(BaseTestCase):
         self.assertEqual(child_node.parent_id, 1)
         nodes = OfficeStructure.query.all()
         self.assertEqual(len(nodes), 4)
+        node_tags = OfficeStructure.query.filter_by(id=1).first()
+        self.assertEqual(node_tags.tag_id, 1)
 
     def test_add_branch(self):
         """

--- a/utilities/validator.py
+++ b/utilities/validator.py
@@ -4,6 +4,7 @@ from helpers.calendar.credentials import (
     get_google_calendar_events)
 
 from api.location.models import Location
+from api.tag.models import Tag as TagModel
 
 
 def verify_email(email):
@@ -23,6 +24,16 @@ def verify_location_id(kwargs):
     if location_id and not Location.query.filter_by(id=location_id,
                                                     state="active").first():
         raise AttributeError("Location Id does not exist")
+
+
+def verify_tag_id(tag_id):
+    """
+    Function to validate tag ID
+    when creating a node or a child
+    """
+    tag_id = TagModel.query.filter_by(id=tag_id).first()
+    if not tag_id:
+        raise GraphQLError("Tag ID Provided does not exist")
 
 
 class ErrorHandler():


### PR DESCRIPTION
 ### What does this PR do?
Adds the tag_id argument to the addNode endpoint
### Description of the task to be completed?
When an admin is creating a new node they can add an optional argument tag_id.
### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `git checkout story/164457514-add-tagid-to-addnode-endpoint`
 - Perform the mutation below to create a new tag.
```
mutation {
   createTag (name: "BlockA", color: "blue", description: "Block") {
    tag {
      id,
      name,
      color,
      description
    }
  }
}
```

- Perform this mutation to add the tag_id from the created tag.

```
mutation{
  createNode(name:"Block", tagId:1){
    node{
      id
      name
      level
      left
      right
    }
   }
}
```

### Any background context you want to provide?
N/A
### What are the relevant pivotal tracker stories?
[#164457514](https://www.pivotaltracker.com/story/show/164457514)
### Screenshots
 - #### Mutation to add the tag_id
![image](https://user-images.githubusercontent.com/29709981/54196767-3df89400-44d3-11e9-8201-6d8659e2c7fa.png)


- #### The added tag_id into the database
![image](https://user-images.githubusercontent.com/29709981/54196791-4d77dd00-44d3-11e9-9175-5d6812c7bb7a.png)




