### PR TITLE
#165595771 Fix HTTPS conn errors on notifications endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,5 @@ typing==3.6.4
 flake8==3.5.0
 coveralls
 validators==0.12.4
+ndg-httpsclient
+pyopenssl


### PR DESCRIPTION
 ### What does this PR do?
Fixes HTTPS Conn errors on notifications endpoint.

### Description of the task to be completed?
Add two libraries that help with HTTPs handshaking

### How should this be manually tested?
 Try and access the notifications endpoint (`<BACKEND-API-URL>/notifications`), it should not be timing out anymore

### Screenshots
N/A

#### What are the relevant pivotal tracker stories?
[#165595771](https://www.pivotaltracker.com/story/show/165595771)