### PR TITLE
#165528858 User should receive notification when added as an admin

### DIFF
--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -157,8 +157,18 @@ class ChangeUserRole(graphene.Mutation):
         if not new_role:
             raise GraphQLError('invalid role id')
 
+        current_user_role = exact_user.roles[0].role
+        if new_role.role == current_user_role:
+            raise GraphQLError('This role is already assigned to this user')
+
         exact_user.roles[0] = new_role
         exact_user.save()
+
+        if new_role.role == 'Admin':
+            user_name = exact_user.name
+            if not notification.send_admin_invite_email(email, user_name):
+                raise GraphQLError("Role changed but email not sent")
+
         return ChangeUserRole(user=exact_user)
 
 

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -112,6 +112,21 @@ query_user_email_response = {
 
 change_user_role_mutation = '''
 mutation{
+    changeUserRole(email:"mrmtestuser@andela.com", roleId: 1){
+        user{
+            name
+            roles{
+                role
+            }
+        }
+    }
+}
+'''
+
+change_user_role_mutation_response = "Role changed but email not sent"
+
+change_user_role_with_already_assigned_role_mutation = '''
+mutation{
     changeUserRole(email:"peter.walugembe@andela.com", roleId: 1){
         user{
             name
@@ -123,18 +138,7 @@ mutation{
 }
 '''
 
-change_user_role_mutation_response = {
-    "data": {
-        "changeUserRole": {
-            "user": {
-                "name": "Peter Walugembe",
-                "roles": [{
-                    "role": "Admin"
-                }]
-            }
-        }
-    }
-}
+change_user_role_with_already_assigned_role_mutation_response = "This role is already assigned to this user"  # noqa: E501
 
 change_user_role_to_non_existence_role_mutation = '''
 mutation{

--- a/fixtures/user_role/user_role_fixtures.py
+++ b/fixtures/user_role/user_role_fixtures.py
@@ -99,7 +99,7 @@ query_user_by_user_email_response = {
 
 change_user_role_mutation_query = '''
 mutation{
-  changeUserRole(email:"mrm@andela.com", roleId:1){
+  changeUserRole(email:"mrmtestuser@andela.com", roleId:1){
     user{
       email
       roles{
@@ -110,20 +110,7 @@ mutation{
 }
 '''
 
-change_user_role_mutation_response = {
-    "data": {
-        "changeUserRole": {
-            "user": {
-                "email": "mrm@andela.com",
-                "roles": [
-                    {
-                        "id": "1"
-                    }
-                ]
-            }
-        }
-    }
-}
+change_user_role_mutation_response = "Role changed but email not sent"
 
 change_unavailable_user_role_mutation_query = '''
 mutation{

--- a/helpers/email/email.py
+++ b/helpers/email/email.py
@@ -63,5 +63,23 @@ class EmailNotification:
             event_reject_reason=event_reject_reason
         )
 
+    def send_admin_invite_email(self, user_email, user_name):
+        """
+        send email notification when an admin is added
+            :params
+                - user_email: the email of the user being added as an admin
+                - user_name: the name of the user being added as an admin
+        """
+        subject = 'Converge - You have been added as an admin'
+        template = 'admin_invite.html'
+
+        return EmailNotification.send_email_notification(
+            self,
+            email=user_email,
+            subject=subject,
+            user_name=user_name,
+            template=template
+        )
+
 
 notification = EmailNotification()

--- a/templates/admin_invite.html
+++ b/templates/admin_invite.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en" style="box-sizing: border-box;height:100%;font-family: sans-serif;line-height: 1.15;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;-ms-overflow-style: scrollbar;-webkit-tap-highlight-color: transparent;">
+
+<head style="box-sizing: border-box;">
+    <!-- Required meta tags -->
+    <meta charset="utf-8" style="box-sizing: border-box;">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" style="box-sizing: border-box;">
+
+    <title style="box-sizing: border-box;">Converge</title>
+
+
+    <style style="box-sizing: border-box;">
+        @font-face {
+            font-family: 'DINPro';
+            src: url("https://firebasestorage.googleapis.com/v0/b/andelamrm.appspot.com/o/email_assets%2Ffonts%2FDINPro-Regular.woff?alt=media&token=8740b12d-b0d5-497a-8288-53fc5a6b432e");
+        }
+        * {
+            font-family: 'DINPro';
+        }
+    </style>
+</head>
+
+<body style="box-sizing: border-box;margin: 0;height:100%;font-family: 'DINPro', 'Roboto', sans-serif;font-size: 1rem;font-weight: 400;line-height: 1.5;color: #212529;text-align: left;background-color: #f4f8f9;min-width: 992px!important;">
+    <div class="container" style="box-sizing: border-box;height:100%;width: 100%;padding-right: 15px;padding-left: 15px;margin-right: auto;margin-left: auto;min-width: 992px!important;padding:70px;">
+        <div id="email" style="box-sizing: border-box;height: 605px;width: 611px;background-color: #ffff;margin: auto;">
+            <div class="converge" style="box-sizing: border-box;padding-top: 24px;height: 23;width: 195px;color: #3359db;font-size: 18px;font-weight: 500;letter-spacing: 0.36px;line-height: 23px;margin: auto;">
+                <img src="https://i.imgur.com/6foV1gb.png" alt="" style="box-sizing: border-box;vertical-align: middle;border-style: none;page-break-inside: avoid;">
+                <span class="logo" style="box-sizing: border-box;display: inline-block;margin-left: 10px;">
+                    <h5 style="box-sizing: border-box;margin-top: 0;margin-bottom: .5rem;font-family: inherit;font-weight: 500;line-height: 1.2;color: inherit;font-size: 1.25rem; font-family: 'DINPro', 'Roboto', sans-serif">CONVERGE</h5>
+                </span>
+            </div>
+            <div style="box-sizing: border-box;">
+                <hr style="box-sizing: content-box;height: 0;overflow: visible;margin-top: 1rem;margin-bottom: 1rem;border: 0;border-top: 1px solid rgba(0,0,0,.1);">
+            </div>
+            <div class="rectangle" style="box-sizing: border-box;height: 370px;width: 610px;text-align: center;">
+                <div style="box-sizing: border-box;">
+                    <h5 class="greeting" style="box-sizing: border-box;margin-top: 0;margin-bottom: .5rem;font-family: inherit;font-weight: 500;line-height: 31px;color: inherit;font-size: 24px;padding-top: 63px;">
+                        <Strong>Hello, {{user_name}}!</strong>
+                    </h5>
+                </div>
+                <div class="rectangle-3" style="box-sizing: border-box;margin: 60px 138px;">
+                    <p class="invite" style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;color: #6d6d6d;line-height: 21px;font-family: 'DINPro', 'Roboto', sans-serif !important;">
+                        You have been added as an Admin to Converge
+                        <br><br>Regards,<br><strong>Converge Team</strong>
+                    </p>
+                </div>
+                <div style="box-sizing: border-box;">
+                    <a href=http://converge-staging.andela.com/> <button type=" button" class="btn btn-primary" style="box-sizing: border-box;border-radius: 4px;margin: 0;font-family: 'DINPro', 'Roboto', sans-serif;font-size: 1rem;overflow: visible;text-transform: none;-webkit-appearance: button;display: inline-block;font-weight: 400;text-align: center;white-space: nowrap;vertical-align: middle;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;border: 1px solid transparent;padding: .375rem .75rem;transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;color: #fff;background-color: #007bff;border-color: #007bff;height: 44px;width: 174px;">Login
+                        to view</button></a>
+                </div>
+                <div style="box-sizing: border-box;">
+                    <hr class="line" style="box-sizing: content-box;height: 0;overflow: visible;margin-top: 70px;margin-bottom: 1rem;border: 0;border-top: 1px solid rgba(0,0,0,.1);">
+                </div>
+            </div>
+            <div class="rectangle-2" style="box-sizing: border-box;height: 130px;width: 610px;border-radius: 0 0 4px 4px;">
+                <div class="contact" style="box-sizing: border-box;height: 54.32px;width: 490px;font-family: 'DINPro', 'Roboto', sans-serif, sans-serif;color: #000000;font-size: 16px;line-height: 27px;padding-top: 39px;padding-bottom: 39px;margin: auto;text-align: center;">
+                    <p style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;">
+                        Have a question?
+                        <br style="box-sizing: border-box;"> <a href="mailto:support@converge.com" style="box-sizing: border-box;color: #007bff;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
+                            support@converge.com</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="subcription" style="box-sizing: border-box;height: 19.16px;width: 490px;color: #000111;font-family: 'DINPro', 'Roboto', sans-serif, sans-serif;font-size: 16px;line-height: 19px;text-align: center;margin: auto;padding-top: 15px;">
+            <p style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;">Click <span style="box-sizing: border-box;"><a
+                        id="link" href="https://converge-staging.andela.com/preference" style="box-sizing: border-box;color: #999999;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
+                        <strong>here</strong></a></span> if you wish to unsubscribe</p>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/tests/base.py
+++ b/tests/base.py
@@ -313,3 +313,15 @@ def change_user_role_helper(func):
         db_session().commit()
         return headers
     return func_wrapper
+
+
+def change_test_user_role(func):
+    def func_wrapper(self):
+        user_role = Role(role='Default User')
+        user_role.save()
+        user = User(email='mrmtestuser@andela.com', name='Test user',
+                    location="Lagos", picture='www.andela.com/testuser')
+        user.save()
+        user.roles.append(user_role)
+        db_session().commit()
+    return func_wrapper

--- a/tests/test_user/test_change_user_role.py
+++ b/tests/test_user/test_change_user_role.py
@@ -1,10 +1,12 @@
-from tests.base import BaseTestCase, CommonTestCases
+from tests.base import BaseTestCase, CommonTestCases, change_test_user_role
 from fixtures.user.user_fixture import (
     change_user_role_mutation, change_user_role_mutation_response,
     change_user_role_to_non_existence_role_mutation,
     change_user_role_to_non_existing_role_mutation_response,
     change_role_of_non_existing_user_mutation,
-    assign_role_to_non_existing_user_mutation
+    assign_role_to_non_existing_user_mutation,
+    change_user_role_with_already_assigned_role_mutation,
+    change_user_role_with_already_assigned_role_mutation_response
 )
 
 import sys
@@ -14,11 +16,12 @@ sys.path.append(os.getcwd())
 
 class TestChangeUserRole(BaseTestCase):
 
+    @change_test_user_role
     def test_change_user_role(self):
         """
         Testing change of user role
         """
-        CommonTestCases.admin_token_assert_equal(
+        CommonTestCases.admin_token_assert_in(
             self, change_user_role_mutation, change_user_role_mutation_response
         )
 
@@ -49,4 +52,14 @@ class TestChangeUserRole(BaseTestCase):
             self,
             assign_role_to_non_existing_user_mutation,
             "User not found"
+        )
+
+    def test_change_user_role_with_already_assigned_role(self):
+        """
+        Testing change of user role to an already assigned user
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            change_user_role_with_already_assigned_role_mutation,
+            change_user_role_with_already_assigned_role_mutation_response
         )

--- a/tests/test_user_roles/test_query_user_role.py
+++ b/tests/test_user_roles/test_query_user_role.py
@@ -1,4 +1,9 @@
-from tests.base import BaseTestCase, CommonTestCases, change_user_role_helper
+from tests.base import (
+    BaseTestCase,
+    CommonTestCases,
+    change_user_role_helper,
+    change_test_user_role
+)
 from fixtures.user_role.user_role_fixtures import (
     change_user_role_mutation_query,
     change_unavailable_user_role_mutation_query,
@@ -65,9 +70,9 @@ class TestQueryUserRole(BaseTestCase):
         expected_response = query_user_by_user_email_response
         self.assertEqual(execute_query, expected_response)
 
+    @change_test_user_role
     def test_change_user_role(self):
-        create_user()
-        CommonTestCases.admin_token_assert_equal(
+        CommonTestCases.admin_token_assert_in(
             self,
             change_user_role_mutation_query,
             change_user_role_mutation_response


### PR DESCRIPTION
#### What does this PR do?
Currently, there's an existing implementation for changing a user's role. The aim of this PR is to check when a user's role is being changed to admin and send an email notification to that user.
#### Description of Task to be completed?
- Send email notification to newly added admin
- Ensure existing tests pass.
#### How should this be manually tested?
- Pull this branch ft-admin-receive-notification-when-added-165528858
- Make sure your application containers are running
- Run the following query
```
mutation {
  changeUserRole(email: "email@email.com", roleId: 2) {
    user {
      name
      roles{
        role
      }
    }
  }
}
```
- For the `email` field in the mutation, make use of an existing valid email address in your User model.
- For the `roleId` field in the mutation, let the id being passed tally with the id of the role admin in your Role model.
#### What are the relevant pivotal tracker stories?
[165528858](https://www.pivotaltracker.com/story/show/165528858)
#### Screenshots (if appropriate)
<img width="1195" alt="Screen Shot 2019-05-06 at 4 22 11 PM" src="https://user-images.githubusercontent.com/42177767/57235604-280ed780-701b-11e9-9788-2d8f6f6be0ab.png">
<img width="1034" alt="Screen Shot 2019-05-06 at 4 30 31 PM" src="https://user-images.githubusercontent.com/42177767/57236155-504b0600-701c-11e9-95dd-b797e02580fd.png">
