### PR TITLE
#164167409 Enable admin to query feedback responses based on date range (V2)

### DIFF
--- a/api/response/schema_query.py
+++ b/api/response/schema_query.py
@@ -5,6 +5,13 @@ from api.room.schema import Room
 from api.room.models import Room as RoomModel
 from helpers.auth.authentication import Auth
 from helpers.pagination.paginate import ListPaginate
+from helpers.response.query_response import (
+    filter_response_by_date, check_limits_are_provided,
+    filter_rooms_by_responses,
+    validate_responses_by_room,
+    check_response_and_room,
+    filter_responses
+)
 
 
 class ResponseDetails(graphene.ObjectType):
@@ -40,14 +47,18 @@ class Query(graphene.ObjectType):
         PaginatedResponses,
         page=graphene.Int(),
         per_page=graphene.Int(),
-        upper_limit=graphene.Int(),
-        lower_limit=graphene.Int(),
+        upper_limit_count=graphene.Int(),
+        lower_limit_count=graphene.Int(),
+        end_date=graphene.String(),
+        start_date=graphene.String(),
         room=graphene.String(),
         description="Returns a list of room responses. Accepts the arguments\
             \n- page: Page number of responses\
             \n- per_page: Number of room responses per page\
-            \n- upper_limit: Highest number of room responses\
-            \n- lower_limit: Highest number of room responses\
+            \n- upper_limit_count: Highest number of room responses\
+            \n- lower_limit_count: Lowest number of room responses\
+             \n- end_date: Latest date range given\
+            \n- start_date: Earliest date range given\
             \n- room: Room name where the response is sent to"
     )
 
@@ -102,47 +113,26 @@ class Query(graphene.ObjectType):
             total_responses=total_response,
             response=responses)
 
-    def get_all_reponses(self, info):
-        response = []
-        rooms = RoomModel.query.all()
-        for room in rooms:
-            room_name = room.name
-            room_response = Response.get_query(info).filter_by(room_id=room.id)
-            total_response = room_response.count()
-            all_responses = Query.get_room_response(
-                self, room_response, room.id)
-            responses = RoomResponse(
-                room_id=room.id,
-                room_name=room_name,
-                total_responses=total_response,
-                response=all_responses)
-            response.append(responses)
-        return response
-
-    def filter_rooms_by_responses(self, info, upper_limit, lower_limit):
-        all_responses = Query.get_all_reponses(self, info)
-        filtered_responses = []
-        for response in all_responses:
-            reponse_count = response.total_responses
-            if lower_limit <= reponse_count <= upper_limit:
-                filtered_responses.append(response)
-        return filtered_responses
-
-    def search_response_by_room(self, info, upper_limit, lower_limit, room):
+    def search_response_by_room(self, info, **kwargs):
         search_result = []
         filtered_search = []
-        if upper_limit and lower_limit:
-            filtered_response = Query.filter_rooms_by_responses(
-                self, info, upper_limit, lower_limit)
-            for response in filtered_response:
-                if response.room_name.lower() == room.lower():
-                    filtered_search.append(response)
-            if filtered_search:
-                return filtered_search
-            else:
-                raise GraphQLError("No response for this room at this range")
+        if isinstance(kwargs.get('upper_limit'), int):
+            filtered_count_search = validate_responses_by_room(
+                    int, filter_rooms_by_responses, **kwargs, Query=Query,
+                    info=info,
+                    filtered_search=filtered_search
+                )
+            if filtered_count_search:
+                return filtered_count_search
+        filtered_date_search = validate_responses_by_room(
+            str, filter_response_by_date, **kwargs, Query=Query,
+            info=info,
+            filtered_search=filtered_search
+        )
+        if filtered_date_search:
+            return filtered_date_search
         exact_room = RoomModel.query.filter(
-            RoomModel.name.ilike('%' + room + '%')).first()
+            RoomModel.name.ilike('%' + kwargs.get('room') + '%')).first()
         if not exact_room:
             raise GraphQLError(
                 "No response for this room, enter a valid room name")
