### PR TITLE
#165210376 Filter meeting rooms by wings and floors

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -116,6 +116,7 @@ class Query(graphene.ObjectType):
     """
     all_rooms = graphene.Field(
         PaginatedRooms,
+        room_labels=graphene.String(),
         page=graphene.Int(),
         per_page=graphene.Int(),
         capacity=graphene.Int(),
@@ -130,7 +131,8 @@ class Query(graphene.ObjectType):
             \n- resources: Resuources found in the room\
             \n- location: Location of the room\
             \n- office: Office where the room is found\
-            \n- devices: Devices that are in a room"
+            \n- devices: Devices that are in a room\
+            \n- room_labels: Labels to filter the rooms with"
     )
     get_room_by_id = graphene.Field(
         Room,

--- a/fixtures/room/filter_room_fixtures.py
+++ b/fixtures/room/filter_room_fixtures.py
@@ -48,6 +48,53 @@ filter_rooms_by_location_response = {
         }
     }
 }
+filter_rooms_by_wings_and_floors = '''
+    query {
+    allRooms(roomLabels:"1st Floor, Wing A") {
+        rooms {
+        id
+        name
+        roomLabels
+        }
+    }
+    }
+    '''
+
+filter_rooms_by_wings_and_floors_response = {
+    'data': {
+        'allRooms': {
+            'rooms': [
+                {
+                    'id': '1',
+                    'name': 'Entebbe',
+                    'roomLabels': [
+                        '1st Floor',
+                        'Wing A'
+                    ]
+                }
+            ]
+        }
+    }
+}
+filter_rooms_by_non_existent_room_label = '''
+    query {
+    allRooms(roomLabels:"Random") {
+        rooms {
+        id
+        name
+        roomLabels
+        }
+    }
+    }
+    '''
+
+filter_rooms_by_non_existent_room_label_response = {
+    'data': {
+        'allRooms': {
+            'rooms': []
+        }
+    }
+}
 filter_rooms_by_location_capacity = '''query {
   allRooms(location:"Kampala",capacity:6){
    rooms{

--- a/tests/base.py
+++ b/tests/base.py
@@ -92,7 +92,8 @@ class BaseTestCase(TestCase):
                         capacity=6,
                         location_id=location.id,
                         calendar_id='andela.com_3630363835303531343031@resource.calendar.google.com',  # noqa: E501
-                        image_url="https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg")  # noqa: E501
+                        image_url="https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",  # noqa: E501
+                        room_labels=["1st Floor", "Wing A"])
             room.save()
             room.room_tags.append(tag)
             resource = Resource(name='Markers',

--- a/tests/test_rooms/test_room_filter.py
+++ b/tests/test_rooms/test_room_filter.py
@@ -8,7 +8,11 @@ from fixtures.room.filter_room_fixtures import (
     filter_rooms_by_location,
     filter_rooms_by_location_response,
     filter_rooms_by_location_capacity,
-    filter_rooms_by_location_capacity_response
+    filter_rooms_by_location_capacity_response,
+    filter_rooms_by_wings_and_floors,
+    filter_rooms_by_wings_and_floors_response,
+    filter_rooms_by_non_existent_room_label,
+    filter_rooms_by_non_existent_room_label_response
 )
 
 sys.path.append(os.getcwd())
@@ -35,4 +39,18 @@ class RoomsFilter(BaseTestCase):
             self,
             filter_rooms_by_location_capacity,
             filter_rooms_by_location_capacity_response
+        )
+
+    def test_filter_room_by_wings_and_floors(self):
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_wings_and_floors,
+            filter_rooms_by_wings_and_floors_response
+        )
+
+    def test_room_filter_with_non_existent_room_label(self):
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_non_existent_room_label,
+            filter_rooms_by_non_existent_room_label_response
         )


### PR DESCRIPTION
 ### What does this PR do?
Adds a `roomLabels` argument to `allRooms` query that filters rooms by wings and floors
### Description of the task to be completed?
When a user provides the argument `roomLabels` to the `allRooms` query the query returns all rooms that have that label. One can also provide comma separated labels to perform a deeper filter and only rooms that contain the provided labels will be returned
### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `gco ft-filter-meeting-rooms-by-wings-and-floors-165210376`
 - Perform the mutation below to query rooms with the specified labels.
```
{
  allRooms(roomLabels:"Block A, Wing B"){
    rooms{
      id
      name
      roomLabels
    }
  }
}
```
### Any background context you want to provide?
You must create rooms with the room labels you want to query with, otherwise, no rooms will be returned.
### What are the relevant pivotal tracker stories?
[#165210376](https://www.pivotaltracker.com/story/show/165210376)
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
### Screenshots
- #### Query for all rooms with `roomLabels` filter
![image](https://user-images.githubusercontent.com/29709981/56223594-bcb69300-6076-11e9-89da-73e28b27715d.png)






