### PR TITLE
#165822522 Fix event email notification template

### DIFF
--- a/templates/event_cancellation.html
+++ b/templates/event_cancellation.html
@@ -36,8 +36,8 @@
                     </h5>
                 </div>
                 <div class="rectangle-3" style="box-sizing: border-box;margin: 45px 105px;">
-                    <p class="invite" style="box-sizing: border-box;margin-top: 0;margin-bottom: 0;orphans: 3;widows: 3;color: #6d6d6d;line-height: 21px;font-family: 'DINPro', 'Roboto', sans-serif !important; text-align: unset; width: max-content;">
-                        <strong> {{ room_name }} </strong> has just rejected the reservation for the meeting <br/> <strong> {{ event_title }} </strong> because no one has checked in <br/> {{ event_reject_reason }}.
+                    <p class="invite" style="box-sizing: border-box;margin-top: 0;margin-bottom: 0;orphans: 3;widows: 3;color: #6d6d6d;line-height: 21px;font-family: 'DINPro', 'Roboto', sans-serif !important; text-align: unset; width: fit-content;">
+                        <strong> {{ room_name }} </strong> has just rejected the reservation for the meeting  <strong> {{ event_title }} </strong> because no one has checked in {{ event_reject_reason }}.
                     </p>
                 </div>
                 <div style="box-sizing: border-box;">


### PR DESCRIPTION
 ### What does this PR do?
Ensure the email text fits with the container width

### Description of the task to be completed?
Currently, when the email text for event rejection notification is long it tends to overflow the html container. This PR ensures the content fits the container.

### How should this be manually tested?
- git pull and checkout branch bg-fix-event-notification-template-16582252
- run application
- run the cancelEvent mutation.




### What are the relevant pivotal tracker stories?
[#165222721](https://www.pivotaltracker.com/story/show/165822522)