@@ -162,45 +152,68 @@ class Query(graphene.ObjectType):
         search_result.append(responses)
         return search_result
 
+    def get_all_responses(self, info):
+        response = []
+        rooms = RoomModel.query.all()
+        for room in rooms:
+            room_name = room.name
+            room_response = Response.get_query(info).filter_by(room_id=room.id)
+            response_count = room_response.count()
+            all_responses = Query.get_room_response(
+                self, room_response, room.id)
+            responses = RoomResponse(
+                room_id=room.id,
+                room_name=room_name,
+                total_responses=response_count,
+                response=all_responses)
+            response.append(responses)
+        return response
+
     @Auth.user_roles('Admin')
-    def resolve_all_room_responses(self,
-                                   info,
-                                   page=None,
-                                   per_page=None,
-                                   lower_limit=None,
-                                   upper_limit=None,
-                                   room=None,
-                                   **kwargs):
-        responses = Query.get_all_reponses(self, info)
-        if isinstance(lower_limit, int) and isinstance(upper_limit, int):
-            responses = Query.filter_rooms_by_responses(
-                self, info, upper_limit, lower_limit)
-        if ((isinstance(lower_limit, int) and not isinstance(upper_limit, int))
-                or (isinstance(upper_limit, int)
-                    and not isinstance(lower_limit, int))):
-            raise GraphQLError(
-                "Provide upper and lower limits to filter by response number")
-        if (isinstance(lower_limit, int) and isinstance(upper_limit, int)
-                and room):
-            responses = Query.search_response_by_room(self, info, upper_limit,
-                                                      lower_limit, room)
-        if not upper_limit and not lower_limit and room:
-            upper_limit = None
-            lower_limit = None
-            responses = Query.search_response_by_room(self, info, upper_limit,
-                                                      lower_limit, room)
-        if page and per_page:
+    def resolve_all_room_responses(self, info, **kwargs):
+        responses = Query.get_all_responses(self, info)
+        check_limits_are_provided(
+            kwargs.get('lower_limit_count'),
+            kwargs.get('upper_limit_count'), int
+        )
+        responses = filter_responses(
+            int, filter_rooms_by_responses, kwargs.get('upper_limit_count'),
+            kwargs.get('lower_limit_count'),  Query, info, responses
+        )
+        responses = check_response_and_room(
+            int, info, kwargs.get('room'), kwargs.get('upper_limit_count'),
+            kwargs.get('lower_limit_count'), responses, Query
+        )
+        if 'upper_limit_count' and 'lower_limit_count' not in kwargs and kwargs.get('room'): # noqa
+            upper_limit, lower_limit = (kwargs.get('upper_limit'),
+                                        kwargs.get('lower_limit'))
+            responses = Query().search_response_by_room(info,
+                                                        lower_limit=lower_limit,
+                                                        upper_limit=upper_limit,
+                                                        **kwargs)
+        if kwargs.get('page') and kwargs.get('per_page'):
             paginated_response = ListPaginate(
-                iterable=responses, per_page=per_page, page=page)
+                iterable=responses, per_page=kwargs.get('per_page'),
+                page=kwargs.get('page'))
             current_page = paginated_response.current_page
             has_previous = paginated_response.has_previous
             has_next = paginated_response.has_next
             pages = paginated_response.pages
             query_total = paginated_response.query_total
-            return PaginatedResponses(
-                responses=current_page,
-                has_previous=has_previous,
-                has_next=has_next,
-                query_total=query_total,
-                pages=pages)
+            return PaginatedResponses(responses=current_page,
+                                      has_previous=has_previous,
+                                      has_next=has_next,
+                                      query_total=query_total,
+                                      pages=pages)
+        check_limits_are_provided(
+            kwargs.get('start_date'), kwargs.get('end_date'), str
+        )
+        responses = filter_responses(
+            str, filter_response_by_date, kwargs.get('end_date'),
+            kwargs.get('start_date'),  Query, info, responses
+        )
+        responses = check_response_and_room(
+            str, info, kwargs.get('room'), kwargs.get('end_date'),
+            kwargs.get('start_date'), responses, Query
+        )
         return PaginatedResponses(responses=responses)

--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -31,6 +31,67 @@ get_room_response_query_data = {
     }
 }
 
+get_room_response_query_by_date = '''
+query{
+    allRoomResponses(startDate: "2019 feb 20",
+     endDate: "2019 feb 25" ){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+get_room_response_query_with_invalid_date = '''
+query{
+    allRoomResponses(startDate: "2019 Dec 20",
+     endDate: "2019 Dec 25" ){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+get_room_response_query_with_higher_lower_limit = '''
+query{
+    allRoomResponses(startDate: "2019 feb 20",
+     endDate: "2019 feb 1" ){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                missingItems
+            }
+        }
+    }
+}
+'''
+
+get_room_response_query_by_date_query = {
+  "data": {
+    "allRoomResponses": {
+      "responses": [
+        {
+          "totalResponses": 2,
+          "roomName": "Entebbe",
+          "response": []
+        }
+      ]
+    }
+  }
+}
+
+
 get_room_response_non_existence_room_id = '''{
     roomResponse(roomId:15) {
         roomName,
@@ -86,7 +147,7 @@ summary_room_response_data = {
 
 filter_by_response_query = '''
 query{
-    allRoomResponses(upperLimit: 2, lowerLimit: 0 ){
+    allRoomResponses(upperLimitCount: 3, lowerLimitCount: 0 ){
         responses{
             totalResponses
             roomName
@@ -100,7 +161,7 @@ query{
 
 filter_by_response_invalid_query = '''
 query{
-    allRoomResponses(upperLimit: 2){
+    allRoomResponses(upperLimitCount: 2){
         responses{
             totalResponses
             roomName
@@ -113,8 +174,8 @@ query{
 '''
 
 search_response_by_room_query = '''
-query{
-    allRoomResponses(upperLimit: 2, lowerLimit: 0, room:"Entebbe"){
+ query{
+    allRoomResponses(lowerLimitCount: 1, upperLimitCount: 3, room:"Entebbe"){
         responses{
             totalResponses
             roomName
@@ -128,7 +189,7 @@ query{
 
 search_response_by_room_beyond_limits_query = '''
 query{
-    allRoomResponses(upperLimit: 7, lowerLimit: 5, room:"Entebbe"){
+    allRoomResponses(upperLimitCount: 7, lowerLimitCount: 5, room:"Entebbe"){
         responses{
             totalResponses
             roomName
@@ -142,7 +203,7 @@ query{
 
 search_response_by_room_invalid_room_query = '''
 query{
-    allRoomResponses(upperLimit: 2, lowerLimit: 0, room:"Entebbes"){
+    allRoomResponses(upperLimitCount: 2, lowerLimitCount: 0, room:"Entebbes"){
         responses{
             totalResponses
             roomName
@@ -170,7 +231,7 @@ query{
 
 search_response_by_invalid_room = '''
 query{
-    allRoomResponses(room:"Entebbes"){
+    allRoomResponses(room:"Mubende"){
         responses{
             totalResponses
             roomName

--- a/helpers/response/query_response.py
+++ b/helpers/response/query_response.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from graphql import GraphQLError
+from utilities.validations import validate_date_range
+
+
+def filter_rooms_by_responses(
+    Query, info, upper_limit_count, lower_limit_count
+):
+    all_responses = Query().get_all_responses(info)
+    filtered_responses = []
+    for response in all_responses:
+        response_count = response.total_responses
+        if lower_limit_count <= response_count <= upper_limit_count:
+            filtered_responses.append(response)
+    return filtered_responses
+
+
+def filter_response_by_date(Query, info, end_date, start_date):
+    all_responses = Query().get_all_responses(info)
+    filtered_responses = []
+    for responses in all_responses:
+        for response in responses.response:
+            validate_response_dates(
+                response,
+                end_date, start_date, filtered_responses
+            )
+        setattr(responses, 'response', filtered_responses)
+        filtered_responses = []
+    return all_responses
+
+
+def validate_response_dates(
+    response, end_date, start_date, filtered_responses
+):
+    end_date = datetime.strptime(end_date, '%Y %b %d')
+    start_date = datetime.strptime(start_date, '%Y %b %d')
+    validate_date_range(
+        end_date=end_date, start_date=start_date
+    )
+    if (response.created_date < end_date and
+            response.created_date > start_date):
+        filtered_responses.append(response)
+    return filtered_responses
+
+
+def check_limits_are_provided(lower_limit, upper_limit, data_type):
+    if (
+      (isinstance(lower_limit, data_type)
+          and not isinstance(upper_limit, data_type))
+      or (isinstance(upper_limit, data_type)
+            and not isinstance(lower_limit, data_type))):
+        raise GraphQLError(
+            "Provide upper and lower limits to filter")
+
+
+def validate_responses_by_room(data_type, function, **kwargs):
+    if ((isinstance(kwargs['upper_limit'], data_type)) and kwargs['upper_limit']
+            and kwargs['lower_limit']):
+        filtered_response = function(
+            kwargs['Query'], kwargs['info'], kwargs['upper_limit'],
+            kwargs['lower_limit'])
+        for room_response in filtered_response:
+            if room_response.room_name.lower() == kwargs['room'].lower():
+                kwargs['filtered_search'].append(room_response)
+        if kwargs['filtered_search']:
+            return kwargs['filtered_search']
+        else:
+            raise GraphQLError(
+                "No response for this room at this range")
+
+
+def check_response_and_room(*args):
+    data_type, info, room, upper_limit, lower_limit, responses, Query = args
+    if (isinstance(upper_limit, data_type)
+            and isinstance(lower_limit, data_type) and room):
+        responses = Query().search_response_by_room(
+            info, upper_limit=upper_limit, lower_limit=lower_limit, room=room
+        )
+    return responses
+
+
+def filter_responses(data_type, function, *args,):
+    upper_limit, lower_limit, Query, info, responses = args
+    if (isinstance(upper_limit, data_type)
+            and isinstance(lower_limit, data_type)):
+        responses = function(
+            Query, info, upper_limit,
+            lower_limit
+        )
+    return responses

--- a/tests/test_response/test_room_response.py
+++ b/tests/test_response/test_room_response.py
@@ -23,6 +23,10 @@ from fixtures.response.room_response_fixture import (
     mark_response_as_resolved_mutation_with_an_invalid_response_id,
     mark_a_user_response_as_unresolved_mutation,
     mark_a_user_response_as_unresolved_mutation_response,
+    get_room_response_query_by_date,
+    get_room_response_query_by_date_query,
+    get_room_response_query_with_invalid_date,
+    get_room_response_query_with_higher_lower_limit
 )
 
 sys.path.append(os.getcwd())
@@ -68,8 +72,10 @@ class TestRoomResponse(BaseTestCase):
         using ignoring one of the limits
         """
         CommonTestCases.admin_token_assert_in(
-            self, filter_by_response_invalid_query,
-            "Provide upper and lower limits to filter by response number")
+            self,
+            filter_by_response_invalid_query,
+            "Provide upper and lower limits to filter"
+        )
 
     def test_filter_search_response_room_name(self):
         """
@@ -157,3 +163,60 @@ class TestRoomResponse(BaseTestCase):
         CommonTestCases.admin_token_assert_equal(
             self, mark_a_user_response_as_unresolved_mutation,
             mark_a_user_response_as_unresolved_mutation_response)
+
+    def test_room_response_with_date_range(self):
+        """
+        Testing for room response with date range
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_room_response_query_by_date,
+            get_room_response_query_by_date_query
+        )
+
+    def test_room_response_with_invalid_date(self):
+        """
+        Testing for room response with invalid/ future dates
+        """
+        CommonTestCases.admin_token_assert_in(
+                self,
+                get_room_response_query_with_invalid_date,
+                "Dates should be before today"
+            )
+
+    def test_room_with_invalid_date_difference(self):
+        """
+        Testing for room response with higher lower limit
+        """
+        CommonTestCases.admin_token_assert_in(
+                self,
+                get_room_response_query_with_higher_lower_limit,
+                "Earlier date should be lower than later date"
+            )
+
+    def test_database_connection_error(self):
+        """
+        test a user friendly message is returned to a user when database
+        cannot be reached
+        """
+        BaseTestCase().tearDown()
+        CommonTestCases.admin_token_assert_in(
+            self,
+            get_room_response_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            summary_room_response_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            filter_by_response_query,
+            "The database cannot be reached"
+            )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            search_response_by_room_only,
+            "The database cannot be reached"
+        )

--- a/utilities/validations.py
+++ b/utilities/validations.py
@@ -93,3 +93,17 @@ def validate_question_type(**kwargs):
         type = kwargs['question_type']
         if type.lower() not in question_types:
             raise AttributeError("Not a valid question type")
+
+
+def validate_date_range(**kwargs):
+    """
+    Function to validate the date range
+    :params kwargs
+    """
+    if (('end_date' and 'start_date' in kwargs) and
+        kwargs['end_date'] > datetime.datetime.now() or
+            kwargs['start_date'] > datetime.datetime.now()):
+        raise ValueError('Dates should be before today')
+    elif (('end_date' and 'start_date' in kwargs) and
+            kwargs['end_date'] < kwargs['start_date']):
+        raise ValueError('Earlier date should be lower than later date')


### PR DESCRIPTION
#### What does this PR do?
Enable admin to query feedback responses based on date range

#### Description of Task to be completed?
- Currently, when querying responses, one can not query responses by date. This PR allows an admin to query responses by date range. 
- The query can also be run with a `room`  as shown below
- The code has been refactored to cater for both `date range` and `count range` since the functionality is almost similar

#### How should this be manually tested?
- Pull this branch `ft-query-responses-with-data-range-164167409`
- Run the following query
```
query{
    allRoomResponses(startDate: "2019 feb 20", endDate: "2019 feb 25" ){
        responses{
            totalResponses
            roomName
            response{
                responseId
                missingItems
            }
        }
    }
}
```
or 

```
query{
    allRoomResponses(startDate: "2019 feb 20",  endDate: "2019 feb 25", room: "Entebbe" ){
        responses{
            totalResponses
            roomName
            response{
                responseId
                missingItems
            }
        }
    }
}
```
You should be able to query all the responses that fall between that date range.

#### Any background context you want to provide?
This is an extension to query all responses.

#### What are the relevant pivotal tracker stories?
[#164167409](https://www.pivotaltracker.com/story/show/164167409)

#### Screenshots (if appropriate)
**Before**
![screen shot 2019-02-28 at 6 44 21 am](https://user-images.githubusercontent.com/22786444/53539960-ae430500-3b24-11e9-92b0-178fd3fc0437.png)

**After**
![screen shot 2019-02-28 at 6 45 15 am](https://user-images.githubusercontent.com/22786444/53539971-b733d680-3b24-11e9-8ac3-cf1ebeb5a8ba.png)
 
This screenshot shows date range for a specific room
![screen shot 2019-02-28 at 8 35 53 pm](https://user-images.githubusercontent.com/22786444/53595652-dc6d2700-3bae-11e9-988a-49d011f25adb.png)

