### PR TITLE
#165535238 Delete assigned room resource

### DIFF
--- a/fixtures/room_resource/delete_assigned_resource_fixtures.py
+++ b/fixtures/room_resource/delete_assigned_resource_fixtures.py
@@ -1,0 +1,54 @@
+delete_assigned_resource_mutation = '''
+    mutation {
+        deleteAssignedResource(resourceId: 1, roomId: 1) {
+            roomResource {
+                roomId
+                resourceId
+            }
+        }
+    }
+'''
+
+delete_assigned_resource_from_non_existing_resource = '''
+    mutation {
+        deleteAssignedResource(resourceId: 10, roomId: 1) {
+            roomResource {
+                roomId
+                resourceId
+            }
+        }
+    }
+'''
+
+delete_assigned_resource_from_non_existing_room = '''
+    mutation {
+        deleteAssignedResource(resourceId: 1, roomId: 10) {
+            roomResource {
+                roomId
+                resourceId
+            }
+        }
+    }
+'''
+
+delete_non_existing_assigned_resource_mutation = '''
+    mutation {
+        deleteAssignedResource(resourceId: 1, roomId: 1) {
+            roomResource {
+                roomId
+                resourceId
+            }
+        }
+    }
+'''
+
+delete_assigned_resource_response = {
+    "data": {
+        "deleteAssignedResource": {
+            "roomResource": {
+                "roomId": "1",
+                "resourceId": "1"
+            }
+        }
+    }
+}

--- a/tests/test_room_resource/test_delete_assigned_resource.py
+++ b/tests/test_room_resource/test_delete_assigned_resource.py
@@ -1,0 +1,73 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.room_resource.delete_assigned_resource_fixtures import (
+    delete_assigned_resource_mutation,
+    delete_assigned_resource_from_non_existing_resource,
+    delete_assigned_resource_from_non_existing_room,
+    delete_non_existing_assigned_resource_mutation,
+    delete_assigned_resource_response)
+from fixtures.room.assign_resource_fixture import (
+    assign_resource_mutation,
+    assign_resource_mutation_response)
+
+
+class TestDeleteAssignedResorce(BaseTestCase):
+
+    def test_delete_assigned_resource_by_non_admin(self):
+        """
+        Test that non admin accounts cannot delete an
+        assigned resource
+        """
+        CommonTestCases.user_token_assert_in(
+            self,
+            delete_assigned_resource_mutation,
+            "You are not authorized to perform this action"
+        )
+
+    def test_delete_non_existing_resource(self):
+        """
+        Test that an admin cannot delete an assigned resource
+        if the resource does not exist
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_assigned_resource_from_non_existing_resource,
+            "Resource does not exist"
+        )
+
+    def test_delete_from_non_existing_room(self):
+        """
+        Test that an admin cannot delete an assigned resource
+        from a room that does not exist
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_assigned_resource_from_non_existing_room,
+            "Room does not exist"
+        )
+
+    def test_delete_non_existing_assigned_resource(self):
+        """
+        Test that an admin cannot delete an assigned resource
+        that does not exist
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_non_existing_assigned_resource_mutation,
+            "The resource has not been assigned to the specified room"
+        )
+
+    def test_delete_assigned_resource_by_admin(self):
+        """
+        Test that admins can delete an assigned room resource
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            assign_resource_mutation,
+            assign_resource_mutation_response,
+        )
+
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_assigned_resource_mutation,
+            delete_assigned_resource_response
+        )


### PR DESCRIPTION
### What does this PR do?
Enable admins to delete a resource assigned to a room

### Description of the task to be completed?
- Implement logic to aid feature functionality
- Write tests for the feature

### How should this be manually tested?
1. Git pull branch `ft-delete-assigned-resource-165535238`
2. Follow instructions to assign a resource to a room from [#353](https://github.com/andela/mrm_api/pull/353)
2. Run the mutation below to delete the assigned resource
```
mutation {
  deleteAssignedResource(resourceId: 1, roomId: 1) {
    roomResource {
      roomId
      resourceId
      quantity
    }
  }
}
```

### Screenshots?
* On Success
<img width="1302" alt="Screenshot 2019-05-03 at 11 28 47 PM" src="https://user-images.githubusercontent.com/13919080/57168805-69c13780-6dfb-11e9-8979-219164156dd1.png">

* On Failure 
<img width="1302" alt="Screenshot 2019-05-03 at 11 29 37 PM" src="https://user-images.githubusercontent.com/13919080/57168814-70e84580-6dfb-11e9-955c-0773488cd97d.png">


### What are the relevant pivotal tracker stories?
[#165535238](https://www.pivotaltracker.com/story/show/165535238)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations