### PR TITLE
#165056357 Add check-in time and meeting end time to daily room events Query

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -80,6 +80,8 @@ class CalendarEvent(graphene.ObjectType):
     cancelled = graphene.Boolean()
     state = graphene.String()
     checked_in = graphene.Boolean()
+    check_in_time = graphene.String()
+    meeting_end_time = graphene.String()
 
 
 class DailyEvents(graphene.ObjectType):
@@ -361,7 +363,9 @@ class Query(graphene.ObjectType):
                         event_id=event["event_id"],
                         cancelled=event["cancelled"],
                         state=event["state"],
-                        checked_in=event["checked_in"]
+                        checked_in=event["checked_in"],
+                        check_in_time=event["check_in_time"],
+                        meeting_end_time=event["meeting_end_time"]
                     )
                     daily_events.append(current_event)
             all_days_events.append(

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -126,6 +126,8 @@ class CommonAnalytics:
                     'cancelled_status': event.cancelled,
                     'checked_in_status': event.checked_in,
                     'state': event.state,
+                    'meeting_end_time': event.meeting_end_time,
+                    'check_in_time': event.check_in_time
                 }
                 room_events.append(room_event)
         return room_events

--- a/helpers/calendar/events.py
+++ b/helpers/calendar/events.py
@@ -87,6 +87,8 @@ class RoomSchedules(Credentials):
                     "state": event['state'],
                     "checked_in": event['checked_in_status'],
                     "cancelled": event['cancelled_status'],
+                    "check_in_time": event['check_in_time'],
+                    "meeting_end_time": event['meeting_end_time'],
                 }
                 all_events.append(current_event)
 


### PR DESCRIPTION
 ### What does this PR do?
Add check-in time and meeting end time to Query the status of the daily room events
### Description of the task to be completed?
A user should be able to query the status of daily room events and know what time a user checks in and ends a meeting.
### How should this be manually tested?
 - Clone the repository and carry out the steps laid out [here](https://github.com/andela/mrm_api).
 - Checkout by running `git checkout ft-query-checkin-endmeeting-time-for-event-165056357`
 - Perform the query below to get the status of the room events (checkin time and meeting end time).
```
query
{
  analyticsForDailyRoomEvents(startDate: "Jan 1 2019", endDate: "Apr 1 2019") {
    DailyRoomEvents {
      day
      events {
        state
        eventSummary
        startTime
        endTime
        cancelled
        roomName
        noOfParticipants
        checkInTime
        meetingEndTime
      }
    }
  }
}
```

### Any background context you want to provide?
N/A
### What are the relevant pivotal tracker stories?
[#165056357](https://www.pivotaltracker.com/story/show/165056357)
### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
### Screenshot:
<img width="1180" alt="Screenshot 2019-04-03 at 11 14 47" src="https://user-images.githubusercontent.com/27801956/55463650-30ca5300-5602-11e9-933f-6ddb67d83971.png">


