### PR TITLE
#164824376 Fix least booked rooms bug (v1)

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -37,10 +37,10 @@ def resolve_booked_rooms_analytics(*args):
 def get_most_and_least_booked_rooms(*args):
     instance, active_rooms, start_date, end_date, criteria, limit = args
     if limit and criteria == "least_booked":
-        limit = (-limit)
-        return RoomAnalytics.get_booked_rooms(instance, active_rooms,
-                                              start_date, end_date
-                                              )[limit:]
+        reversed_order = RoomAnalytics.get_booked_rooms(instance, active_rooms,
+                                                        start_date, end_date
+                                                        )[::-1]
+        return reversed_order[:limit]
     elif limit and criteria == "most_booked":
         return RoomAnalytics.get_booked_rooms(instance, active_rooms,
                                               start_date, end_date


### PR DESCRIPTION
#### What does this PR do
Fix a bug that returns the most booked rooms when querying for the least booked rooms

#### Description of the task to be completed?
- A user should be able to query for the least booked rooms and in return get them from the least booked to the most booked.
#### How should this be manually tested?
- Clone the branch and follow the setup steps in the README.
- Checkout to the branch by using the command `git checkout bg-least-booked-rooms-v1-164824376`
- Start the server and navigate to the right url.
- Make a query to get analytics for most booked rooms using the query below
- You can set a `limit` on the number of rooms you would like displayed. This should be an `int`
- You can also set a `criteria` on what you want to query. Use `most_booked` or `least_booked` as an argument. Omiting this argument will display `most_booked` by default.
```
{
 analyticsForBookedRooms(startDate: "Feb 14 2019", endDate: "Feb 14 2019", limit:10, criteria:"most_booked"){
     analytics{
      roomName
      count
      meetings
      percentage
      roomName
    }
    }
}

```
![image](https://user-images.githubusercontent.com/31338414/55409539-e0ec7d00-556a-11e9-946b-b86a7a4c5e20.png)


- Make a query to get analytics for least booked rooms using the query below
```
{
 analyticsForBookedRooms(startDate: "Feb 14 2019", endDate: "Feb 14 2019", limit:10, criteria:"least_booked"){
     analytics{
      roomName
      count
      meetings
      percentage
      roomName
    }
    }
}

```
![image](https://user-images.githubusercontent.com/31338414/55409307-7b988c00-556a-11e9-8172-330affc04ded.png)

#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
[#164824376](https://www.pivotaltracker.com/story/show/164824376)