### PR TITLE
#165570624 Fix the key error on syncEventdata mutation

### DIFF
--- a/helpers/calendar/events.py
+++ b/helpers/calendar/events.py
@@ -160,8 +160,10 @@ class CalendarEvents:
 
                 elif existing_event:
                     existing_event.event_title = event.get("summary")
-                    existing_event.start_time = event["start"]["dateTime"]
-                    existing_event.end_time = event["end"]["dateTime"]
+                    existing_event.start_time = event["start"].get(
+                        "dateTime") or event["start"].get("date")
+                    existing_event.end_time = event["end"].get(
+                        "dateTime") or event["end"].get("date")
                     existing_event.number_of_participants = number_of_attendees
                     existing_event.save()
 
@@ -171,8 +173,10 @@ class CalendarEvents:
                         recurring_event_id=event.get("recurringEventId"),
                         room_id=room.id,
                         event_title=event.get("summary"),
-                        start_time=event["start"]["dateTime"],
-                        end_time=event["end"]["dateTime"],
+                        start_time=event["start"].get(
+                            "dateTime") or event["start"].get("date"),
+                        end_time=event["end"].get(
+                            "dateTime") or event["end"].get("date"),
                         number_of_participants=number_of_attendees,
                         checked_in=False,
                         cancelled=False


### PR DESCRIPTION
  #### Description
Currently, When running a mutation to sync event table in the local database with events data from the Google calendar API,  the mutation crushes and returns a key error as shown below. This PR fixes this error by allowing the mutation to successfully populate the events table.
```
{
    "errors": [
        {
            "message": "'dateTime'",
            "locations": [
                {
                    "line": 2,
                    "column": 3
                }
            ],
            "path": [
                "syncEventData"
            ]
        }
    ],
    "data": {
        "syncEventData": null
    }
}
```
#### Type of change
- This is a bug fix

#### How Has This Been Tested?
- Pull this branch `bg-fix-error-on-populating-events-table-165570624`
- Ensure that the event database is empty
- Run the mutation `syncEventData`  as shown below 
```
mutation{
  syncEventData{
    message
  }
}
```

#### Pivotal Tracker
[#165570624](https://www.pivotaltracker.com/story/show/165570624)
#### Screenshots if any
<img width="1190" alt="Screenshot 2019-04-24 at 19 27 00" src="https://user-images.githubusercontent.com/28715887/56676507-206c3c00-66c7-11e9-8801-352a57bd2197.png">
