### PR TITLE
#165443496 Room labels should only accept a list of strings

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -6,7 +6,7 @@ from graphql import GraphQLError
 from config import Config
 from api.room.models import Room as RoomModel
 from api.tag.models import Tag as TagModel
-from utilities.validations import validate_empty_fields
+from utilities.validations import validate_empty_fields, validate_room_labels
 from utilities.utility import update_entity_fields
 from helpers.auth.authentication import Auth
 from helpers.auth.admin_roles import admin_roles
@@ -105,13 +105,15 @@ class CreateRoom(graphene.Mutation):
         calendar_id = graphene.String()
         cancellation_duration = graphene.Int()
         room_tags = graphene.List(graphene.Int)
-        room_labels = graphene.List(graphene.String)
+        room_labels = graphene.List(graphene.String, required=False)
     room = graphene.Field(Room)
 
     @Auth.user_roles('Admin')
     def mutate(self, info, **kwargs):
         validate_empty_fields(**kwargs)
         verify_location_id(kwargs)
+        query = RoomModel.query
+        validate_room_labels(**kwargs, query=query)
         admin_roles.create_rooms_update_delete_location(kwargs)
         query = Room.get_query(info)
         active_rooms = query.filter(RoomModel.state == "active")
@@ -125,7 +127,7 @@ class CreateRoom(graphene.Mutation):
             RoomModel.name == kwargs.get('name'),
             RoomModel.state == "active",
             RoomModel.location_id == kwargs.get('location_id')
-            )
+        )
         if result.count():
             ErrorHandler.check_conflict(self, kwargs['name'], 'Room')
         room_tags = []

--- a/fixtures/helpers/decorators_fixtures.py
+++ b/fixtures/helpers/decorators_fixtures.py
@@ -36,7 +36,8 @@ room_mutation_query = '''
           capacity: 1,
           locationId: 1,
           roomTags: [1],
-          imageUrl: "http://url.com") {
+          imageUrl: "http://url.com",
+          roomLabels: ["Epic tower", "1st Floor"]) {
             room {
                 name
                 roomType
@@ -48,6 +49,7 @@ room_mutation_query = '''
                   name
                   color
                 }
+                roomLabels
             }
         }
     }
@@ -57,7 +59,7 @@ user_role_401_msg = b'{"errors":[{"message":"You are not authorized to perform t
 
 query_string = '/mrm?query='+room_mutation_query
 
-query_string_response = b'{"data":{"createRoom":{"room":{"name":"Syne","roomType":"Meeting","capacity":1,"locationId":1,"calendarId":"andela.com_3836323338323230343935@resource.calendar.google.com","imageUrl":"http://url.com","roomTags":[{"name":"Block-B","color":"green"}]}}}}'  # noqa: E501
+query_string_response = b'{"data":{"createRoom":{"room":{"name":"Syne","roomType":"Meeting","capacity":1,"locationId":1,"calendarId":"andela.com_3836323338323230343935@resource.calendar.google.com","imageUrl":"http://url.com","roomTags":[{"name":"Block-B","color":"green"}],"roomLabels":["Epic tower","1st Floor"]}}}}'  # noqa: E501
 
 expired_token = jwt.encode(expired, SECRET_KEY)
 

--- a/fixtures/room/create_room_fixtures.py
+++ b/fixtures/room/create_room_fixtures.py
@@ -1,26 +1,48 @@
 null = None
 
 room_mutation_query = '''
-    mutation {
+ mutation {
         createRoom(
-            name: "Mbarara", roomType: "Meeting", capacity: 4, roomTags: [1], locationId: 1,
-            calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
-            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+          name: "Syne",
+          calendarId: "andela.com_3836323338323230343935@resource.calendar.google.com",  # noqa: E501
+          roomType: "Meeting",
+          capacity: 1,
+          locationId: 1,
+          roomTags: [1],
+          imageUrl: "http://url.com",
+          roomLabels: ["Epic tower", "1st Floor"]) {
             room {
-                id
                 name
                 roomType
                 capacity
-                locationId
+                locationId,
+                calendarId,
                 imageUrl
                 roomTags {
                   name
-                  description
+                  color
                 }
+                roomLabels
             }
         }
     }
 '''
