### PR TITLE
#164823820 (v1) Paginate room events

### DIFF
--- a/fixtures/room/daily_room_events_fixture.py
+++ b/fixtures/room/daily_room_events_fixture.py
@@ -1,13 +1,15 @@
 daily_room_events_query = '''
 query{
-    analyticsForDailyRoomEvents(startDate:"jan 10 2019", endDate:"jan 10 2019"){
-        day
-        events{
-            eventSummary
-            startTime
-            endTime
-            roomName
-            noOfParticipants
+    analyticsForDailyRoomEvents(startDate:"Jul 11 2018", endDate:"Jul 11 2018"){
+        DailyRoomEvents {
+            day
+            events{
+                eventSummary
+                startTime
+                endTime
+                roomName
+                noOfParticipants
+            }
         }
     }
 }
@@ -15,40 +17,119 @@ query{
 daily_room_events_wrong_date_format_query = '''
 query{
     analyticsForDailyRoomEvents(startDate:"10 jan 2019", endDate:"jan 10 2019"){
-        day
-        events{
-            eventSummary
-            startTime
-            endTime
-            roomName
-            noOfParticipants
+        DailyRoomEvents {
+            day
+            events {
+                noOfParticipants,
+                eventSummary,
+                startTime,
+                endTime,
+                roomName,
+                eventId
+            }
         }
     }
 }
 '''
 
 daily_room_events_response = {
-    "data": {
-        "analyticsForDailyRoomEvents": [{
-            "day": "Tue Jan 22 2019",
-            "events": [
-                {
-                    'endTime': '14:00:00',
-                    'eventSummary': 'SD sync',
-                    'noOfParticipants': 3,
-                    'roomName': 'Entebbe',
-                    'startTime': '13:30:00'
-                },
-                {
-                    'endTime': '14:45:00',
-                    'eventSummary': 'Uzo<>Philip',
-                    'noOfParticipants': 6,
-                    'roomName': 'Entebbe',
-                    'startTime': '14:00:00'
-                }
-            ]
-        }]
+  "data": {
+    "analyticsForDailyRoomEvents": {
+      "DailyRoomEvents": [
+        {
+          "day": "Tue Jan 22 2019",
+          "events": [
+            {
+              "eventSummary": "SD sync",
+              "startTime": "13:30:00",
+              "endTime": "14:00:00",
+              "roomName": "Entebbe",
+              "noOfParticipants": 3
+            },
+            {
+              "eventSummary": "Uzo<>Philip",
+              "startTime": "14:00:00",
+              "endTime": "14:45:00",
+              "roomName": "Entebbe",
+              "noOfParticipants": 6
+            }
+          ]
+        }
+      ]
     }
+  }
+}
+
+paginated_daily_room_events_query = '''
+query{
+    analyticsForDailyRoomEvents(startDate:"Jul 11 2018",page:1, perPage:1,
+     endDate:"Jul 11 2018"){
+        DailyRoomEvents {
+            day
+            events{
+                eventSummary
+                startTime
+                endTime
+                roomName
+                noOfParticipants
+            }
+        }
+        pages
+        hasNext
+        hasPrevious
+    }
+}'''
+
+invalid_page_for_analytics_for_daily_events_query = '''
+query{
+    analyticsForDailyRoomEvents(startDate:"Jul 11 2018",page:1500, perPage:1000,
+     endDate:"Jul 11 2018"){
+        DailyRoomEvents {
+            day
+            events{
+                eventSummary
+                startTime
+                endTime
+                roomName
+                noOfParticipants
+            }
+        }
+        pages
+        hasNext
+        hasPrevious
+    }
+}'''  # fetch for invalid page number(non-existing)
+
+
+daily_paginated_room_events_response = {
+  "data": {
+    "analyticsForDailyRoomEvents": {
+      "DailyRoomEvents": [
+        {
+          "day": "Tue Jan 22 2019",
+          "events": [
+            {
+              "eventSummary": "SD sync",
+              "startTime": "13:30:00",
+              "endTime": "14:00:00",
+              "roomName": "Entebbe",
+              "noOfParticipants": 3
+            },
+            {
+              "eventSummary": "Uzo<>Philip",
+              "startTime": "14:00:00",
+              "endTime": "14:45:00",
+              "roomName": "Entebbe",
+              "noOfParticipants": 6
+            }
+          ]
+        }
+      ],
+      "pages": 1,
+      "hasNext": False,
+      "hasPrevious": False
+    }
+  }
 }
 
 daily_events_wrong_date_format_response = {'errors': [

--- a/tests/test_rooms/test_daily_room_events.py
+++ b/tests/test_rooms/test_daily_room_events.py
@@ -6,6 +6,9 @@ from fixtures.room.daily_room_events_fixture import (
     daily_room_events_query, daily_room_events_response,
     daily_room_events_wrong_date_format_query,
     daily_events_wrong_date_format_response,
+    paginated_daily_room_events_query,
+    daily_paginated_room_events_response,
+    invalid_page_for_analytics_for_daily_events_query
 )
 
 
@@ -14,6 +17,10 @@ from fixtures.room.daily_room_events_fixture import (
 class TestDailyEvents(BaseTestCase):
 
     def test_analytics_for_daily_events(self, mock_get_json):
+        """
+            Test querying analytics for daily events returns
+            correct data
+        """
         mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
@@ -22,9 +29,39 @@ class TestDailyEvents(BaseTestCase):
         )
 
     def test_analytics_for_daily_events_wrong_format_date(self, mock_get_json):
+        """
+            Test querying analytics for daily events with
+            wrong date formats fails with correct error message
+        """
         mock_get_json.return_value = get_events_mock_data()
         CommonTestCases.admin_token_assert_equal(
             self,
             daily_room_events_wrong_date_format_query,
             daily_events_wrong_date_format_response
+        )
+
+    def test_analytics_for_daily_events_pagination(self, mock_get_json):
+        """
+            Test querying analytics for daily room events
+            data with pagination returns correct paginated data
+        """
+        mock_get_json.return_value = get_events_mock_data()
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            paginated_daily_room_events_query,
+            daily_paginated_room_events_response
+        )
+
+    def test_fetching_invalid_page_for_paginated_analytics_for_daily_events(
+        self, mock_get_json
+    ):
+        """
+            Test fetching a non-existing page in paginated analytics for
+            daily room events fails with correct error message
+        """
+        mock_get_json.return_value = get_events_mock_data()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            invalid_page_for_analytics_for_daily_events_query,
+            'Page does not exist'
         )


### PR DESCRIPTION
 ### What does this PR do?
Paginate analytics for daily room events
### Description of the task to be completed?
Currently, when querying the analytics for daily room events, the result isn't paginated. This PR adds functionality to paginate the results when both the `page` number and items `perPage` are provided.
### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `git checkout ft-paginate-room-events-v1-164823820`
 - Perform the query below. This will return all the rooms without pagination 
```
query{
    analyticsForDailyRoomEvents(startDate:"jan 10 2019", endDate:"feb 10 2019"){
        DailyRoomEvents {
            day
            events {
                noOfParticipants,
                eventSummary,
                startTime,
                endTime,
                roomName,
                eventId
            }
        }
    }
}
```
 - query analytics for daily room events with pagination.
```
query{
    analyticsForDailyRoomEvents(startDate:"jan 10 2019",page:3, perPage:4, endDate:"feb 10 2019"){
        DailyRoomEvents {
            day
            events {
                noOfParticipants,
                eventSummary,
                startTime,
                endTime,
                roomName,
                eventId
            }
        }
    hasNext,
    hasPrevious,
    pages
    }
}
```
### Any background context you want to provide?
N/A
### What are the relevant pivotal tracker stories?
[#164823820](https://www.pivotaltracker.com/story/show/164823820)
### Screenshots
 - #### Query analytics for daily room events without pagination.
<img width="1183" alt="image" src="https://user-images.githubusercontent.com/38049235/55061178-26e5a480-5084-11e9-85ee-56964b32a317.png">



 - #### Query analytics for daily rooms events with pagination.
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/38049235/55061022-d3735680-5083-11e9-9b4f-bd03d6af5914.png">
