### PR TITLE
#164890997 Add check-in-time to events checkin mutation

### DIFF
--- a/api/events/schema.py
+++ b/api/events/schema.py
@@ -25,6 +25,7 @@ class EventCheckin(graphene.Mutation):
         start_time = graphene.String(required=True)
         end_time = graphene.String(required=True)
         number_of_participants = graphene.Int(required=True)
+        check_in_time = graphene.String(required=False)
     event = graphene.Field(Events)
 
     def mutate(self, info, **kwargs):
@@ -113,6 +114,10 @@ def check_event_in_db(instance, info, event_check, **kwargs):
         return room_id, event
     elif event and event_check == 'checked_in':
         event.checked_in = True
+        if 'check_in_time' in kwargs:
+            event.check_in_time = kwargs['check_in_time']
+        else:
+            event.check_in_time = None
         event.save()
         return room_id, event
     return room_id, event

--- a/fixtures/events/event_checkin_fixtures.py
+++ b/fixtures/events/event_checkin_fixtures.py
@@ -3,7 +3,8 @@ event_checkin_mutation = '''mutation {
         calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
         eventId:"test_id5", eventTitle:"Onboarding", numberOfParticipants: 4,
         startTime:"2018-07-10T09:00:00Z",
-        endTime:"2018-07-10T09:45:00Z"){
+        endTime:"2018-07-10T09:45:00Z",
+        checkInTime:"2018-07-10T09:00:00Z"){
             event{
                 eventId
                 roomId


### PR DESCRIPTION
#### Description

Add a checkintime to events checkin mutation 

### Type of change
-Feature (Add checkintime to eventscheckin mutation)

#### How Has This Been Tested?
- Pull this branch `ft-checkin-time-mutation-164890997`
- Run the `eventCheckin` mutation with 
```
mutation {
    eventCheckin(
        calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
        eventId:"6i9bhvfbbjphflqel1prhbdh1g_20180710T150000Z", 
         eventTitle:"Google<>Andela<>Udacity Meeting", numberOfParticipants: 11,
        startTime:"2018-07-10T08:00:00-07:00",
        endTime:"2018-07-10T09:00:00-07:00",
        checkInTime:"2018-07-10T08:00:00-07:00"){
            event{
                eventId
                roomId
                checkedIn
                cancelled
              	checkInTime
                room{
                    id
                    name
                    calendarId
                }
            }
        }
    }
```
- You should be able to have checkin time when you checkin

#### Any background context you want to provide?
- Run the version 2 data dump
- Make sure the event exists in the database
- Make sure the event is not checked in

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations


#### Pivotal Tracker

[#164890997](https://www.pivotaltracker.com/story/show/164890997)

#### Screenshots if any

<img width="1431" alt="Screenshot 2019-04-02 at 11 05 59" src="https://user-images.githubusercontent.com/33450849/55386074-550d2d80-5537-11e9-859d-1c9796fdbb31.png">