+
+room_mutation_query_response = {'data': {'createRoom': {
+    'room': {
+        'name': 'Syne',
+        'roomType': 'Meeting',
+        'capacity': 1,
+        'locationId': 1,
+        'calendarId': 'andela.com_3836323338323230343935@resource.calendar.google.com',   # noqa: E501
+        'imageUrl': 'http://url.com',
+        'roomTags': [{'name': 'Block-B', 'color': 'green'}],
+        'roomLabels': ['Epic tower', '1st Floor']
+    }
+}
+}
+}
+
 
 room_mutation_response = {
     "data": {
@@ -41,7 +63,8 @@ room_invalid_location_id_mutation = '''
             name: "aso", roomType: "Meeting", capacity: 4,
             locationId: 9, roomTags: [1],
             calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
-            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",
+            roomLabels: ["Epic Tower", "1st Floor"]) {  # noqa: E501
             room {
                 name
                 roomType
@@ -62,7 +85,8 @@ room_invalid_tag_mutation = '''
         createRoom(
             name: "Mbarara", roomType: "Meeting", capacity: 4, roomTags: [8], locationId: 1,
             calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
-            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",
+            roomLabels: ["Epic tower", "1st Floor"]) {  # noqa: E501
             room {
                 id
                 name
@@ -81,7 +105,8 @@ room_name_empty_mutation = '''
             name: "", roomType: "Meeting", capacity: 4,
             locationId: 1, roomTags: [1],
             calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
-            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",
+            roomLabels: ["Epic Tower", "1st Floor"]) {  # noqa: E501
             room {
                 name
                 roomType
@@ -95,9 +120,10 @@ room_name_empty_mutation = '''
 room_invalid_calendar_id_mutation_query = '''
     mutation {
         createRoom(
-            name: "Kigali", roomType: "Meeting", capacity: 6, locationId: 1, roomTags: [1],
+            name: "Kigali", roomType: "Meeting", capacity: 6, locationId: 1,
             calendarId:"andela.com_38363233383232303439@resource.calendar.google.com",
-            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",
+            roomLabels: ["Epic tower", "1st Floor"]) {  # noqa: E501
             room {
                 name
             }
@@ -139,6 +165,53 @@ query {
       }
         }
     }
+}
+'''
+
+
+invalid_room_label_query = '''
+mutation {
+  createRoom(
+    name: "yaoundejsdcds",
+    roomType: "Meeting",
+    capacity: 4,
+    locationId: 3,
+    calendarId: "andela.com_3735303539313930363030@resource.calendar.google.com",
+    imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg", # noqa: E501
+    roomLabels: ["{'id': '1', 'value': 'Office 1'}"]) {
+    room {
+      id
+      name
+      roomType
+      capacity
+      locationId
+      imageUrl
+    }
+  }
+}
+'''
+
+non_existent_structure_room_label_query = '''
+  mutation {
+createRoom(name: "Djibouti", roomType: "Meeting", capacity: 4, locationId: 1,
+calendarId:"andela.com_3334333830313238333634@resource.calendar.google.com",
+imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg", # noqa: E501
+roomLabels: ["Block Z", "10th Floor"]) {
+    room {
+      id
+      name
+      roomType
+      capacity
+      locationId
+      imageUrl
+      roomLabels
+      roomTags {
+        name
+        color
+      }
+
+    }
+  }
 }
 '''
 
@@ -188,9 +261,10 @@ query_rooms_response = {
 room_mutation_query_duplicate_name = '''
     mutation {
         createRoom(
-            name: "Entebbe", roomType: "Meeting", capacity: 4, roomTags: [1], locationId: 1,
+            name: "Entebbe", roomType: "Meeting", capacity: 4, locationId: 1,
             calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
-            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",
+            roomLabels: ["Epic tower", "1st Floor"]) {  # noqa: E501
             room {
                 id
                 name
@@ -230,9 +304,10 @@ room_mutation_query_duplicate_name_response = {
 room_duplicate_calender_id_mutation_query = '''
     mutation {
         createRoom(
-            name: "Mbarara", roomType: "Meeting", capacity: 4, locationId:1,
+            name: "Mbarara", roomType: "Meeting", capacity: 4, locationId: 1,
             calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
-            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg") {  # noqa: E501
+            imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",
+            roomLabels: ["Epic tower", "1st Floor"]) {  # noqa: E501
             room {
                 name
                 roomType

--- a/fixtures/structure/create_structure_fixtures.py
+++ b/fixtures/structure/create_structure_fixtures.py
@@ -7,10 +7,10 @@ office_structure_mutation_query = '''
                 {structureId: "a-web-story", name: "Office 1", level: 1,
                 parentId: "1", parentTitle: "parent1", tag: "office",
                 position: 1, locationId: 2},
-                {structureId: "a-web-user", name: "Office 1", level: 1,
+                {structureId: "a-web-user", name: "1st Floor", level: 1,
                 parentId: "1", parentTitle: "parent2", tag: "office",
                 position: 2, locationId: 2},
-                {structureId: "a-web-guy", name: "Office 1", level: 1,
+                {structureId: "a-web-guy", name: "Block A", level: 1,
                 parentId: "1", parentTitle: "parent3", tag: "office",
                 position: 2, locationId: 2}
             ]){
@@ -45,7 +45,7 @@ office_structure_mutation_response = {
                 },
                 {
                     "structureId": "a-web-user",
-                    "name": "Office 1",
+                    "name": "1st Floor",
                     "level": 1,
                     "parentId": "1",
                     "parentTitle": "parent2",
@@ -55,7 +55,7 @@ office_structure_mutation_response = {
                 },
                 {
                     "structureId": "a-web-guy",
-                    "name": "Office 1",
+                    "name": "Block A",
                     "level": 1,
                     "parentId": "1",
                     "parentTitle": "parent3",

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -15,7 +15,10 @@ from fixtures.room.create_room_fixtures import (
     room_duplicate_calender_id_mutation_query,
     room_duplicate_calendar_id_mutation_response,
     room_invalid_location_id_mutation,
-    room_invalid_tag_mutation)
+    room_invalid_tag_mutation,
+    invalid_room_label_query,
+    non_existent_structure_room_label_query,
+    room_mutation_query_response)
 from fixtures.token.token_fixture import ADMIN_TOKEN
 
 sys.path.append(os.getcwd())
@@ -53,6 +56,35 @@ class TestCreateRoom(BaseTestCase):
             room_mutation_query_duplicate_name,
             room_mutation_query_duplicate_name_response
         )
+
+    def test_invalid_room_label_format(self):
+        """
+        Test that room label does not accepts list of
+        dictionaries and saves them as strings
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            invalid_room_label_query,
+            "Room label is not a valid string type")
+
+    def test_valid_room_label_format(self):
+        """
+        Test when the room label inserted is valid
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            room_mutation_query,
+            room_mutation_query_response)
+
+    def test_nonexistent_structure_room_label_query(self):
+        """
+        Test that a room label cannot be created when
+        structure does not exist
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            non_existent_structure_room_label_query,
+            "Structure does not exist")
 
     def test_create_room_with_invalid_location_id(self):
         """

--- a/utilities/validations.py
+++ b/utilities/validations.py
@@ -1,9 +1,11 @@
 import datetime
 import validators
+import re
 
 from api.location.models import CountryType, TimeZoneType
 from graphql import GraphQLError
 from api.office_structure.models import OfficeStructure as OfficeStructureModel
+from api.structure.models import Structure as StructureModel
 
 
 def validate_url(**kwargs):
@@ -42,7 +44,7 @@ def validate_date_time_range(**kwargs):
     elif ('start_date' and 'end_date' in kwargs) and\
             kwargs['end_date'] - kwargs['start_date'] < datetime.timedelta(
                 days=1
-            ):
+    ):
         raise ValueError(
             'endDate should be at least a day after startDate'
         )
@@ -107,3 +109,19 @@ def validate_date_range(**kwargs):
     elif (('end_date' and 'start_date' in kwargs) and
             kwargs['end_date'] < kwargs['start_date']):
         raise ValueError('Earlier date should be lower than later date')
+
+
+def validate_room_labels(**kwargs):
+    """
+    Function to validate the room label string type
+    :params **kwargs
+    """
+    room_labels = kwargs.get('room_labels')
+    label = re.search("[{}:]", str(room_labels))
+    if label:
+        raise AttributeError("Room label is not a valid string type")
+    for label in room_labels:
+        structure = StructureModel.query.filter_by(name=label).first()
+        if structure is None:
+            raise GraphQLError("Structure does not exist")
+        break


### PR DESCRIPTION
**What does this PR do?**

- Validates room labels such that it only allows a list of strings
- Prevents Admin from creating room labels for a structure that does not exist.

**Description of the Task to be completed**
- At the moment, when the Admin is creating a room. They can be able to add a list of dictionaries.
- The Admin is also able to create a room in a structure that does not exist. The bug fix handles this issue.

**How should this be manually tested?**
- git pull the branch `bg-labels-accept-strings-165443496`
- Run the application
- Checkout to the branch and run the following mutation
```mutation {
createRoom(
name: "mongoliae",
roomType: "Meeting",
capacity: 4,
locationId: 1,
calendarId: "andela.com_2d3437383637373630343336@resource.calendar.google.com",
imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg", roomLabels: ["{'id': '1', 'value': 'Office 1'}"]) {
    room {
      id
      name
      roomType
      capacity
      locationId
      imageUrl
      roomLabels
    }
  }
}
```
**What are the relevant pivotal tracker stories?**
[#165443496](https://www.pivotaltracker.com/n/projects/2154921/stories/165443496)

**Background information**
- None

**Screenshots**
`Before bug was fixed`
![image](https://user-images.githubusercontent.com/28762562/56811373-3bfb5200-6841-11e9-8047-cbbf33cddc3b.png)
`After bug was fixed`
![image](https://user-images.githubusercontent.com/28762562/56807451-88419480-6837-11e9-8d0f-2f3383a2fa3e.png)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations