### PR TITLE
#164673176 Query status of daily room events

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -78,6 +78,9 @@ class CalendarEvent(graphene.ObjectType):
     end_time = graphene.String()
     room_name = graphene.String()
     event_id = graphene.String()
+    cancelled = graphene.Boolean()
+    state = graphene.String()
+    checked_in = graphene.Boolean()
 
 
 class DailyEvents(graphene.ObjectType):
@@ -343,7 +346,10 @@ class Query(graphene.ObjectType):
                         start_time=event["start_time"],
                         end_time=event["end_time"],
                         room_name=event["room_name"],
-                        event_id=event["event_id"]
+                        event_id=event["event_id"],
+                        cancelled=event["cancelled"],
+                        state=event["state"],
+                        checked_in=event["checked_in"]
                     )
                     daily_events.append(current_event)
             all_days_events.append(

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -123,6 +123,9 @@ class CommonAnalytics:
                     'event_title': event.event_title,
                     'participants': event.number_of_participants,
                     'event_id': event.event_id,
+                    'cancelled_status': event.cancelled,
+                    'checked_in_status': event.checked_in,
+                    'state': event.state,
                 }
                 room_events.append(room_event)
         return room_events

--- a/helpers/calendar/events.py
+++ b/helpers/calendar/events.py
@@ -84,6 +84,9 @@ class RoomSchedules(Credentials):
                     "event_summary": event['event_title'],
                     "date_of_event": day_of_event,
                     "event_id": event['event_id'],
+                    "state": event['state'],
+                    "checked_in": event['checked_in_status'],
+                    "cancelled": event['cancelled_status'],
                 }
                 all_events.append(current_event)
 


### PR DESCRIPTION
 ### What does this PR do?
Query the status of the daily room events
### Description of the task to be completed?
A user should be able to query the status of daily room events and know what events have been canceled and what events are active
### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `git checkout ft-query-status-of-daily-room-events-164673176`
 - Perform the query below to get all locations.
```
query{
    analyticsForDailyRoomEvents(startDate:"jan 10 2019", endDate:"jan 10 2019"){
        day
        events{
          	state
                checkedIn
          	cancelled
                eventSummary
                startTime
                endTime
                roomName
                noOfParticipants
          	eventId
          }
    }
}
```

### Any background context you want to provide?
N/A
### What are the relevant pivotal tracker stories?
[#164673176](https://www.pivotaltracker.com/story/show/164673176)
### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
### Screenshot:
![image](https://user-images.githubusercontent.com/29709981/55222092-0bad9d00-521c-11e9-8e36-1b4e8354dc1e.png)
