### PR TITLE
#164823820 (v2) Paginate room events

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -88,6 +88,17 @@ class DailyEvents(graphene.ObjectType):
     events = graphene.List(CalendarEvent)
 
 
+class PaginatedEvents(graphene.ObjectType):
+    """
+        Paginated result for daily room events
+        analytics
+    """
+    DailyRoomEvents = graphene.List(DailyEvents)
+    has_previous = graphene.Boolean()
+    has_next = graphene.Boolean()
+    pages = graphene.Int()
+
+
 class Query(graphene.ObjectType):
     all_rooms = graphene.Field(
         PaginatedRooms,
@@ -127,9 +138,11 @@ class Query(graphene.ObjectType):
     )
 
     analytics_for_daily_room_events = graphene.Field(
-        graphene.List(DailyEvents),
+        PaginatedEvents,
         start_date=graphene.String(required=True),
-        end_date=graphene.String(required=True)
+        end_date=graphene.String(required=True),
+        page=graphene.Int(),
+        per_page=graphene.Int(),
 
     )
 
@@ -325,9 +338,9 @@ class Query(graphene.ObjectType):
             self, query, start_date, end_date)
         return analytics
 
-    def resolve_analytics_for_daily_room_events(self, info,
-                                                start_date, end_date
-                                                ):
+    def resolve_analytics_for_daily_room_events(
+        self, info, start_date, end_date, page=None, per_page=None
+    ):
         start_date, end_date = CommonAnalytics().convert_dates(
             start_date, end_date
         )
@@ -358,8 +371,23 @@ class Query(graphene.ObjectType):
                     events=daily_events
                 )
             )
-
-        return all_days_events
+        if page and per_page:
+            paginated_results = ListPaginate(
+                iterable=all_days_events, per_page=per_page, page=page
+            )
+            current_page = paginated_results.current_page
+            has_previous = paginated_results.has_previous
+            has_next = paginated_results.has_next
+            pages = paginated_results.pages
+            return PaginatedEvents(
+                DailyRoomEvents=current_page,
+                has_next=has_next,
+                has_previous=has_previous,
+                pages=pages
+            )
+        return PaginatedEvents(
+            DailyRoomEvents=all_days_events
+        )
 
     @Auth.user_roles('Admin', 'Default User')
     def resolve_analytics_for_booked_rooms(self, info, **kwargs):

