### PR TITLE
#165355134 Fix analytics for booked rooms

### DIFF
--- a/helpers/calendar/analytics.py
+++ b/helpers/calendar/analytics.py
@@ -144,13 +144,14 @@ class RoomAnalytics:
         for room in rooms_available:
             all_events = CommonAnalytics.get_all_events_in_a_room(
                 self, room['room_id'], start_date, end_date)
-            room_details = RoomStatistics(
-                                            room_name=room["name"],
-                                            meetings=len(all_events),
-                                            percentage=(
-                                                len(all_events))/bookings*100
-                                        )
+            if all_events:
+                room_details = RoomStatistics(
+                    room_name=room["name"],
+                    meetings=len(all_events),
+                    percentage=(len(all_events))/bookings*100)
 
-            result.append(room_details)
-            result.sort(key=lambda x: x.meetings, reverse=True)
+                result.append(room_details)
+                result.sort(key=lambda x: x.meetings, reverse=True)
+            else:
+                return result
         return result


### PR DESCRIPTION
 #### Description
Currently, When querying booked rooms when there are no events in the database,  the query returns a division error as shown below. This PR fixes this error by allowing the query to return an empty list instead of the ambiguous error.
```
{
  "errors": [
    {
      "message": "division by zero",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "analyticsForBookedRooms"
      ]
    }
  ],
  "data": {
    "analyticsForBookedRooms": null
  }
}
```
#### Type of change
- This is a bug fix

#### How Has This Been Tested?
- Pull this branch `ch-fix-analytics-for-booked-rooms-165355134`
- Ensure that the event database is empty
- Run the `analyticsForBookedRooms` query with 
```
 query{
  analyticsForBookedRooms(startDate:"Jan 20 2019", endDate:"Feb 20 2019"){
    analytics{
      roomName
    }
  }
}
```

#### Pivotal Tracker
[#65355134](https://www.pivotaltracker.com/story/show/165355134)
#### Screenshots if any
<img width="1209" alt="Screenshot 2019-04-15 at 19 04 05" src="https://user-images.githubusercontent.com/28715887/56147783-87943d00-5fb1-11e9-8126-5195670a19a8.png">

