### PR TITLE
#165675148 Fix bug on updating room resource 

### DIFF
--- a/fixtures/room_resource/update_resource_fixtures.py
+++ b/fixtures/room_resource/update_resource_fixtures.py
@@ -2,7 +2,7 @@ null = None
 
 update_room_resource_query = '''
             mutation{
-            updateRoomResource(resourceId:1,name:"Markers"){
+            updateRoomResource(resourceId:1,name:"Markers", quantity:100){
                 resource{
                 name
                 }
@@ -74,4 +74,34 @@ expected_response_empty_field = {
         "updateRoomResource": null
     }
 
+}
+
+update_room_resource_negative_integer = '''
+            mutation{
+            updateRoomResource(resourceId:1,quantity:-2){
+                resource{
+                name
+                }
+            }
+            }
+            '''
+
+update_room_resource_negative_integer_response = {
+    "errors": [
+        {
+            "message": "Quantity cannot be less than zero",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 13
+                }
+            ],
+            "path": [
+                "updateRoomResource"
+            ]
+        }
+    ],
+    "data": {
+        "updateRoomResource": null
+    }
 }

--- a/tests/test_room_resource/test_update_room_resource.py
+++ b/tests/test_room_resource/test_update_room_resource.py
@@ -1,7 +1,9 @@
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.room_resource.update_resource_fixtures import (
     update_room_resource_query,
-    non_existant_resource_id_query
+    non_existant_resource_id_query,
+    update_room_resource_negative_integer,
+    update_room_resource_negative_integer_response
 )
 
 import os
@@ -30,4 +32,11 @@ class TestUpdateRoomResorce(BaseTestCase):
             self,
             non_existant_resource_id_query,
             "Resource not found"
+        )
+
+    def test_update_resource_mutation_with_negative_integer(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_room_resource_negative_integer,
+            update_room_resource_negative_integer_response
         )


### PR DESCRIPTION
#### What does this PR do?

Fix bug when admin tries to update a resource

#### Description of Task to be completed?
Currently, when the Admin tries to update a resource, he can enter the quantity to be a negative number which should not be so. This PR adds a check to ensure that does not happen with the proper error message.

#### How should this be manually tested?
- git pull and checkout to the branch bg-fix-update-resource-mutation-bug-165675148
- run application
- Run the following mutation
```
mutation {
 updateRoomResource( resourceId:2 quantity:-36 name:"peach"){
   resource{
    quantity
  }
}
}
```
#### What are the relevant pivotal tracker stories?
[165675148](https://www.pivotaltracker.com/story/show/165675148)

### Screenshots
<img width="620" alt="Screenshot 2019-04-29 at 2 38 07 PM" src="https://user-images.githubusercontent.com/27890903/56899918-891f3400-6a8c-11e9-9641-3591226a5f36.png">

