### PR TITLE
#165594925 Clear a resource from a room when the resource …

### DIFF
--- a/api/room_resource/schema.py
+++ b/api/room_resource/schema.py
@@ -1,6 +1,6 @@
 import graphene
 from graphene_sqlalchemy import SQLAlchemyObjectType
-from sqlalchemy import func
+from sqlalchemy import func, and_
 from graphql import GraphQLError
 
 from api.room_resource.models import Resource as ResourceModel
@@ -218,17 +218,21 @@ class DeleteResource(graphene.Mutation):
     resource = graphene.Field(Resource)
 
     @Auth.user_roles('Admin')
-    def mutate(self, info, resource_id, **kwargs):
-        query_room_resource = Resource.get_query(info)
-        active_resources = query_room_resource.filter(
-            ResourceModel.state == "active")
-        exact_room_resource = active_resources.filter(
-            ResourceModel.id == resource_id).first()
-        if not exact_room_resource:
+    def mutate(self, info, resource_id):
+        query_resources = Resource.get_query(info)
+        exact_resource = query_resources.filter(and_(
+            ResourceModel.state == "active",
+            ResourceModel.id == resource_id)).first()
+        if not exact_resource:
             raise GraphQLError("Resource not found")
-        update_entity_fields(exact_room_resource, state="archived", **kwargs)
-        exact_room_resource.save()
-        return DeleteResource(resource=exact_room_resource)
+        update_entity_fields(exact_resource, state="archived")
+        query_room_resource = RoomResource.get_query(info)
+        room_resources = query_room_resource.filter(
+            RoomResourceModel.resource_id == resource_id).all()
+        for room_resource in room_resources:
+            room_resource.delete()
+        exact_resource.save()
+        return DeleteResource(resource=exact_resource)
 
 
 class Query(graphene.ObjectType):

--- a/fixtures/room_resource/delete_room_resource.py
+++ b/fixtures/room_resource/delete_room_resource.py
@@ -1,28 +1,30 @@
 
 null = None
 delete_resource = '''
-mutation {
-    deleteResource(resourceId: 1) {
-        resource {
-            id
-            name
-        }
+mutation{
+  deleteResource(resourceId:1){
+    resource{
+      id
+      name
+      state
     }
+  }
 }
 '''
 
-expected_query_after_delete = {
-    "data": {
-        "deleteResource": {
-            "resource": {
-                "id": "1",
-                "name": "Markers"
-            }
-        }
+expected_response_after_delete = {
+  "data": {
+    "deleteResource": {
+      "resource": {
+        "id": "1",
+        "name": "Markers",
+        "state": "StateType.archived",
+      }
     }
+  }
 }
 
-delete_non_existant_resource = '''
+delete_non_existent_resource = '''
 mutation {
     deleteResource(resourceId: 12) {
         resource {

--- a/tests/test_room_resource/test_delete_resource.py
+++ b/tests/test_room_resource/test_delete_resource.py
@@ -2,9 +2,8 @@ import sys
 import os
 
 from tests.base import BaseTestCase, CommonTestCases
-from fixtures.room_resource.delete_room_resource import (  # noqa: F401
-  delete_resource, expected_query_after_delete, delete_non_existant_resource)  # noqa: E501
-from helpers.database import db_session  # noqa: F401
+from fixtures.room_resource.delete_room_resource import (
+  delete_resource, expected_response_after_delete, delete_non_existent_resource)
 
 
 sys.path.append(os.getcwd())
@@ -12,7 +11,10 @@ sys.path.append(os.getcwd())
 
 class TestDeleteRoomResource(BaseTestCase):
 
-    def test_deleteresource_mutation_when_not_admin(self):
+    def test_delete_resource_mutation_when_not_admin(self):
+        """
+             Test user connot delete resource when not an admin
+        """
         CommonTestCases.user_token_assert_in(
             self,
             delete_resource,
@@ -20,15 +22,38 @@ class TestDeleteRoomResource(BaseTestCase):
         )
 
     def test_delete_resource_mutation_when_admin(self):
+        """
+            Test successful soft delete of a resource by an admin.
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_resource,
+            expected_response_after_delete
+        )
+
+    def test_delete_non_existent_resource(self):
+        """
+            Test that admin user cannot delete a resource that doesn't exist
+            in the database.
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_non_existent_resource,
+            "Resource not found"
+        )
+
+    def test_delete_already_deleted_resource(self):
+        """
+            Test that admin user cannot delete a resource that has already been
+            soft deleted.
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_resource,
+            expected_response_after_delete
+        )
         CommonTestCases.admin_token_assert_in(
             self,
             delete_resource,
-            "Markers"
-        )
-
-    def test_non_existant_delete_resource_mutation(self):
-        CommonTestCases.admin_token_assert_in(
-            self,
-            delete_non_existant_resource,
             "Resource not found"
         )


### PR DESCRIPTION
 ### What does this PR do?
Add functionality to clear a resource from a room after deleting it from the resources.
### Description of the task to be completed?
When an admin user runs the mutation below specifying the  resource to delete with its id, the resource state is set to archive and all the resource(s) that were assigned to the room(s) are unassigned
### How should this be manually tested?
 - Clone the branch and follow the following steps to [setup](https://github.com/andela/mrm_api).
 - Checkout by running `gco ft-clear-resource-from-a-room-on-deleting-resource-165594925`
 - Perform the mutation below to query rooms with the specified argument(s).
```
mutation{
  deleteResource(resourceId:1){
    resource{
      id
      name
      state
      quantity
    }
  }
}
```
### Any background context you want to provide?
When the mutation is run, it sets the state of the resource to archive in the `Resource` model and also clears the relationships of all the rooms that the resource was assigned to in the `RoomResource` model. The quantity of the deleted resources are restored and saved in the resources model
### What are the relevant pivotal tracker stories?
[#165594925](https://www.pivotaltracker.com/story/show/165594925)
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
### Screenshots
- #### Mutation to soft-delete a resource.
![image](https://user-images.githubusercontent.com/29709981/56897076-33e82000-6a96-11e9-9fc7-cedadaf6987a.png)







