### PR TITLE
#164471444 Fetch Total Booking Count for a Specific Room

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -92,6 +92,7 @@ class BookingsAnalyticsCount(graphene.ObjectType):
     """
     bookings = graphene.Int()
     period = graphene.String()
+    room_name = graphene.String()
 
 
 class CreateRoom(graphene.Mutation):

--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -10,7 +10,7 @@ from helpers.calendar.analytics import RoomStatistics  # noqa: E501
 from api.room.models import Room as RoomModel
 from helpers.auth.user_details import get_user_from_db
 from helpers.remote_rooms.remote_rooms_location import (
-     map_remote_room_location_to_filter
+    map_remote_room_location_to_filter
 )
 from api.room.schema import (RatioOfCheckinsAndCancellations,
                              BookingsAnalyticsCount)
@@ -124,7 +124,7 @@ class Query(graphene.ObjectType):
         AllRemoteRooms,
         description="Returns a list of all remote rooms",
         return_all=graphene.Boolean()
-        )
+    )
 
     get_room_by_name = graphene.List(
         Room,
@@ -235,6 +235,7 @@ class Query(graphene.ObjectType):
         BookingsAnalyticsCount,
         start_date=graphene.String(required=True),
         end_date=graphene.String(required=True),
+        room_id=graphene.Int(),
         description="Returns the total number of room bookings and accepts the arguments\
             \n- start_date: Start date when you want to get analytics from\
             [required]\n- end_date: The end date to take the analytics upto\
@@ -270,7 +271,7 @@ class Query(graphene.ObjectType):
         while True:
             calendar_list = get_google_api_calendar_list(pageToken=page_token)
             for room_object in calendar_list['items']:
-                if 'andela.com' in room_object['id'] and room_object['id'].endswith( # noqa
+                if 'andela.com' in room_object['id'] and room_object['id'].endswith(  # noqa
                     'resource.calendar.google.com') and filter.get(location)(
                         room_object[
                             'summary'
@@ -376,11 +377,11 @@ class Query(graphene.ObjectType):
 
     @Auth.user_roles('Admin', 'Default User')
     def resolve_bookings_analytics_count(
-            self, info, start_date, end_date):
+            self, info, start_date, end_date, room_id=None):
         # Getting booking analytics count
         query = Room.get_query(info)
         analytics = RoomAnalyticsRatios.get_bookings_analytics_count(
-            self, query, start_date, end_date)
+            self, query, start_date, end_date, room_id=room_id)
         return analytics
 
     def resolve_analytics_for_daily_room_events(self, info,

--- a/fixtures/room/room_analytics_bookings_count_fixtures.py
+++ b/fixtures/room/room_analytics_bookings_count_fixtures.py
@@ -92,3 +92,47 @@ get_bookings_count_monthly_diff_years_response = {
         }]
     }
 }
+
+get_single_room_daily_count = '''
+query {
+  bookingsAnalyticsCount(startDate:"Nov 10 2018",
+   endDate:"Nov 12 2018", roomId:1){
+   roomName
+   period
+   bookings
+  }
+}
+'''
+
+get_single_room_daily_count_response = {
+  "data": {
+    "bookingsAnalyticsCount": [
+      {
+        "roomName": "Entebbe",
+        "period": "Nov 10 2018",
+        "bookings": 2
+      },
+      {
+        "roomName": "Entebbe",
+        "period": "Nov 11 2018",
+        "bookings": 2
+      },
+      {
+        "roomName": "Entebbe",
+        "period": "Nov 12 2018",
+        "bookings": 2
+      }
+    ]
+  }
+}
+
+non_existing_room_id_query = '''
+query {
+  bookingsAnalyticsCount(startDate:"Nov 10 2018",
+   endDate:"Nov 12 2018", roomId:100){
+   roomName
+   period
+   bookings
+  }
+}
+'''

--- a/helpers/calendar/ratios_and_utilization.py
+++ b/helpers/calendar/ratios_and_utilization.py
@@ -6,6 +6,7 @@ from api.room.models import Room as RoomModel
 from api.events.models import Events
 from api.room.schema import (RatioOfCheckinsAndCancellations,
                              BookingsAnalyticsCount)
+from utilities.verify_ids_for_room import get_room_name
 
 
 class RoomAnalyticsRatios(Credentials):
@@ -20,7 +21,7 @@ class RoomAnalyticsRatios(Credentials):
             - start_date, end_date
         """
         start_date, day_after_end_date = CommonAnalytics.validate_current_date(
-                self, start, end)
+            self, start, end)
         rooms = CommonAnalytics.get_calendar_id_name(
             self, query)
 
@@ -30,7 +31,7 @@ class RoomAnalyticsRatios(Credentials):
         app_events_list = []
 
         for room in rooms:
-            checkins, cancellations, calendar_events_list, app_events_list = RoomAnalyticsRatios().retrieve_cancellations_and_checkins_for_room(room['calendar_id'], # noqa 
+            checkins, cancellations, calendar_events_list, app_events_list = RoomAnalyticsRatios().retrieve_cancellations_and_checkins_for_room(room['calendar_id'],  # noqa
                                                         start_date,
                                                         day_after_end_date,
                                                         checkins,
@@ -39,10 +40,10 @@ class RoomAnalyticsRatios(Credentials):
                                                         app_events_list)
 
         ratio_object = RoomAnalyticsRatios().map_results_to_ratio_class(
-                            checkins,
-                            cancellations,
-                            calendar_events_list,
-                            app_events_list)
+            checkins,
+            cancellations,
+            calendar_events_list,
+            app_events_list)
 
         return ratio_object
 
@@ -52,7 +53,7 @@ class RoomAnalyticsRatios(Credentials):
             - start_date, end_date
         """
         start_date, day_after_end_date = CommonAnalytics.validate_current_date(
-                self, start, end)
+            self, start, end)
         rooms = CommonAnalytics.get_calendar_id_name(
             self, query)
 
@@ -63,7 +64,7 @@ class RoomAnalyticsRatios(Credentials):
             calendar_events_list = []
             app_events_list = []
 
-            checkins, cancellations, calendar_events_list, app_events_list = RoomAnalyticsRatios().retrieve_cancellations_and_checkins_for_room(room['calendar_id'], # noqa
+            checkins, cancellations, calendar_events_list, app_events_list = RoomAnalyticsRatios().retrieve_cancellations_and_checkins_for_room(room['calendar_id'],  # noqa
                                                         start_date,
                                                         day_after_end_date,
                                                         checkins,
@@ -72,11 +73,11 @@ class RoomAnalyticsRatios(Credentials):
                                                         app_events_list)
 
             ratio_object = RoomAnalyticsRatios().map_results_to_ratio_class(
-                                checkins,
-                                cancellations,
-                                calendar_events_list,
-                                app_events_list,
-                                room['name'])
+                checkins,
+                cancellations,
+                calendar_events_list,
+                app_events_list,
+                room['name'])
 
             response.append(ratio_object)
         return response
@@ -95,11 +96,11 @@ class RoomAnalyticsRatios(Credentials):
                 checkins,cancellations, output
         """
         all_events = CommonAnalytics.get_all_events_in_a_room(
-                self, calendar_id, start_date, day_after_end_date)
+            self, calendar_id, start_date, day_after_end_date)
         if all_events:
             for event in all_events:
                 event_details = CommonAnalytics.get_event_details(
-                        self, event, calendar_id)
+                    self, event, calendar_id)
                 if event.get('attendees'):
                     calendar_events_list.append(event_details)
                 if event.get('organizer') and event.get(
@@ -108,9 +109,9 @@ class RoomAnalyticsRatios(Credentials):
 
         room_id = RoomModel.query.filter_by(calendar_id=calendar_id,).first().id  # noqa
 
-        checkins += (Events.query.filter(Events.room_id==room_id, Events.checked_in==True, Events.start_time>=start_date, Events.end_time<day_after_end_date)).count()  # noqa
+        checkins += (Events.query.filter(Events.room_id == room_id, Events.checked_in == True, Events.start_time >= start_date, Events.end_time < day_after_end_date)).count()  # noqa
 
-        cancellations += (Events.query.filter(Events.room_id==room_id, Events.cancelled==True, Events.start_time>=start_date, Events.end_time<day_after_end_date)).count()  # noqa
+        cancellations += (Events.query.filter(Events.room_id == room_id, Events.cancelled == True, Events.start_time >= start_date, Events.end_time < day_after_end_date)).count()  # noqa
 
         return checkins, cancellations, calendar_events_list, app_events_list
 
@@ -137,15 +138,15 @@ class RoomAnalyticsRatios(Credentials):
             checkins,
             bookings)
         result = RatioOfCheckinsAndCancellations(
-                room_name=room_name,
-                checkins=checkins,
-                cancellations=cancellations,
-                bookings=bookings,
-                checkins_percentage=checkins_percentage,
-                cancellations_percentage=cancellations_percentage,
-                app_bookings=app_bookings,
-                app_bookings_percentage=app_bookings_percentage,
-            )
+            room_name=room_name,
+            checkins=checkins,
+            cancellations=cancellations,
+            bookings=bookings,
+            checkins_percentage=checkins_percentage,
+            cancellations_percentage=cancellations_percentage,
+            app_bookings=app_bookings,
+            app_bookings_percentage=app_bookings_percentage,
+        )
         return result
 
     def percentage_formater(self, portion, total):
@@ -159,27 +160,35 @@ class RoomAnalyticsRatios(Credentials):
         except ZeroDivisionError:
             return 0
 
-    def get_bookings_analytics_count(self, query, start, end):
+    def get_bookings_analytics_count(self, query, start, end, room_id=None):
         results = []
-        start_date, day_after_end_date = CommonAnalytics.convert_dates(self, start, end)  # noqa E501
-        start_dt = dateutil.parser.parse(start_date)
-        end_dt = dateutil.parser.parse(day_after_end_date)
-        number_of_days = (end_dt - start_dt).days
+        start_date, day_after_end_date = CommonAnalytics.convert_dates(
+            self, start, end)
+        formated_start_date = dateutil.parser.parse(start_date)
+        formated_end_date = dateutil.parser.parse(day_after_end_date)
+        number_of_days = (formated_end_date - formated_start_date).days
+        room_name = get_room_name(room_id)
 
         if number_of_days <= 30:
-            dates = CommonAnalytics.get_list_of_dates(start, number_of_days)  # noqa E501
+            dates = CommonAnalytics.get_list_of_dates(start, number_of_days)
             for date in dates:
-                bookings = CommonAnalytics.get_total_bookings(self, query, date[0], date[1])  # noqa E501
-                string_date = dateutil.parser.parse(date[0]).strftime("%b %d %Y")  # noqa E501
-                output = BookingsAnalyticsCount(period=string_date, bookings=bookings) # noqa E501
+                bookings = CommonAnalytics.get_total_bookings(
+                    self, query, date[0], date[1], room_id=room_id)
+                string_date = dateutil.parser.parse(
+                    date[0]).strftime("%b %d %Y")
+                output = BookingsAnalyticsCount(
+                    period=string_date, bookings=bookings, room_name=room_name)
                 results.append(output)
-
         else:
-            dates = CommonAnalytics.get_list_of_month_dates(start_date, start_dt, day_after_end_date, end_dt)  # noqa E501
+            dates = CommonAnalytics.get_list_of_month_dates(
+                start_date, formated_start_date,
+                day_after_end_date, formated_end_date)
             for date in dates:
