### PR TITLE
#164623476 Ignore rooms with invalid Calendar IDs

### DIFF
--- a/fixtures/room/most_booked_room_least_booked_rooms_fixtures.py
+++ b/fixtures/room/most_booked_room_least_booked_rooms_fixtures.py
@@ -74,10 +74,10 @@ top_ten_response = {
   }
 }
 
-test_for_division_error = '''
+test_for_no_meetings = '''
     {
         analyticsForBookedRooms(
-            startDate:"Aug 8 2018", endDate: "Aug 12 2018", limit:10)
+            startDate:"Aug 12 2018", endDate: "Aug 12 2018", limit:10)
         {
             analytics {
                 roomName
@@ -87,3 +87,11 @@ test_for_division_error = '''
         }
     }
 '''
+
+test_for_no_meetings_response = {
+  "data": {
+    "analyticsForBookedRooms": {
+      "analytics": []
+    }
+  }
+}

--- a/fixtures/room/room_analytics_duration_fixtures.py
+++ b/fixtures/room/room_analytics_duration_fixtures.py
@@ -172,3 +172,27 @@ get_paginated_meetings_total_duration_invalid_page_result = {
         "analyticsForMeetingsDurations": null
     }
 }
+
+get_weekly_meetings_total_duration_no_meetings_query = '''
+query {
+    analyticsForMeetingsDurations(startDate:"Aug 12 2018", endDate:"Aug 12 2018"){  # noqa: E501
+        MeetingsDurationaAnalytics{
+            roomName
+            count
+            totalDuration
+            events{
+                durationInMinutes
+                numberOfMeetings
+            }
+        }
+    }
+}
+'''
+
+get_weekly_meetings_total_duration_no_meetings_response = {
+    'data': {
+        'analyticsForMeetingsDurations': {
+            'MeetingsDurationaAnalytics': []
+        }
+    }
+}

--- a/fixtures/room/room_analytics_least_used_fixtures.py
+++ b/fixtures/room/room_analytics_least_used_fixtures.py
@@ -101,6 +101,26 @@ get_room_usage_anaytics_response = {
     }
 }
 
+get_room_usage_no_meetings_analytics = '''
+    {
+    analyticsForMeetingsPerRoom(
+        startDate:"Aug 12 2018" endDate:"Aug 12 2018"){
+            analytics{
+                roomName
+                count
+            }
+        }
+    }
+'''
+
+get_room_usage_no_meetings_anaytics_response = {
+    "data": {
+        "analyticsForMeetingsPerRoom": {
+            "analytics": []
+        }
+    }
+}
+
 get_least_used_room_per_month = '''
     {
         analyticsForLeastUsedRooms(startDate:"Jul 1 2018", endDate:"Jul 31 2018")  # noqa: E501

--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -1,5 +1,4 @@
 from collections import Counter
-from graphql import GraphQLError
 from .credentials import Credentials
 from helpers.calendar.analytics_helper import (
     CommonAnalytics, EventsDuration, RoomStatistics
@@ -81,6 +80,8 @@ class RoomAnalytics(Credentials):
         for room in rooms_available:
             all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room['calendar_id'], start_date, end_date)
+            if len(all_events) == 0:
+                continue
             room_details = RoomStatistics(room_name=room["name"], count=len(all_events))  # noqa: E501
             res.append(room_details)
         return res
@@ -98,6 +99,8 @@ class RoomAnalytics(Credentials):
         result = []
         for room in rooms:
             events = CommonAnalytics.get_all_events_in_a_room(self, room['calendar_id'], start_date, end_date)  # noqa: E501
+            if len(events) == 0:
+                continue
             events_duration = []
             for event in events:
                 start = event['start'].get('dateTime', event['start'].get('date'))  # noqa: E501
@@ -144,10 +147,9 @@ class RoomAnalytics(Credentials):
         for room in rooms_available:
             all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room['calendar_id'], start_date, end_date)
-            try:
-                room_details = RoomStatistics(room_name=room["name"], meetings=len(all_events), percentage=(len(all_events))/bookings*100)  # noqa: E501
-            except ZeroDivisionError:
-                raise GraphQLError("There are no meetings")
+            if len(all_events) == 0:
+                continue
+            room_details = RoomStatistics(room_name=room["name"], meetings=len(all_events), percentage=(len(all_events))/bookings*100)  # noqa: E501
             result.append(room_details)
             result.sort(key=lambda x: x.meetings, reverse=True)
         return result

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -110,7 +110,7 @@ class CommonAnalytics(Credentials):
                 timeMax=max_limit, singleEvents=True,
                 orderBy='startTime')
         except Exception:
-            raise GraphQLError("Resource not found")
+            return []
         all_events = events_result.get('items', [])
         return all_events
 

--- a/tests/test_rooms/test_room_analytics_with_no_meetings.py
+++ b/tests/test_rooms/test_room_analytics_with_no_meetings.py
@@ -3,7 +3,16 @@ from unittest.mock import patch
 from tests.base import BaseTestCase, CommonTestCases
 from helpers.calendar.calendar import get_events_mock_data
 from fixtures.room.most_booked_room_least_booked_rooms_fixtures import (
-    test_for_division_error
+    test_for_no_meetings,
+    test_for_no_meetings_response
+)
+from fixtures.room.room_analytics_least_used_fixtures import (
+    get_room_usage_no_meetings_analytics,
+    get_room_usage_no_meetings_anaytics_response
+)
+from fixtures.room.room_analytics_duration_fixtures import (
+    get_weekly_meetings_total_duration_no_meetings_query,
+    get_weekly_meetings_total_duration_no_meetings_response
 )
 
 events = get_events_mock_data()
@@ -13,11 +22,33 @@ class QueryRoomsEmptyAnalytics(BaseTestCase):
 
     @patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
            spec=True)
-    def test_for_percentage_division_error(self, mock_get_json):
+    def test_for_rooms_with_no_meetings(self, mock_get_json):
         mock_get_json.return_value = events
         events['items'].clear()
-        CommonTestCases.admin_token_assert_in(
+        CommonTestCases.admin_token_assert_equal(
             self,
-            test_for_division_error,
-            "There are no meetings"
+            test_for_no_meetings,
+            test_for_no_meetings_response
+        )
+
+    @patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+           spec=True)
+    def test_for_room_usage_with_no_meetings(self, mock_get_json):
+        mock_get_json.return_value = events
+        events['items'].clear()
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_room_usage_no_meetings_analytics,
+            get_room_usage_no_meetings_anaytics_response
+        )
+
+    @patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+           spec=True)
+    def test_for_meeting_duration_with_no_meetings(self, mock_get_json):
+        mock_get_json.return_value = events
+        events['items'].clear()
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_weekly_meetings_total_duration_no_meetings_query,
+            get_weekly_meetings_total_duration_no_meetings_response
         )


### PR DESCRIPTION
 ### What does this PR do?
Ignores rooms with invalid Calendar IDs that are causing Analytics to crash
### Description of the task to be completed?
Currently, the backend appears not to return data for certain locations. This is because some rooms in these locations have invalid Calendar IDs. This PR ensures that analytics continues to work with only rooms that have valid Calendar IDs. 
### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout the bug fix branch
 - Perform the query below to get most booked rooms.
```
{
 analyticsForBookedRooms(startDate: "Jan 14 2019", endDate: "Mar 15 2019", limit:10, criteria:"most_booked"){
     analytics{
      roomName
      count
      meetings
      percentage
      roomName
    }
    }
}
```
### Any background context you want to provide?
N/A
### What are the relevant pivotal tracker stories?
[#164623476](https://www.pivotaltracker.com/story/show/164623476)
### Screenshots
N/A



