### PR TITLE
#165412771 Create notification endpoint to redirect

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -253,7 +253,7 @@ class UpdateFirebaseToken(graphene.Mutation):
             raise GraphQLError("Room not found")
         update_entity_fields(room, **kwargs)
         room.save()
-        requests.get(url=Config.MRM_PUSH_URL, params="hello")
+        requests.get(url=Config.MRM_PUSH_URL + "/refresh", params="hello")
         return UpdateFirebaseToken(room=room)
 
 

--- a/app.py
+++ b/app.py
@@ -1,11 +1,11 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, redirect
 
 from flask_graphql import GraphQLView
 from flask_cors import CORS
 from flask_json import FlaskJSON
 
 from flask_mail import Mail
-from config import config
+from config import config, Config
 from helpers.database import db_session
 from schema import schema
 from healthcheck_schema import healthcheck_schema
@@ -22,6 +22,10 @@ def create_app(config_name):
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
     mail.init_app(app)
+
+    @app.route("/notifications", methods=["POST", "GET"])
+    def redirect_notifications():
+        return redirect(Config.MRM_PUSH_URL + "/notifications", code=307)
 
     @app.route("/", methods=['GET'])
     def index():


### PR DESCRIPTION
### What does this PR do?
Adds notifications endpoint to redirect to specified URL

### Description of the task to be completed?
A notifications endpoint should accept both GET and POST endpoints and redirect to the specified URL

### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `gco bg-add-notification-endpoint-165412771`
 - Start the server and navigate to `/notifications`

### What are the relevant pivotal tracker stories?
[#165412771](https://www.pivotaltracker.com/story/show/165412771)