### PR TITLE
#164890924 Add mutation to end meeting

### DIFF
--- a/fixtures/events/end_event_fixtures.py
+++ b/fixtures/events/end_event_fixtures.py
@@ -1,0 +1,88 @@
+end_event_mutation = '''mutation {
+    endEvent(calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
+            eventId:"test_id5",
+            startTime:"2018-07-10T09:00:00Z",
+            endTime:"2018-07-10T09:45:00Z",
+            meetingEndTime: "2018-07-10T09:45:00Z"){
+            event{
+                eventId
+                  eventTitle
+                checkedIn
+                cancelled
+                meetingEndTime
+                room{
+                    id
+                    name
+                    calendarId
+                }
+            }
+        }
+    }
+'''
+
+end_event_mutation_response = {
+  "data": {
+    "endEvent": {
+      "event": {
+        "eventId": "test_id5",
+        "eventTitle": "Onboarding",
+        "checkedIn": True,
+        "cancelled": False,
+        "meetingEndTime": "2018-07-10T09:45:00Z",
+        "room": {
+          "id": "1",
+          "name": "Entebbe",
+          "calendarId": "andela.com_3630363835303531343031@resource.calendar.google.com"  # noqa: E501
+        }
+      }
+    }
+  }
+}
+
+end_unchecked_in_event_mutation = '''mutation {
+    endEvent(calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
+            eventId:"test_id5",
+            startTime:"2018-07-11T09:00:00Z",
+            endTime:"2018-07-11T09:45:00Z",
+            meetingEndTime: "2018-07-11T09:45:00Z"){
+            event{
+                eventId
+                  eventTitle
+                checkedIn
+                cancelled
+                room{
+                    id
+                    name
+                    calendarId
+                }
+              meetingEndTime
+            }
+        }
+    }
+'''
+
+end_unchecked_in_event_mutation_response = "Event yet to be checked in"
+
+end_event_twice_mutation_response = "Event has already ended"
+
+wrong_calendar_id_end_event_mutation = '''mutation {
+    endEvent(calendarId:"invalid_calendar_id",
+            eventId:"test_id5",
+            startTime:"2018-08-11T09:00:00Z",
+            endTime:"2018-08-11T09:45:00Z",
+            meetingEndTime: "2018-08-11T09:45:00Z"){
+            event{
+                eventId
+                  eventTitle
+                checkedIn
+                cancelled
+                room{
+                    id
+                    name
+                    calendarId
+                }
+              meetingEndTime
+            }
+        }
+    }
+'''

--- a/helpers/calendar/events.py
+++ b/helpers/calendar/events.py
@@ -108,9 +108,10 @@ class RoomSchedules(Credentials):
                 room_id=room_id,
                 start_time=kwargs['start_time'],
                 cancelled=True).count()
-            if checked_in_events > 0:
+            if checked_in_events > 0 and 'meeting_end_time' not in kwargs:
                 raise GraphQLError("Event already checked in")
-
+            elif checked_in_events < 1 and 'meeting_end_time' in kwargs:
+                raise GraphQLError("Event yet to be checked in")
             elif cancelled_events > 0:
                 raise GraphQLError("Event already cancelled")
             return room_id

--- a/tests/test_events/test_end_event.py
+++ b/tests/test_events/test_end_event.py
@@ -1,0 +1,72 @@
+from tests.base import BaseTestCase, CommonTestCases
+
+from fixtures.events.end_event_fixtures import (
+    end_event_mutation,
+    end_event_mutation_response,
+    end_unchecked_in_event_mutation,
+    end_unchecked_in_event_mutation_response,
+    end_event_twice_mutation_response,
+    wrong_calendar_id_end_event_mutation,
+)
+from fixtures.events.event_checkin_fixtures import (
+    event_checkin_mutation,
+    event_checkin_response
+)
+
+
+class TestEndEvent(BaseTestCase):
+
+    def test_end_event(self):
+        """
+        Test user can end an event
+        """
+        CommonTestCases.user_token_assert_equal(
+            self,
+            event_checkin_mutation,
+            event_checkin_response
+        )
+        CommonTestCases.user_token_assert_equal(
+            self,
+            end_event_mutation,
+            end_event_mutation_response
+        )
+
+    def test_end_unchecked_in_event(self):
+        """
+        Test user cannot end an event before checking in
+        """
+        CommonTestCases.user_token_assert_in(
+            self,
+            end_unchecked_in_event_mutation,
+            end_unchecked_in_event_mutation_response
+        )
+
+    def test_end_event_twice(self):
+        """
+        Test user cannot end an event twice
+        """
+        CommonTestCases.user_token_assert_equal(
+            self,
+            event_checkin_mutation,
+            event_checkin_response
+        )
+        CommonTestCases.user_token_assert_equal(
+            self,
+            end_event_mutation,
+            end_event_mutation_response
+        )
+        CommonTestCases.user_token_assert_in(
+            self,
+            end_event_mutation,
+            end_event_twice_mutation_response
+        )
+
+    def test_end_event_with_invalid_calendar_id(self):
+        """
+        Test user cannot end event with invalid calendar ID
+        """
+        CommonTestCases.user_token_assert_in(
+            self,
+            wrong_calendar_id_end_event_mutation,
+            "This Calendar ID is invalid"
+        )


### PR DESCRIPTION
#### What does this PR do?
Add a mutation to end meeting
#### Description of Task to be completed?
As a user I want to end a meeting from the mobile app and have this updated in the event table so that I can save the time when the meeting actually ended
#### How should this be manually tested?
- git pull and checkout branch ft-end-meeting-mutation-164890924
- run application
- Ensure you have a checked-in event
- run the mutation below
```
mutation {
 endEvent(calendarId:"andela.com_353633323439323830@resource.calendar.google.com",
        eventId:"3f85pi6jgpc1qslnp312k3k4fl", startTime:"2018-04-10T01:00:00-07:00",
        endTime:"2018-04-10T03:00:00-07:00", meetingEndTime:"2018-02-07T04:15:00-08:00")
        {
            event{
                eventId
              	eventTitle
                checkedIn
                cancelled
              	meetingEndTime
                room{
                    id
                    name
                    calendarId
                }
            }
        }
    }

```
#### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

#### What are the relevant pivotal tracker stories?
[#164890924](https://www.pivotaltracker.com/story/show/164890924)