--- a/fixtures/room/daily_room_events_fixture.py
+++ b/fixtures/room/daily_room_events_fixture.py
@@ -1,35 +1,42 @@
 daily_room_events_query = '''
 query{
     analyticsForDailyRoomEvents(startDate:"Jul 11 2018", endDate:"Jul 11 2018"){
-        day
-        events{
-            eventSummary
-            startTime
-            endTime
-            roomName
-            noOfParticipants
+        DailyRoomEvents {
+            day
+            events{
+                eventSummary
+                startTime
+                endTime
+                roomName
+                noOfParticipants
+            }
         }
     }
 }
 '''
 daily_room_events_wrong_date_format_query = '''
 query{
-    analyticsForDailyRoomEvents(startDate:"10 jan 2019", endDate:"10 jan 2019"){
-        day
-        events{
-            eventSummary
-            startTime
-            endTime
-            roomName
-            noOfParticipants
+    analyticsForDailyRoomEvents(startDate:"10 jan 2019", endDate:"jan 10 2019"){
+        DailyRoomEvents {
+            day
+            events {
+                noOfParticipants,
+                eventSummary,
+                startTime,
+                endTime,
+                roomName,
+                eventId
+            }
         }
     }
 }
 '''
 
 daily_room_events_response = {
-    "data": {
-        "analyticsForDailyRoomEvents": [{
+  "data": {
+    "analyticsForDailyRoomEvents": {
+      "DailyRoomEvents": [
+        {
             "day": "Wed Jul 11 2018",
             "events": [
                 {
@@ -40,8 +47,75 @@ daily_room_events_response = {
                     'startTime': '09:00:00'
                 }
             ]
-        }]
+        }
+      ]
     }
+  }
+}
+
+paginated_daily_room_events_query = '''
+query{
+    analyticsForDailyRoomEvents(startDate:"Jul 11 2018",page:1, perPage:1,
+     endDate:"Jul 11 2018"){
+        DailyRoomEvents {
+            day
+            events{
+                eventSummary
+                startTime
+                endTime
+                roomName
+                noOfParticipants
+            }
+        }
+        pages
+        hasNext
+        hasPrevious
+    }
+}'''
+
+invalid_page_for_analytics_for_daily_events_query = '''
+query{
+    analyticsForDailyRoomEvents(startDate:"Jul 11 2018",page:1500, perPage:1000,
+     endDate:"Jul 11 2018"){
+        DailyRoomEvents {
+            day
+            events{
+                eventSummary
+                startTime
+                endTime
+                roomName
+                noOfParticipants
+            }
+        }
+        pages
+        hasNext
+        hasPrevious
+    }
+}'''  # fetch for invalid page number(non-existing)
+
+
+daily_paginated_room_events_response = {
+  "data": {
+    "analyticsForDailyRoomEvents": {
+      "DailyRoomEvents": [
+        {
+          "day": "Wed Jul 11 2018",
+          "events": [
+            {
+              "eventSummary": "Onboarding",
+              "startTime": "09:00:00",
+              "endTime": "09:45:00",
+              "roomName": "Entebbe",
+              "noOfParticipants": 4
+            }
+          ]
+        }
+      ],
+      "pages": 1,
+      "hasNext": False,
+      "hasPrevious": False
+    }
+  }
 }
 
 daily_events_wrong_date_format_response = {'errors': [

--- a/tests/test_rooms/test_daily_room_events.py
+++ b/tests/test_rooms/test_daily_room_events.py
@@ -3,12 +3,18 @@ from fixtures.room.daily_room_events_fixture import (
     daily_room_events_query, daily_room_events_response,
     daily_room_events_wrong_date_format_query,
     daily_events_wrong_date_format_response,
+    paginated_daily_room_events_query,
+    daily_paginated_room_events_response,
+    invalid_page_for_analytics_for_daily_events_query
 )
 
 
 class TestDailyEvents(BaseTestCase):
 
     def test_analytics_for_daily_events(self):
+        """
+            Test querying analytics for daily events
+        """
         CommonTestCases.admin_token_assert_equal(
             self,
             daily_room_events_query,
@@ -16,8 +22,36 @@ class TestDailyEvents(BaseTestCase):
         )
 
     def test_analytics_for_daily_events_wrong_format_date(self):
+        """
+            Test querying analytics for daily events with
+            wrong date formats
+        """
         CommonTestCases.admin_token_assert_equal(
             self,
             daily_room_events_wrong_date_format_query,
             daily_events_wrong_date_format_response
+        )
+
+    def test_analytics_for_daily_events_pagination(self):
+        """
+            Test querying analytics for daily room events
+            data with pagination
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            paginated_daily_room_events_query,
+            daily_paginated_room_events_response
+        )
+
+    def test_fetching_invalid_page_for_paginated_analytics_for_daily_events(
+        self
+    ):
+        """
+            Test fetching a non-existing page in paginated analytics for
+            daily room events
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            invalid_page_for_analytics_for_daily_events_query,
+            'Page does not exist'
         )


### PR DESCRIPTION
 ### What does this PR do?
Paginate analytics for daily room events
### Description of the task to be completed?
Currently, when querying the analytics for daily room events, the result isn't paginated. This PR adds functionality to paginate the results when both the `page` number and items `perPage` are provided.
### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `git checkout ft-paginate-room-events-164823820`
 - Perform the query below. This will return all the rooms without pagination 
```
query{
    analyticsForDailyRoomEvents(startDate:"jan 10 2019", endDate:"feb 10 2019"){
        DailyRoomEvents {
            day
            events {
                noOfParticipants,
                eventSummary,
                startTime,
                endTime,
                roomName,
                eventId
            }
        }
    }
}
```
 - query analytics for daily room events with pagination.
```
query{
    analyticsForDailyRoomEvents(startDate:"jan 10 2019",page:3, perPage:4, endDate:"feb 10 2019"){
        DailyRoomEvents {
            day
            events {
                noOfParticipants,
                eventSummary,
                startTime,
                endTime,
                roomName,
                eventId
            }
        }
    hasNext,
    hasPrevious,
    pages
    }
}
```
### Any background context you want to provide?
N/A
### What are the relevant pivotal tracker stories?
[#164823820](https://www.pivotaltracker.com/story/show/164823820)
### Screenshots
 - #### Query analytics for daily room events without pagination.
<img width="1183" alt="image" src="https://user-images.githubusercontent.com/38049235/55061178-26e5a480-5084-11e9-85ee-56964b32a317.png">



 - #### Query analytics for daily rooms events with pagination.
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/38049235/55061022-d3735680-5083-11e9-9b4f-bd03d6af5914.png">

