### PR TITLE
#165240715 Restrict office structures query by location

### DIFF
--- a/fixtures/structure/structures_fixtures.py
+++ b/fixtures/structure/structures_fixtures.py
@@ -1,6 +1,6 @@
 null = None
 
-structure_query = '''
+structures_query = '''
    {
       allStructures {
         structureId
@@ -14,7 +14,7 @@ structure_query = '''
     }
         '''
 
-expected_structure_query_response = {
+expected_structures_query_response = {
     "data": {
         "allStructures": [
             {
@@ -30,24 +30,26 @@ expected_structure_query_response = {
     }
 }
 
-structures_query = '''
+structure_query = '''
    {
      structureByStructureId(structureId: "b05fc5f2-b4aa-4f48-a8fb-30bdcc3fc968")
      {
           name
           level
           tag
+          locationId
       }
    }
         '''
 
-expected_structures_query_response = {
+expected_structure_query_response = {
     "data": {
         "structureByStructureId":
             {
                 "name": "Epic tower",
                 "level": 1,
-                "tag": "Building"
+                "tag": "Building",
+                "locationId": 1
             }
     }
 }

--- a/helpers/auth/admin_roles.py
+++ b/helpers/auth/admin_roles.py
@@ -5,6 +5,7 @@ from api.room.models import Room as RoomModel
 from helpers.auth.user_details import get_user_from_db
 from helpers.room_filter.room_filter import (
     location_join_room)
+from utilities.utility import StateType
 
 
 class Admin_roles():
@@ -36,8 +37,14 @@ class Admin_roles():
         Return admin's location for viewing analytics data
         """
         admin_details = get_user_from_db()
-        location = Location.query.filter_by(name=admin_details.location).first()
-        return location.id
+        location = Location.query.filter_by(
+             name=admin_details.location
+        ).first()
+        if location:
+            if location.state != StateType.active:
+                raise GraphQLError('Location is not active')
+            return location.id
+        raise GraphQLError('Your location does not exist')
 
 
 admin_roles = Admin_roles()

--- a/tests/test_structure/test_all_structures.py
+++ b/tests/test_structure/test_all_structures.py
@@ -16,3 +16,13 @@ class TestAllStructures(BaseTestCase):
           structures_query,
           expected_structures_query_response
         )
+
+    def test_structures_location_id_matches_admin_location(self):
+        """
+        Test that an admin only views the structures
+        in their location
+        """
+        CommonTestCases.structures_query_matches_admin_location(
+          self,
+          structures_query
+        )

--- a/tests/test_structure/test_structure.py
+++ b/tests/test_structure/test_structure.py
@@ -22,6 +22,16 @@ class TestStructure(BaseTestCase):
             expected_structure_query_response
         )
 
+    def test_structure_location_id_matches_admin_location(self):
+        """
+        Test that an admin can get a single office structure by
+        supplying its structureId from their location only
+        """
+        CommonTestCases.single_structure_query_matches_admin_location(
+            self,
+            structure_query
+        )
+
     def test_structure_with_non_existant_structure_id(self):
         """
         Test that no structure is returned if structureId is not provided


### PR DESCRIPTION
#### What does this PR do?

Restrict office structure query according to location

#### Description of Task to be completed?
Currently, admin can query all of the levels regardless of their locations, this PR makes sure an admin should query office structures(levels) that only belong to their locations

#### How should this be manually tested?
- git pull and checkout branch bg-query-structures-bylocation-165240715
- run application
- Run the following mutations
```
{
      allStructures {
        structureId
        level
        name
        parentId
        tag
        locationId
        position
      }
   }
```
```
{
     structureByStructureId(structureId: "b05fc5f2-b4aa-4f48-a8fb-30bdcc3fc968")
     {
          name
          level
          tag
      }
   }
```
#### What are the relevant pivotal tracker stories?
[#165240715](https://www.pivotaltracker.com/story/show/165240715)

### Background information
* Make sure to create office structures using the structure fixture
* Try playing around the location_id in postico 

### Screenshots
<img width="1429" alt="Screenshot 2019-04-10 at 21 09 50" src="https://user-images.githubusercontent.com/33450849/55903300-07975d00-5bd6-11e9-875e-994a1cfa8f62.png">

<img width="1430" alt="Screenshot 2019-04-10 at 21 10 40" src="https://user-images.githubusercontent.com/33450849/55903340-1bdb5a00-5bd6-11e9-9a8b-a1436fe8a8e3.png">
