### PR TITLE
#165014764 Update an assigned room resource

### DIFF
--- a/api/room_resource/schema.py
+++ b/api/room_resource/schema.py
@@ -94,16 +94,16 @@ class UpdateAssignedResource(graphene.Mutation):
         exact_resource = ResourceModel.query.filter_by(
             id=resource_id).first()
         room_resource_query = RoomResource.get_query(info)
-        room_resources = room_resource_query.filter(
+        rooms_with_resource = room_resource_query.filter(
             RoomResourceModel.room_id == room_id).all()
-        if not room_resources:
+        if not rooms_with_resource:
             raise GraphQLError('Room has no assigned resource')
         current_resource = None
-        for room_resource in room_resources:
+        for room_resource in rooms_with_resource:
             if room_resource.resource_id == resource_id:
                 current_resource = room_resource.quantity
                 break
-        if not current_resource:
+        if current_resource is None:
             raise GraphQLError('Resource does not exist in the room')
         if kwargs['quantity'] < 0:
             raise GraphQLError(

--- a/fixtures/room_resource/update_assigned_resource.py
+++ b/fixtures/room_resource/update_assigned_resource.py
@@ -1,0 +1,59 @@
+update_assigned_resource_query = '''
+    mutation{
+        updateAssignedResource(roomId:1, resourceId:1, quantity: 3){
+            roomResource{
+                roomId
+                resourceId
+                quantity
+            }
+        }
+    }
+'''
+
+update_assigned_resource_query_response = {
+  'data': {
+    'updateAssignedResource': {
+      'roomResource': {
+        "roomId": "1",
+        "resourceId": "1",
+        'quantity': 3
+      }
+    }
+  }
+}
+
+update_with_negative_quantity = '''
+    mutation{
+        updateAssignedResource(roomId:1, resourceId:1, quantity:-1 ){
+        roomResource{
+            roomId
+            resourceId
+            quantity
+        }
+    }
+}
+'''
+
+update_non_existing_room = '''
+  mutation{
+        updateAssignedResource(roomId:11, resourceId:1, quantity:1 ){
+        roomResource{
+            roomId
+            resourceId
+            quantity
+        }
+    }
+}
+'''
+
+update_non_existing_resource = '''
+  mutation{
+        updateAssignedResource(roomId:1, resourceId:12, quantity:1 ){
+        roomResource{
+            roomId
+            resourceId
+            quantity
+        }
+    }
+}
+'''

--- a/tests/test_room_resource/test_update_assigned_resource.py
+++ b/tests/test_room_resource/test_update_assigned_resource.py
@@ -1,0 +1,89 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.room_resource.update_assigned_resource import (
+    update_assigned_resource_query,
+    update_assigned_resource_query_response,
+    update_with_negative_quantity,
+    update_non_existing_room,
+    update_non_existing_resource
+)
+from fixtures.room.assign_resource_fixture import (
+    assign_resource_mutation,
+    assign_resource_mutation_response
+)
+
+
+class TestUpdateAssignedResorce(BaseTestCase):
+
+    def test_update_assigned_resource_by_non_admin(self):
+        """
+        Test that only an admin can update an
+        assigned resource
+        """
+        CommonTestCases.user_token_assert_in(
+            self,
+            update_assigned_resource_query,
+            "You are not authorized to perform this action"
+        )
+
+    def test_update_assigned_resource_by_admin(self):
+        """
+        Test that an admin can update an assigned resource
+        """
+        CommonTestCases.admin_token_assert_equal(
+           self,
+           assign_resource_mutation,
+           assign_resource_mutation_response,
+        )
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_assigned_resource_query,
+            update_assigned_resource_query_response
+        )
+
+    def test_update_assigned_resource_with_negative_quantity(self):
+        """
+        Test that an admin cannot update a resource
+        with a negative quantity
+        """
+        CommonTestCases.admin_token_assert_equal(
+           self,
+           assign_resource_mutation,
+           assign_resource_mutation_response,
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_with_negative_quantity,
+            "Assigned quantity cannot be less than zero"
+        )
+
+    def test_update_with_non_existing_room(self):
+        """
+        Test that an admin can not update a
+        non existing room in the room_resources table
+        """
+        CommonTestCases.admin_token_assert_equal(
+           self,
+           assign_resource_mutation,
+           assign_resource_mutation_response,
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_non_existing_room,
+            "Room has no assigned resource"
+        )
+
+    def test_update_with_non_existing_resource(self):
+        """
+        Test that an admin can not update a
+        non existing resource in the room_resources table
+        """
+        CommonTestCases.admin_token_assert_equal(
+           self,
+           assign_resource_mutation,
+           assign_resource_mutation_response,
+        )
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_non_existing_resource,
+            "Resource does not exist in the room"
+        )


### PR DESCRIPTION
#### What does this PR do?

Update an assigned room resource

#### Description of Task to be completed?
Currently, one can assign a resource to a room using an association object, this PR makes it possible to update the quantity on the association object

#### How should this be manually tested?
- git pull and checkout to the branch ft-update-assigned-resource-165014764
- run application
- Run the following mutation
```
mutation{
        updateAssignedResource(roomId:1, resourceId:1, quantity: 5){
            roomResource{
                roomId
                resourceId
                quantity
            }
        }
    }
```
#### What are the relevant pivotal tracker stories?
[165014764](https://www.pivotaltracker.com/story/show/165014764)

### Background information
* Assign a resource first
* Ensure the resource of id one is assigned to room one to use the above mutation

### Screenshots
<img width="1426" alt="Screenshot 2019-04-23 at 18 30 49" src="https://user-images.githubusercontent.com/33450849/56594697-f8f96e80-65f5-11e9-96d7-9f026b3ab79c.png">

### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