-                bookings = CommonAnalytics.get_total_bookings(self, query, date[0], date[1])  # noqa E501
+                bookings = CommonAnalytics.get_total_bookings(
+                    self, query, date[0], date[1], room_id=room_id)
                 string_month = dateutil.parser.parse(date[0]).strftime("%B")
-                output = BookingsAnalyticsCount(period=string_month, bookings=bookings) # noqa E501
+                output = BookingsAnalyticsCount(
+                    period=string_month, bookings=bookings, room_name=room_name)
                 results.append(output)
 
         return results

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -36,6 +36,9 @@ from fixtures.room.room_analytics_bookings_count_fixtures import (
     get_bookings_count_monthly_response,
     get_bookings_count_monthly_diff_years,
     get_bookings_count_monthly_diff_years_response,
+    get_single_room_daily_count,
+    get_single_room_daily_count_response,
+    non_existing_room_id_query
 )
 
 
@@ -136,3 +139,23 @@ class QueryRoomsAnalytics(BaseTestCase):
         CommonTestCases.admin_token_assert_equal(
             self, get_bookings_count_monthly_diff_years,
             get_bookings_count_monthly_diff_years_response)
+
+    def test_single_room_daily_bookings(self, mock_get_json):
+        """This function tests that the booking count for a single
+                 room is returned provided a room_id is provided
+        """
+        mock_get_json.return_value = get_events_mock_data()
+        CommonTestCases.admin_token_assert_equal(
+            self, get_single_room_daily_count,
+            get_single_room_daily_count_response
+        )
+
+    def test_non_existing_room_id(self, mock_get_json):
+        """This function tests for when the provided room_id
+         does not exist in the database
+        """
+        mock_get_json.return_value = get_events_mock_data()
+        CommonTestCases.admin_token_assert_in(
+            self, non_existing_room_id_query,
+            "Room Id does not exist"
+        )

--- a/utilities/verify_ids_for_room.py
+++ b/utilities/verify_ids_for_room.py
@@ -2,6 +2,7 @@ from api.office.models import Office
 from api.floor.models import Floor
 from api.wing.models import Wing
 from api.location.models import Location
+from api.room.models import Room as RoomModel
 
 
 def verify_ids(office_id, kwargs):
@@ -20,3 +21,12 @@ def verify_ids(office_id, kwargs):
     wing_id = kwargs.get('wing_id')
     if wing_id and not Wing.query.filter_by(id=wing_id).first():
         raise AttributeError("Wing Id does not exist")
+
+
+def get_room_name(room_id):
+    exact_room = RoomModel.query.filter_by(id=room_id).first()
+    if exact_room:
+        room_name = exact_room.name
+    else:
+        room_name = None
+    return room_name


### PR DESCRIPTION
#### What does this PR do?
Fetch Total Booking Count for a Specific Room
#### Description of Task to be completed?
Ensure that the user can view the booking count of a single room.
#### How should this be manually tested?
git checkout `ft-room-booking-count-164471444`
run the mutation below to view bookings for a room with id `1`
Daily bookings count
````
query {
  bookingsAnalyticsCount(startDate:"Nov 10 2018", endDate:"Nov 12 2018", roomId:1){
   roomName
   period
   bookings
  }
}
````
monthly room bookings query
````
query {
  bookingsAnalyticsCount(startDate:"Aug 1 2018", endDate:"Nov 1 2018", roomId:4){
    roomName
   period
   bookings
  }
}
````
#### What are the relevant pivotal tracker stories?
[#164471444](https://www.pivotaltracker.com/story/show/164471444)
#### Screenshots
Daily bookings count
![image](https://user-images.githubusercontent.com/39625835/54515920-8f3ed280-496e-11e9-9185-1a6a8a900786.png)
Monthly bookings count
![image](https://user-images.githubusercontent.com/39625835/54516094-ffe5ef00-496e-11e9-9374-88e7d1b7a380.png)




