### PR TITLE
 #165557236 Allow admin get rooms that contain a resource

### DIFF
--- a/api/room/models.py
+++ b/api/room/models.py
@@ -28,7 +28,7 @@ class RoomResource(Base, Utility):
     resource_id = Column(Integer, ForeignKey('resources.id'), primary_key=True)
     quantity = Column(Integer)
     resource = relationship("Resource", back_populates="room")
-    room = relationship("Room", back_populates="resource")
+    room = relationship("Room", back_populates="resources")
 
 
 class Room(Base, Utility):
@@ -60,7 +60,7 @@ class Room(Base, Utility):
     devices = relationship(
         'Devices', cascade="all, delete-orphan",
         order_by="func.lower(Devices.name)")
-    resource = relationship("RoomResource", back_populates='room')
+    resources = relationship("RoomResource", back_populates='room')
 
     __table_args__ = (
             Index(

--- a/fixtures/room_resource/get_rooms_with_resource_fixtures.py
+++ b/fixtures/room_resource/get_rooms_with_resource_fixtures.py
@@ -1,0 +1,54 @@
+rooms_containing_resource_query = '''
+   query {
+     roomsContainingResource(resourceId: 1) {
+      room {
+        name
+        capacity
+      }
+    }
+  }
+        '''
+
+rooms_containing_resource_expected_response = {
+    "data": {
+        "roomsContainingResource": [
+            {
+                "room": {
+                    "name": "Entebbe",
+                    "capacity": 6
+                }
+            },
+        ]
+    }
+}
+
+rooms_containing_non_existent_resource_query = '''
+   query {
+     roomsContainingResource(resourceId: 3) {
+      room {
+        name
+        capacity
+      }
+    }
+  }
+        '''
+
+rooms_containing_non_existent_resource_expected_response = {
+  "errors": [
+    {
+      "message": "Resource does not exist",
+      "locations": [
+        {
+          "line": 3,
+          "column": 6
+        }
+      ],
+      "path": [
+        "roomsContainingResource"
+      ]
+    }
+  ],
+  "data": {
+    "roomsContainingResource": None
+  }
+}

--- a/tests/test_room_resource/test_query_rooms_with_resource.py
+++ b/tests/test_room_resource/test_query_rooms_with_resource.py
@@ -1,0 +1,41 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.room_resource.get_rooms_with_resource_fixtures import (
+    rooms_containing_resource_query,
+    rooms_containing_resource_expected_response,
+    rooms_containing_non_existent_resource_query,
+    rooms_containing_non_existent_resource_expected_response
+)
+from fixtures.room.assign_resource_fixture import (
+    assign_resource_mutation,
+    assign_resource_mutation_response
+    )
+
+
+class TestGetRoomsWithResource(BaseTestCase):
+
+    def test_query_rooms_containing_resource(self):
+        """
+        Test that an admin can get the rooms that have a particular resource
+        by providing the resourceId
+        """
+        CommonTestCases.admin_token_assert_equal(
+           self,
+           assign_resource_mutation,
+           assign_resource_mutation_response,
+        )
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            rooms_containing_resource_query,
+            rooms_containing_resource_expected_response
+        )
+
+    def test_query_rooms_containing_non_existent_resource(self):
+        """
+        Test that "Resource not found" error is returned if no resource with
+        provided resourceId exists
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            rooms_containing_non_existent_resource_query,
+            rooms_containing_non_existent_resource_expected_response
+        )


### PR DESCRIPTION
 ### What does this PR do?
 - It allows an admin to query for the rooms that contain a particular resource

### Description of the task to be completed?
- Create a query that allows an admin to get the rooms that a resource can be found after providing the `resourceId`

### How should this be manually tested?
-  Follow the instructions [here](ur) to assign a resource to a room. 
 - Run the query below with a valid `resourceId` and you will get the list of rooms with that resource provided you are an admin
```
query {
  roomsContainingResource(resourceId: 1) {
      room {
        name
        capacity
      }
    }
  }

```

### What are the relevant pivotal tracker stories?
[#165557236](https://www.pivotaltracker.com/story/show/165557236)
### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
