### PR TITLE
#165377719 Query All Room Resources by RoomId

### DIFF
--- a/fixtures/room_resource/get_room_resource_fixtures.py
+++ b/fixtures/room_resource/get_room_resource_fixtures.py
@@ -35,7 +35,7 @@ get_room_resources_by_room_id_response = {
 
 get_paginated_room_resources = '''
  {
-  allResources(page:1, perPage:2){
+  allResources(page:1, perPage:1){
    resources{
       name
    }
@@ -47,18 +47,18 @@ get_paginated_room_resources = '''
 '''
 
 get_paginated_room_resources_response = {
-    "data": {
-        "allResources": {
-            "resources": [
-                {
-                    "name": "Markers"
-                }
-            ],
-            "hasNext":  False,
-            "hasPrevious": False,
-            "pages": 1
+  "data": {
+    "allResources": {
+      "resources": [
+        {
+          "name": "Markers"
         }
+      ],
+      "hasNext": False,
+      "hasPrevious": False,
+      "pages": 1
     }
+  }
 }
 
 filter_unique_resources = '''
@@ -114,7 +114,7 @@ get_paginated_resources_response = {
 
 get_paginated_resources_past_page = '''
 query {
-  allResources(page:2, perPage:1){
+  allResources(page:2, perPage:2){
    resources {
     name
     id
@@ -138,3 +138,41 @@ query {
 }
 }
 '''
+
+get_resource_by_room_id = '''
+query
+{
+  getResourcesByRoomId(roomId:1){
+    roomResources{
+      name
+      id
+      quantity
+    }
+  }
+}'''
+
+get_resource_by_room_id_response_by_admin = {
+  "data": {
+    "getResourcesByRoomId": {
+      "roomResources": [
+        {
+          "name": "Markers",
+          "quantity": 1,
+          "id": "1"
+        }
+      ]
+    }
+  }
+}
+
+get_resource_by_non_existing_room_id = '''
+query
+{
+  getResourcesByRoomId(roomId:143){
+    roomResources{
+      name
+      id
+      quantity
+    }
+  }
+}'''

--- a/tests/test_room_resource/test_get_resource_list.py
+++ b/tests/test_room_resource/test_get_resource_list.py
@@ -9,8 +9,15 @@ from fixtures.room_resource.get_room_resource_fixtures import (
     get_paginated_room_resources,
     get_paginated_room_resources_response,
     get_paginated_resources_past_page,
-    get_paginated_resources_inexistent_page
+    get_paginated_resources_inexistent_page,
+    get_resource_by_room_id,
+    get_resource_by_room_id_response_by_admin,
+    get_resource_by_non_existing_room_id
 )
+from fixtures.room.assign_resource_fixture import (
+    assign_resource_mutation,
+    assign_resource_mutation_response
+    )
 from helpers.database import db_session
 from fixtures.token.token_fixture import USER_TOKEN
 
@@ -55,4 +62,43 @@ class TestGetRoomResource(BaseTestCase):
             self,
             get_paginated_resources_inexistent_page,
             "No page requested"
+        )
+
+    def test_get_room_resource_by_room_id_by_admin(self):
+        '''
+            Test getting room resources for a valid roomId
+            by an admin returns correct resources
+        '''
+        # assign resource to a room
+        CommonTestCases.admin_token_assert_equal(
+           self,
+           assign_resource_mutation,
+           assign_resource_mutation_response,
+        )
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            get_resource_by_room_id,
+            get_resource_by_room_id_response_by_admin
+        )
+
+    def test_get_room_resource_by_invalid_room_id(self):
+        '''
+            Test that getting resource for non-existing roomId
+            returns correct error message
+        '''
+        CommonTestCases.admin_token_assert_in(
+            self,
+            get_resource_by_non_existing_room_id,
+            "Room not found"
+        )
+
+    def test_get_room_resource_by_room_id_by_non_admin(self):
+        '''
+            Test getting room resources for a valid roomId
+            by a non admin returns correct message
+        '''
+        CommonTestCases.user_token_assert_in(
+            self,
+            get_resource_by_room_id,
+            "You are not authorized to perform this action"
         )


### PR DESCRIPTION
 ### What does this PR do?
Adds query for getting all resources assigned to a given room
### Description of the task to be completed?
As an admin, it should be possible to get all the resources assigned to a given room by suppliying the query with the desired `roomId`
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `git checkout ft-query-all-resources-165377719`
 - Follow instructions to assign a resource to a room from #353 
 - Run the following query as an **admin** to fetch all the resources assigned to a given `roomId`
```
{
  getResourcesByRoomId(roomId:1){
    roomResources{
      name
      id
      quantity
    }
  }
}
```
### Any background context you want to provide?
N/A
### What are the relevant pivotal tracker stories?
[#165377719](https://www.pivotaltracker.com/story/show/165377719)
### Screenshots
 - #### Existing room resources:
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/38049235/56666148-05dc9780-66b4-11e9-9055-8741d76c53d3.png">

 - #### Non existing `roomId`:
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/38049235/56348699-aff98280-61cf-11e9-9eff-d933d60acbcc.png">

 - #### Get room resources by a `non admin`:
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/38049235/56348623-88a2b580-61cf-11e9-860f-964197293980.png">

