### PR TITLE
#165222721 Send email notification on event rejection

### DIFF
--- a/api/location/schema.py
+++ b/api/location/schema.py
@@ -14,7 +14,7 @@ from utilities.validations import (
     validate_country_field,
     validate_timezone_field)
 from utilities.utility import update_entity_fields
-from helpers.email.email import send_email_notification
+from helpers.email.email import notification
 from helpers.auth.error_handler import SaveContextManager
 from helpers.auth.user_details import get_user_from_db
 from helpers.room_filter.room_filter import room_join_location
@@ -57,12 +57,19 @@ class CreateLocation(graphene.Mutation):
         email = admin.email
         username = email.split("@")[0]
         admin_name = username.split(".")[0]
+        subject = 'A new location has been added'
+        template = 'location_success.html'
         payload = {
             'model': LocationModel, 'field': 'name', 'value':  kwargs['name']
             }
         with SaveContextManager(location, 'Location', payload):
-            if not send_email_notification(email, location.name, admin_name):
-                raise GraphQLError("Location created but email not sent")
+            if not notification.send_email_notification(
+                email=email, subject=subject, template=template,
+                location_name=location.name, user_name=admin_name
+            ):
+                raise GraphQLError(
+                    "Location created but email not sent"
+                    )
             return CreateLocation(location=location)
 
 

--- a/api/office/schema.py
+++ b/api/office/schema.py
@@ -14,7 +14,7 @@ from helpers.room_filter.room_filter import (
 from helpers.auth.admin_roles import admin_roles
 from helpers.auth.error_handler import SaveContextManager
 from helpers.pagination.paginate import Paginate, validate_page
-from helpers.email.email import send_email_notification
+from helpers.email.email import notification
 from helpers.auth.user_details import get_user_from_db
 
 
@@ -55,7 +55,9 @@ class CreateOffice(graphene.Mutation):
            office, 'Office', payload
         ):
             new_office = kwargs['name']
-            if not send_email_notification(email, new_office, location.name, admin_name):  # noqa
+            if not notification.send_email_notification(
+                email, new_office, location.name, admin_name
+            ):
                 raise GraphQLError("Office created but Emails not Sent")
             return CreateOffice(office=office)
 

--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -10,7 +10,7 @@ from helpers.auth.authentication import Auth
 from utilities.validator import verify_email
 from helpers.pagination.paginate import Paginate, validate_page
 from helpers.auth.error_handler import SaveContextManager
-from helpers.email.email import email_invite
+from helpers.email.email import notification
 from helpers.user_filter.user_filter import user_filter
 from utilities.utility import update_entity_fields
 from api.role.schema import Role
@@ -212,7 +212,7 @@ class InviteToConverge(graphene.Mutation):
         if user:
             raise GraphQLError("User already joined Converge")
         admin = get_user_from_db()
-        email_invite(email, admin.__dict__["name"])
+        notification.email_invite(email, admin.__dict__["name"])
         return InviteToConverge(email=email)
 
 

--- a/fixtures/events/event_checkin_fixtures.py
+++ b/fixtures/events/event_checkin_fixtures.py
@@ -82,23 +82,7 @@ cancel_event_mutation = '''
     }
 '''
 
