### PR TITLE
#164471444 Fetch Total Booking Count for a Specific Room (V2) 

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -87,6 +87,7 @@ class BookingsAnalyticsCount(graphene.ObjectType):
     """
     bookings = graphene.Int()
     period = graphene.String()
+    room_name = graphene.String()
 
 
 class CreateRoom(graphene.Mutation):

--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -261,6 +261,7 @@ class Query(graphene.ObjectType):
         BookingsAnalyticsCount,
         start_date=graphene.String(required=True),
         end_date=graphene.String(required=True),
+        room_id=graphene.Int(),
         description="Returns the total number of room bookings and accepts the arguments\
             \n- start_date: Start date when you want to get analytics from\
             [required]\n- end_date: The end date to take the analytics upto\
@@ -411,11 +412,13 @@ class Query(graphene.ObjectType):
 
     @Auth.user_roles('Admin', 'Default User')
     def resolve_bookings_analytics_count(
-            self, info, start_date, end_date):
-        # Getting booking analytics count
+            self, info, **kwargs):
+        start_date, end_date, room_id = (kwargs.get('start_date'),
+                                         kwargs.get('end_date'),
+                                         kwargs.get('room_id'))
         query = Room.get_query(info)
         analytics = RoomAnalyticsRatios.get_bookings_analytics_count(
-            self, query, start_date, end_date)
+            self, query, start_date, end_date, room_id=room_id)
         return analytics
 
     def resolve_analytics_for_daily_room_events(

--- a/fixtures/room/room_analytics_bookings_count_fixtures.py
+++ b/fixtures/room/room_analytics_bookings_count_fixtures.py
@@ -53,3 +53,62 @@ get_bookings_count_monthly_diff_years_response = {
         }]
     }
 }
+
+get_single_room_daily_count = '''
+query {
+  bookingsAnalyticsCount(
+      startDate:"Jul 11 2018", endDate:"Jul 12 2018" roomId:1){
+    roomName
+   period
+   bookings
+  }
+}
+'''
+
+get_single_room_daily_count_response = {
+  "data": {
+    "bookingsAnalyticsCount": [
+      {
+        "roomName": "Entebbe",
+        "period": "Jul 11 2018",
+        "bookings": 1
+      },
+      {
+        "roomName": "Entebbe",
+        "period": "Jul 12 2018",
+        "bookings": 0
+      }
+    ]
+  }
+}
+
+non_existing_room_id_query = '''
+query {
+  bookingsAnalyticsCount(
+      startDate:"Jul 11 2018", endDate:"Jul 12 2018" roomId:100){
+    roomName
+   period
+   bookings
+  }
+}
+'''
+
+non_existing_room_id_response = {
+  "errors": [
+    {
+      "message": "Room Id does not exist",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "bookingsAnalyticsCount"
+      ]
+    }
+  ],
+  "data": {
+    "bookingsAnalyticsCount": null
+  }
+}

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -4,6 +4,7 @@ import dateutil.parser
 from dateutil.relativedelta import relativedelta
 from graphql import GraphQLError
 from collections import Counter
+from api.room.models import Room as RoomModel
 from api.location.models import Location as LocationModel
 from helpers.room_filter.room_filter import room_join_location
 from helpers.auth.admin_roles import admin_roles
@@ -177,15 +178,30 @@ class CommonAnalytics:
         return result
 
     @staticmethod
-    def get_total_bookings(self, query, start_date, end_date):
+    def get_total_bookings(instance, query, start_date, end_date, room_id=None):
         bookings = 0
-        rooms = CommonAnalytics.get_room_details(self, query)
+        rooms = CommonAnalytics.get_room_details(instance, query)
+        active_rooms = RoomModel.query.filter(RoomModel.state == "active")
         for room in rooms:
-            all_events = CommonAnalytics.get_all_events_in_a_room(
-                self, room["room_id"], start_date, end_date)
-            if all_events:
-                bookings += len(all_events)
+            if room_id:
+                exact_room = active_rooms.filter(
+                    RoomModel.id == room_id).first()
+                if not exact_room:
+                    raise GraphQLError("Room Id does not exist")
+
+            bookings = CommonAnalytics.get_bookings_count(instance, room,
+                                                          start_date,
+                                                          end_date,
+                                                          bookings)
         return bookings
+
+    @staticmethod
+    def get_bookings_count(*args):
+        instance, room, start_date, end_date, bookings_count = args
+        all_events = CommonAnalytics.get_all_events_in_a_room(
+            instance, room["room_id"], start_date, end_date)
+        bookings_count += len(all_events)
+        return bookings_count
 
     @staticmethod
     def get_last_day_of_month(date_obj):

--- a/helpers/calendar/ratios_and_utilization.py
+++ b/helpers/calendar/ratios_and_utilization.py
@@ -5,6 +5,7 @@ from api.room.models import Room as RoomModel
 from api.events.models import Events
 from api.room.schema import (RatioOfCheckinsAndCancellations,
                              BookingsAnalyticsCount)
+from utilities.verify_ids_for_room import get_room_name
 
 
 class RoomAnalyticsRatios:
@@ -152,27 +153,36 @@ class RoomAnalyticsRatios:
         except ZeroDivisionError:
             return 0
 
-    def get_bookings_analytics_count(self, query, start, end):
+    def get_bookings_analytics_count(self, query, start, end, room_id=None):
         results = []
-        start_date, day_after_end_date = CommonAnalytics.convert_dates(self, start, end)  # noqa E501
+        start_date, day_after_end_date = CommonAnalytics.convert_dates(
+            self, start, end)
         start_dt = dateutil.parser.parse(start_date)
         end_dt = dateutil.parser.parse(day_after_end_date)
         number_of_days = (end_dt - start_dt).days
+        room_name = get_room_name(room_id)
 
         if number_of_days <= 30:
-            dates = CommonAnalytics.get_list_of_dates(start, number_of_days)  # noqa E501
+            dates = CommonAnalytics.get_list_of_dates(
+                start, number_of_days)
             for date in dates:
-                bookings = CommonAnalytics.get_total_bookings(self, query, date[0], date[1])  # noqa E501
-                string_date = dateutil.parser.parse(date[0]).strftime("%b %d %Y")  # noqa E501
-                output = BookingsAnalyticsCount(period=string_date, bookings=bookings) # noqa E501
+                bookings = CommonAnalytics.get_total_bookings(
+                    self, query, date[0], date[1], room_id=room_id)
+                string_date = dateutil.parser.parse(
+                    date[0]).strftime("%b %d %Y")
+                output = BookingsAnalyticsCount(
+                    period=string_date, bookings=bookings, room_name=room_name)
                 results.append(output)
 
         else:
-            dates = CommonAnalytics.get_list_of_month_dates(start_date, start_dt, day_after_end_date, end_dt)  # noqa E501
+            dates = CommonAnalytics.get_list_of_month_dates(
+                start_date, start_dt, day_after_end_date, end_dt)
             for date in dates:
-                bookings = CommonAnalytics.get_total_bookings(self, query, date[0], date[1])  # noqa E501
+                bookings = CommonAnalytics.get_total_bookings(
+                    self, query, date[0], date[1], room_id=room_id)
                 string_month = dateutil.parser.parse(date[0]).strftime("%B")
-                output = BookingsAnalyticsCount(period=string_month, bookings=bookings) # noqa E501
+                output = BookingsAnalyticsCount(
+                    period=string_month, bookings=bookings, room_name=room_name)
                 results.append(output)
 
         return results

--- a/tests/test_rooms/test_room_analytics.py
+++ b/tests/test_rooms/test_room_analytics.py
@@ -33,6 +33,10 @@ from fixtures.room.room_analytics_bookings_count_fixtures import (
     get_bookings_count_monthly_response,
     get_bookings_count_monthly_diff_years,
     get_bookings_count_monthly_diff_years_response,
+    get_single_room_daily_count,
+    get_single_room_daily_count_response,
+    non_existing_room_id_query,
+    non_existing_room_id_response
 )
 
 
@@ -117,3 +121,21 @@ class QueryRoomsAnalytics(BaseTestCase):
         CommonTestCases.admin_token_assert_equal(
             self, get_bookings_count_monthly_diff_years,
             get_bookings_count_monthly_diff_years_response)
+
+    def test_single_room_daily_bookings(self):
+        """This function tests that the booking count for a single
+                 room is returned provided a room_id is provided
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, get_single_room_daily_count,
+            get_single_room_daily_count_response
+        )
+
+    def test_non_existing_room_id(self):
+        """This function tests for when the provided room_id
+         does not exist in the database
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, non_existing_room_id_query,
+            non_existing_room_id_response
+        )

--- a/utilities/verify_ids_for_room.py
+++ b/utilities/verify_ids_for_room.py
@@ -1,22 +1,10 @@
-from api.office.models import Office
-from api.floor.models import Floor
-from api.wing.models import Wing
-from api.location.models import Location
+from api.room.models import Room as RoomModel
 
 
-def verify_ids(office_id, kwargs):
-    get_office = Office.query.filter_by(id=office_id).first()
-    if not get_office:
-        raise AttributeError("Office Id does not exist")
-
-    location_id = kwargs.get('location_id')
-    if location_id and not Location.query.filter_by(id=location_id).first():
-        raise AttributeError("Location Id does not exist")
-
-    get_floor = Floor.query.filter_by(id=kwargs.get('floor_id')).first()
-    if not get_floor:
-        raise AttributeError("Floor Id does not exist")
-
-    wing_id = kwargs.get('wing_id')
-    if wing_id and not Wing.query.filter_by(id=wing_id).first():
-        raise AttributeError("Wing Id does not exist")
+def get_room_name(room_id):
+    exact_room = RoomModel.query.filter_by(id=room_id).first()
+    if exact_room:
+        room_name = exact_room.name
+    else:
+        room_name = None
+    return room_name


### PR DESCRIPTION
#### What does this PR do?
Fetch Total Booking Count for a Specific Room
#### Description of Task to be completed?
Ensure that the user can view the booking count of a single room.
#### How should this be manually tested?
git checkout `ft-room-booking-count-164471444`
run the mutation below to view bookings for a room with id `1`
Daily bookings count
````
query {
  bookingsAnalyticsCount(startDate:"Nov 10 2018", endDate:"Nov 12 2018", roomId:1){
   roomName
   period
   bookings
  }
}
````
monthly room bookings query
````
query {
  bookingsAnalyticsCount(startDate:"Aug 1 2018", endDate:"Nov 1 2018", roomId:4){
    roomName
   period
   bookings
  }
}
````
#### What are the relevant pivotal tracker stories?
[#164471444](https://www.pivotaltracker.com/story/show/164471444)
#### Screenshots
Daily bookings count
![image](https://user-images.githubusercontent.com/39625835/54515920-8f3ed280-496e-11e9-9185-1a6a8a900786.png)
Monthly bookings count
![image](https://user-images.githubusercontent.com/39625835/54516094-ffe5ef00-496e-11e9-9374-88e7d1b7a380.png)




