### PR TITLE
#164471450 Analytics for auto-cancellation of a single meeting room - v2

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -41,7 +41,8 @@ def save_room_tags(room, room_tags):
 class RatioOfCheckinsAndCancellations(graphene.ObjectType):
     """
         Query to get the ratio of checkins to cancellations and takes the
-            arguments \n- room_name: The name of the room
+            arguments \n- room_id: The id of the room
+                \n- room_name: The name of the room
                 \n- checkins: The number of the event checkins in a room
                 \n- cancellations: The number of the even cacellations in a room
                 \n- bookings: The number of the room bookings
@@ -51,6 +52,7 @@ class RatioOfCheckinsAndCancellations(graphene.ObjectType):
                     via app \n- app_bookings_percentage: The field with the
                         percentage of room bookings via app
     """
+    room_id = graphene.Int()
     room_name = graphene.String()
     checkins = graphene.Int()
     cancellations = graphene.Int()

--- a/fixtures/events/events_ratios_fixtures.py
+++ b/fixtures/events/events_ratios_fixtures.py
@@ -85,3 +85,72 @@ event_ratio_percentage_cancellation_response = {
         }
     }
 }
+
+event_ratio_single_room_query = '''query{
+    analyticsRatiosPerRoom(startDate:"Mar 1 2019", endDate:"Mar 27 2019",
+    roomId:1){
+        ratio{
+            roomName
+            bookings
+            checkins
+            checkinsPercentage
+            cancellations
+            cancellationsPercentage
+            appBookings
+            appBookingsPercentage
+        }
+    }
+}'''
+
+event_ratio_single_room_response = {
+    "data": {
+        "analyticsRatiosPerRoom": {
+            "ratio": {
+                "roomName": "Entebbe",
+                "bookings": 0,
+                "checkins": 0,
+                "checkinsPercentage": 0.0,
+                "cancellations": 0,
+                "cancellationsPercentage": 0.0,
+                "appBookings": 0,
+                "appBookingsPercentage": 0.0
+            }
+        }
+    }
+}
+
+event_ratio_single_room_query_with_non_existing_id = '''query{
+    analyticsRatiosPerRoom(startDate:"Mar 1 2019", endDate:"Mar 27 2019",
+    roomId:5){
+        ratio{
+            roomName
+            bookings
+            checkins
+            checkinsPercentage
+            cancellations
+            cancellationsPercentage
+            appBookings
+            appBookingsPercentage
+        }
+    }
+}'''
+
+event_ratio_single_room_with_non_existing_id_response = {
+    "errors": [
+        {
+            "message": "Room not found",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ],
+            "path": [
+                "analyticsRatiosPerRoom"
+            ]
+        }
+    ],
+    "data": {
+        "analyticsRatiosPerRoom": None
+    }
+}

--- a/tests/test_events/test_events_ratios.py
+++ b/tests/test_events/test_events_ratios.py
@@ -8,6 +8,10 @@ from fixtures.events.events_ratios_fixtures import (
     event_ratio_for_one_day_query,
     event_ratio_per_room_query,
     event_ratio_per_room_response,
+    event_ratio_single_room_query,
+    event_ratio_single_room_response,
+    event_ratio_single_room_query_with_non_existing_id,
+    event_ratio_single_room_with_non_existing_id_response
 )
 
 sys.path.append(os.getcwd())
@@ -46,4 +50,26 @@ class TestEventRatios(BaseTestCase):
             self,
             event_ratio_per_room_query,
             event_ratio_per_room_response
+        )
+
+    def test_event_checkin_and_cancellation_single_room(self):
+        """
+        Test that an admin is able to get the ratio of checkins to bookings
+        for a single room
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            event_ratio_single_room_query,
+            event_ratio_single_room_response
+        )
+
+    def test_event_checkin_cancellation_single_room_wrong_id(self):
+        """
+        Tests that an admin cannot get the ratio of check-ins to bookings for a
+        single room with invalid room id
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            event_ratio_single_room_query_with_non_existing_id,
+            event_ratio_single_room_with_non_existing_id_response
         )


### PR DESCRIPTION
 ### What does this PR do?
Enable admins to view count and auto-cancellation for a single room

### Description of the task to be completed?
- Extend get_per_room function to return single room analytics
- Add tests to cover feature

### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Cd into the cloned repo and checkout to this
3. Git pull branch `ft-cancellation-analytics-single-room-164471450-v2`
4. Run migrations
5. Run the query

```
query{
analyticsRatiosPerRoom(startDate:"Mar 1 2019", endDate:"Mar 27 2019", roomId:1){ 
    	ratio{
      	   roomName
           bookings
           checkins
           checkinsPercentage
           cancellations
           cancellationsPercentage
           appBookings
           appBookingsPercentage
    	}
    }
} 
```

#### Screenshots?
`Getting all rooms`
![Screenshot 2019-03-28 at 7 09 28 PM](https://user-images.githubusercontent.com/13919080/55184804-60590580-5193-11e9-8cca-2dd8ceceba00.png)

`Getting analytics for a single room`
![Screenshot 2019-03-28 at 7 09 59 PM](https://user-images.githubusercontent.com/13919080/55185108-f2610e00-5193-11e9-91ac-c7252ca04ed6.png)


### What are the relevant pivotal tracker stories?
[#164471450](https://www.pivotaltracker.com/story/show/164471450)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations