### PR TITLE
#164471450 Analytics for auto-cancellation of a single meeting room

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -56,6 +56,7 @@ class RatioOfCheckinsAndCancellations(graphene.ObjectType):
                     via app \n- app_bookings_percentage: The field with the
                         percentage of room bookings via app
     """
+    room_id = graphene.Int()
     room_name = graphene.String()
     checkins = graphene.Int()
     cancellations = graphene.Int()

--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -59,6 +59,7 @@ class Analytics(graphene.ObjectType):
 
 
 class RatiosPerRoom(graphene.ObjectType):
+    ratio = graphene.Field(RatioOfCheckinsAndCancellations)
     ratios = graphene.List(RatioOfCheckinsAndCancellations)
 
 
@@ -226,9 +227,11 @@ class Query(graphene.ObjectType):
         RatiosPerRoom,
         start_date=graphene.String(required=True),
         end_date=graphene.String(),
+        room_id=graphene.Int(),
         description="Returns the ratios per room and accepts the arguments\
             \n- start_date: Start date when you want to get analytics from\
-            [required]\n- end_date: The end date to take the analytics upto"
+            [required]\n- end_date: The end date to take the analytics upto\
+            room_id: Room id which you want to get analytics for"
     )
 
     bookings_analytics_count = graphene.List(
@@ -368,12 +371,17 @@ class Query(graphene.ObjectType):
         return ratio
 
     @Auth.user_roles('Admin', 'Default User')
-    def resolve_analytics_ratios_per_room(
-            self, info, start_date, end_date=None):
+    def resolve_analytics_ratios_per_room(self, info, **kwargs):
+        room_id = kwargs.get('room_id')
         query = Room.get_query(info)
         ratio = RoomAnalyticsRatios.get_analytics_ratios_per_room(
-            self, query, start_date, end_date)
-        return RatiosPerRoom(ratio)
+            self, query, **kwargs)
+        if room_id:
+            exact_room = query.filter(RoomModel.id == room_id).first()
+            if not exact_room:
+                raise GraphQLError("Room not found")
+            return RatiosPerRoom(ratios=[], ratio=ratio)
+        return RatiosPerRoom(ratios=ratio, ratio={})
 
     @Auth.user_roles('Admin', 'Default User')
     def resolve_bookings_analytics_count(

--- a/fixtures/events/events_ratios_fixtures.py
+++ b/fixtures/events/events_ratios_fixtures.py
@@ -71,6 +71,75 @@ event_ratio_per_room_response = {
     }
 }
 
+event_ratio_single_room_query = '''query{
+    analyticsRatiosPerRoom(startDate:"Mar 1 2019", endDate:"Mar 27 2019",
+    roomId:1){
+        ratio{
+            roomName
+            bookings
+            checkins
+            checkinsPercentage
+            cancellations
+            cancellationsPercentage
+            appBookings
+            appBookingsPercentage
+        }
+    }
+}'''
+
+event_ratio_single_room_response = {
+    "data": {
+        "analyticsRatiosPerRoom": {
+            "ratio": {
+                "roomName": "Entebbe",
+                "bookings": 2,
+                "checkins": 0,
+                "checkinsPercentage": 0.0,
+                "cancellations": 0,
+                "cancellationsPercentage": 0.0,
+                "appBookings": 0,
+                "appBookingsPercentage": 0.0
+            }
+        }
+    }
+}
+
+event_ratio_single_room_query_with_non_existing_id = '''query{
+    analyticsRatiosPerRoom(startDate:"Mar 1 2019", endDate:"Mar 27 2019",
+    roomId:5){
+        ratio{
+            roomName
+            bookings
+            checkins
+            checkinsPercentage
+            cancellations
+            cancellationsPercentage
+            appBookings
+            appBookingsPercentage
+        }
+    }
+}'''
+
+event_ratio_single_room_with_non_existing_id_response = {
+    "errors": [
+        {
+            "message": "Room not found",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ],
+            "path": [
+                "analyticsRatiosPerRoom"
+            ]
+        }
+    ],
+    "data": {
+        "analyticsRatiosPerRoom": None
+    }
+}
+
 event_ratio_percentage_cancellation_query = '''query {
     analyticsRatios(startDate:"Jul 10 2018", endDate:"Jul 29 2018"){
         cancellationsPercentage

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -95,7 +95,8 @@ class CommonAnalytics(Credentials):
                 raise JsonError(Message='No rooms in this location')
             else:
                 raise GraphQLError("No rooms in this location")
-        result = [{'name': room.name, 'calendar_id': room.calendar_id}
+        result = [{'id': room.id, 'name': room.name,
+                   'calendar_id': room.calendar_id}
                   for room in rooms_in_locations.all()]
         return result
 

--- a/tests/test_events/test_events_ratios.py
+++ b/tests/test_events/test_events_ratios.py
@@ -10,6 +10,10 @@ from fixtures.events.events_ratios_fixtures import (
     event_ratio_for_one_day_query,
     event_ratio_per_room_query,
     event_ratio_per_room_response,
+    event_ratio_single_room_query,
+    event_ratio_single_room_response,
+    event_ratio_single_room_query_with_non_existing_id,
+    event_ratio_single_room_with_non_existing_id_response
 )
 
 sys.path.append(os.getcwd())
@@ -58,6 +62,35 @@ class TestEventRatios(BaseTestCase):
             self,
             event_ratio_per_room_query,
             event_ratio_per_room_response
+        )
+
+    @patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+           spec=True)
+    def test_event_checkin_and_cancellation_single_room(self, mock_get_json):
+        """
+        Test that an admin is able to get the ratio of checkins to bookings
+        for a single room
+        """
+        mock_get_json.return_value = get_events_mock_data()
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            event_ratio_single_room_query,
+            event_ratio_single_room_response
+        )
+
+    @patch("helpers.calendar.analytics_helper.get_events_within_datetime_range",
+           spec=True)
+    def test_event_checkin_cancellation_single_room_wrong_id(self,
+                                                             mock_get_json):
+        """
+        Tests that an admin cannot get the ratio of check-ins to bookings for a
+        single room with invalid room id
+        """
+        mock_get_json.return_value = get_events_mock_data()
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            event_ratio_single_room_query_with_non_existing_id,
+            event_ratio_single_room_with_non_existing_id_response
         )
 
     def test_database_connection_error(self):


### PR DESCRIPTION
 ### What does this PR do?
Enable admins to view count and auto-cancellation for a single room

### Description of the task to be completed?
- Extend get_per_room function to return single room analytics
- Add tests to cover feature

### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Cd into the cloned repo and checkout to this
3. Git pull branch `ft-cancellation-analytics-single-room-164471450-v1`
4. Run migrations
5. Run the query

```
query{
analyticsRatiosPerRoom(startDate:"Mar 1 2019", endDate:"Mar 27 2019", roomId:1){ 
    	ratio{
      	   roomName
           bookings
           checkins
           checkinsPercentage
           cancellations
           cancellationsPercentage
           appBookings
           appBookingsPercentage
    	}
    }
} 
```

#### Screenshots?
`Getting all rooms`
![Screenshot 2019-03-28 at 7 09 28 PM](https://user-images.githubusercontent.com/13919080/55184804-60590580-5193-11e9-8cca-2dd8ceceba00.png)

`Getting analytics for a single room rooms`
![Screenshot 2019-03-28 at 7 09 59 PM](https://user-images.githubusercontent.com/13919080/55185108-f2610e00-5193-11e9-91ac-c7252ca04ed6.png)


### What are the relevant pivotal tracker stories?
[#164471450](https://www.pivotaltracker.com/story/show/164471450)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations