### PR TITLE
#165592500 Restricting querying devices by location

### DIFF
--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -20,7 +20,7 @@ expected_response_devices = {
                                             "lastSeen": "2018-06-08T11:17:58.785136",  # noqa: E501
                                             "dateAdded": "2018-06-08T11:17:58.785136",  # noqa: E501
                                             "name": "Samsung",
-                                            "location": "Nairobi"
+                                            "location": "Kampala"
                                             }
                                             ]
                                             }

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -198,7 +198,7 @@ send_invitation_to_existent_user_response = {
 
 get_users_by_location = '''
 query{
-    users(page:1, perPage:1, locationId:1){
+    users(page:1, perPage:1, locationId:2){
         users{
             name
             location
@@ -209,7 +209,7 @@ query{
 
 get_users_by_location_and_role = '''
 query{
-    users(page:1, perPage:1, locationId:1, roleId:1){
+    users(page:1, perPage:1, locationId:1, roleId:2){
         users{
             name
             location

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,8 +50,9 @@ class BaseTestCase(TestCase):
             command.upgrade(self.alembic_configuration, 'head')
 
             admin_user = User(email="peter.walugembe@andela.com",
-                              location="Kampala", name="Peter Walugembe",
+                              name="Peter Walugembe",
                               picture="https://www.andela.com/walugembe")
+            admin_user.location = "Kampala"
             admin_user.save()
             lagos_admin = User(email="peter.adeoye@andela.com",
                                location="Lagos", name="Peter Adeoye",
@@ -103,7 +104,7 @@ class BaseTestCase(TestCase):
                 last_seen="2018-06-08T11:17:58.785136",
                 date_added="2018-06-08T11:17:58.785136",
                 name="Samsung",
-                location="Nairobi",
+                location="Kampala",
                 device_type="External Display"
             )
             device.save()

--- a/tests/test_devices/test_all_devices.py
+++ b/tests/test_devices/test_all_devices.py
@@ -1,4 +1,4 @@
-from tests.base import BaseTestCase
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.devices.devices_fixtures import (
     query_devices,
     expected_response_devices
@@ -10,6 +10,13 @@ sys.path.append(os.getcwd())
 
 
 class TestAllDevices(BaseTestCase):
+    """
+    Test that an admin can query to get
+    a list of all devices in their location
+    """
     def test_all_devices(self):
-        query = self.client.execute(query_devices)
-        self.assertEquals(query, expected_response_devices)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_devices,
+            expected_response_devices
+        )


### PR DESCRIPTION
#### What does this PR do?
- Currently, there is an existing query that fetches all devices. The aim of this PR is to refactor the query to get the devices based on the location of the user making the request.

#### Description of Task to be completed?
- Refactor the query to return data based on user location
- Ensure existing tests pass

#### How should this be manually tested?
- Pull this branch `ft-query-devices-per-location-165592500`
- Run a new migration to migrate to the V2 database
- Create devices using `createDevice` mutation. If you need help running these mutations, check out the documentation for the [mrm endpoints](http://localhost:8000/mrm)

- After creating devices, you can run the following query 
```
{
  allDevices {
    id
    lastSeen
    dateAdded
    name
    location
  }
}
```

#### Any background context you want to provide?
n/a


#### What are the relevant pivotal tracker stories?
[#165592500](https://www.pivotaltracker.com/story/show/165592500)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

### Screenshots

<img width="1181" alt="Screenshot 2019-05-07 at 14 49 34" src="https://user-images.githubusercontent.com/27801956/57377805-fe38ea80-71ab-11e9-8d36-c5d7e9d5abb2.png">