-cancel_event_respone = {
-    "data": {
-        "cancelEvent": {
-            "event": {
-                "eventId": "test_id5",
-                "roomId": 1,
-                "checkedIn": False,
-                "cancelled": True,
-                "room": {
-                    "id": "1",
-                    "name": "Entebbe",
-                    "calendarId": "andela.com_3630363835303531343031@resource.calendar.google.com"  # noqa: E501
-                }
-            }
-        }
-    }
-}
+cancel_event_respone = "Event cancelled but email not sent"
 
 checkin_mutation_for_event_existing_in_db = '''mutation {
     eventCheckin(

--- a/helpers/calendar/credentials.py
+++ b/helpers/calendar/credentials.py
@@ -66,3 +66,19 @@ def get_google_api_calendar_list(pageToken=None):
     except Exception as exception:
         raise GraphQLError(exception)
     return calendars_list
+
+
+def get_single_calendar_event(calendar_id, event_id):
+    """
+    Get single event from the google calendar
+    :params
+        - calendar_id: The google calendar id for the event
+        - event_id: Unique identifier for the calendar event
+    """
+    credentials = Credentials()
+    service = credentials.set_api_credentials()
+    event = service.events().get(
+                                calendarId=calendar_id,
+                                eventId=event_id
+                                ).execute()
+    return event

--- a/helpers/email/email.py
+++ b/helpers/email/email.py
@@ -1,26 +1,67 @@
 from .email_setup import SendEmail
 from config import Config
 from flask import render_template
+from api.room.models import Room as RoomModel
 
 
-def send_email_notification(admin_email, location_name, user_name):
-    # send the email
-    recipients = [admin_email]
+class EmailNotification:
+    """
+    Send email notifications
+    """
+    def send_email_notification(
+        self, **kwargs
+    ):
+        """
+        send email notifications after a given activity has occured
+        """
+        recipients = [kwargs.get('email')]
 
-    email = SendEmail(
-        'A new location has been added', recipients,
-        render_template(
-            'location_success.html',
-            location_name=location_name,
-            user_name=user_name
-        ))
+        email = SendEmail(
+            kwargs.get('subject'), recipients,
+            render_template(
+                kwargs.get('template'),
+                location_name=kwargs.get('location_name'),
+                user_name=kwargs.get('user_name'),
+                room_name=kwargs.get('room_name'),
+                event_title=kwargs.get('event_title'),
+                event_reject_reason=kwargs.get('event_reject_reason')
+            ))
 
-    return email.send()
+        return email.send()
+
+    def email_invite(self, email, admin):
+        """
+        send email invite for user to join converge
+        """
+        email = SendEmail(
+            "Invitation to join Converge", [email],
+            render_template('invite.html', name=admin,
+                            domain=Config.DOMAIN_NAME)
+            )
+
+        return email.send()
+
+    def event_cancellation_notification(
+        self, event, room_id, event_reject_reason
+    ):
+        """
+        send email notifications on event rejection
+         :params
+            - event: The event being rejected
+            - room_id: Id of the room rejecting the event
+            - event_reject_reason: Reason for rejecting the event
+        """
+        event_title = event['summary']
+        email = event['organizer']['email']
+        room = RoomModel.query.filter_by(id=room_id).first()
+        room_name = room.name
+        subject = 'Your room reservation was rejected'
+        template = 'event_cancellation.html'
+        return EmailNotification.send_email_notification(
+            self, email=email, subject=subject, template=template,
+            room_name=room_name, event_title=event_title,
+            event_reject_reason=event_reject_reason
+        )
 
 
-def email_invite(email, admin):
-    email = SendEmail(
-        "Invitation to join Converge", [email],
-        render_template('invite.html', name=admin, domain=Config.DOMAIN_NAME))
-
-    return email.send()
+notification = EmailNotification()

--- a/templates/event_cancellation.html
+++ b/templates/event_cancellation.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en" style="box-sizing: border-box;height:100%;font-family: sans-serif;line-height: 1.15;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;-ms-overflow-style: scrollbar;-webkit-tap-highlight-color: transparent;">
+
+<head style="box-sizing: border-box;">
+    <!-- Required meta tags -->
+    <meta charset="utf-8" style="box-sizing: border-box;">
+    <meta name="viewport" content="width=device-width, initial-scale=1" style="box-sizing: border-box;">
+
+    <title style="box-sizing: border-box;">Converge</title>
+
+
+    <style style="box-sizing: border-box;">
+        @font-face {
+            font-family: 'DINPro';
+            src: url("https://firebasestorage.googleapis.com/v0/b/andelamrm.appspot.com/o/email_assets%2Ffonts%2FDINPro-Regular.woff?alt=media&token=8740b12d-b0d5-497a-8288-53fc5a6b432e");
+        }
+    </style>
+</head>
+
+<body style="box-sizing: border-box;margin: 0;height:100%;font-family: 'DINPro', 'Roboto', sans-serif;font-size: 1rem;font-weight: 400;line-height: 1.5;color: #212529;text-align: left;background-color: #f4f8f9;min-width: 992px!important;">
+    <div class="container" style="box-sizing: border-box;height:100%;width: 100%;padding-right: 15px;padding-left: 15px;margin-right: auto;margin-left: auto;min-width: 992px!important;padding:70px;">
+        <div id="email" style="box-sizing: border-box;width: 611px;background-color: #ffff;margin: auto;">
+            <div class="converge" style="box-sizing: border-box;padding-top: 24px;height: 23;width: 195px;color: #3359db;font-size: 18px;font-weight: 500;letter-spacing: 0.36px;line-height: 23px;margin: auto;">
+                <img src="https://i.imgur.com/6foV1gb.png" alt="" style="box-sizing: border-box;vertical-align: middle;border-style: none;page-break-inside: avoid;">
+                <span class="logo" style="box-sizing: border-box;display: inline-block;margin-left: 10px;">
+                    <h5 style="box-sizing: border-box;margin-top: 0;margin-bottom: .5rem;font-family: inherit;font-weight: 500;line-height: 1.2;color: inherit;font-size: 1.25rem; font-family: 'DINPro', 'Roboto', sans-serif">CONVERGE</h5>
+                </span>
+            </div>
+            <div style="box-sizing: border-box;">
+                <hr style="box-sizing: content-box;height: 0;overflow: visible;margin-top: 1rem;margin-bottom: 1rem;border: 0;border-top: 1px solid rgba(0,0,0,.1);">
+            </div>
+            <div class="rectangle" style="box-sizing: border-box;width: 610px;text-align: center;">
+                <div style="box-sizing: border-box;">
+                    <h5 class="greeting" style="box-sizing: border-box;margin-top: 0;margin-bottom: .5rem;font-family: inherit;font-weight: 500;line-height: 31px;color: inherit;font-size: 24px;padding-top: 63px;">
+                        <Strong>Rejected Event!</strong>
+                    </h5>
+                </div>
+                <div class="rectangle-3" style="box-sizing: border-box;margin: 45px 105px;">
+                    <p class="invite" style="box-sizing: border-box;margin-top: 0;margin-bottom: 0;orphans: 3;widows: 3;color: #6d6d6d;line-height: 21px;font-family: 'DINPro', 'Roboto', sans-serif !important; text-align: unset; width: max-content;">
+                        <strong> {{ room_name }} </strong> has just rejected the reservation for the meeting <br/> <strong> {{ event_title }} </strong> because no one has checked in <br/> {{ event_reject_reason }}.
+                    </p>
+                </div>
+                <div style="box-sizing: border-box;">
+                    <hr class="line" style="box-sizing: content-box;height: 0;overflow: visible;margin-top: 70px;margin-bottom: 1rem;border: 0;border-top: 1px solid rgba(0,0,0,.1);">
+                </div>
+            </div>
+            <div class="rectangle-2" style="box-sizing: border-box;height: 130px;width: 610px;border-radius: 0 0 4px 4px;">
+                <div class="contact" style="box-sizing: border-box;height: 54.32px;width: 490px;font-family: 'DINPro', 'Roboto', sans-serif, sans-serif;color: #000000;font-size: 16px;line-height: 27px;padding-top: 39px;padding-bottom: 39px;margin: auto;text-align: center;">
+                    <p style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;">
+                        Have a question?
+                        <br style="box-sizing: border-box;"> <a href="#" style="box-sizing: border-box;color: #007bff;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
+                            support@converge.com</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="subcription" style="box-sizing: border-box;height: 19.16px;width: 490px;color: #000111;font-family: 'DINPro', 'Roboto', sans-serif, sans-serif;font-size: 16px;line-height: 19px;text-align: center;margin: auto;padding-top: 15px;">
+            <p style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;">You can change your<span style="box-sizing: border-box;"><a
+                        id="link" href="https://converge-test.andela.com/preference" style="box-sizing: border-box;color: #999999;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
+                        <strong>subscription settings </strong></a></span> anytime.</p>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/tests/test_events/test_event_checkin.py
+++ b/tests/test_events/test_event_checkin.py
@@ -1,5 +1,6 @@
 import sys
 import os
+from unittest.mock import patch
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.events.event_checkin_fixtures import (
     event_checkin_mutation,
@@ -13,6 +14,7 @@ from fixtures.events.event_checkin_fixtures import (
 from fixtures.events.events_ratios_fixtures import (
     event_ratio_percentage_cancellation_query,
     event_ratio_percentage_cancellation_response)
+from helpers.calendar.calendar import get_events_mock_data
 
 sys.path.append(os.getcwd())
 
@@ -54,21 +56,25 @@ class TestEventCheckin(BaseTestCase):
             "This Calendar ID is invalid"
         )
 
-    def test_cancel_event(self):
+    @patch("api.events.schema.get_single_calendar_event", spec=True)
+    def test_cancel_event(self, mocked_method):
         '''
         Test that event status is updated to cancelled.
         '''
-        CommonTestCases.user_token_assert_equal(
+        mocked_method.return_value = get_events_mock_data()['items'][0]
+        CommonTestCases.user_token_assert_in(
             self,
             cancel_event_mutation,
             cancel_event_respone
         )
 
-    def test_cancel_event_twice(self):
+    @patch("api.events.schema.get_single_calendar_event", spec=True)
+    def test_cancel_event_twice(self, mocked_method):
         '''
         test that you cannot cancel an event twice
         '''
-        CommonTestCases.user_token_assert_equal(
+        mocked_method.return_value = get_events_mock_data()['items'][0]
+        CommonTestCases.user_token_assert_in(
             self,
             cancel_event_mutation,
             cancel_event_respone
@@ -85,11 +91,13 @@ class TestEventCheckin(BaseTestCase):
             event_ratio_percentage_cancellation_response
         )
 
-    def test_check_in_to_a_cancelled_event(self):
+    @patch("api.events.schema.get_single_calendar_event", spec=True)
+    def test_check_in_to_a_cancelled_event(self, mocked_method):
         """
         test that you cannot check-in to a cancelled event
         """
-        CommonTestCases.user_token_assert_equal(
+        mocked_method.return_value = get_events_mock_data()['items'][0]
+        CommonTestCases.user_token_assert_in(
             self,
             cancel_event_mutation,
             cancel_event_respone


### PR DESCRIPTION
 ### What does this PR do?
Enable a user to receive an email notification when a meeting is rejected.

### Description of the task to be completed?
The following are scenarios where we will send email notifications when a room rejects the booking of an event:
- When a user misses to check-in within 10 minutes after the meeting has started.
- When a user misses to check-in for 3 consecutive meetings. All future bookings to the specific room will be rejected. 

### How should this be manually tested?
- git pull and checkout branch ft-cancelled-event-notification-v2-165222721
- run application
- run the cancelEvent mutation below
```
mutation {
        cancelEvent(
        calendarId:"andela.com_38393338303730373538@resource.calendar.google.com",
        eventId:"041t6mhogr8cq7i8vvr2h36d9p", eventTitle:"First LFA On-Boarding", numberOfParticipants: 13,
        startTime:"2018-08-14T06:00:00-07:00",
        endTime:"2018-08-14T07:00:00-07:00")
        {
            event{
                eventId
                roomId
                checkedIn
                cancelled
                room{
                    id
                    name
                    calendarId
                }
            }
        }
}
```

#### Screenshots?
`Email received`
![image](https://user-images.githubusercontent.com/12385482/56959683-ee3f5c00-6b56-11e9-8584-b2169db36805.png)




### What are the relevant pivotal tracker stories?
[#165222721](https://www.pivotaltracker.com/story/show/165222721)

### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes