### PR TITLE
#165850754 Refactor the bookings count query for optimization

### DIFF
--- a/fixtures/room/room_analytics_bookings_count_fixtures.py
+++ b/fixtures/room/room_analytics_bookings_count_fixtures.py
@@ -96,7 +96,7 @@ query {
 non_existing_room_id_response = {
   "errors": [
     {
-      "message": "Room Id does not exist",
+      "message": "Room with such id does not exist",
       "locations": [
         {
           "line": 3,


### PR DESCRIPTION
 ### What does this PR do?
 - It helps to reduce the amount of time taken to get `bookingsAnalyticsCount`

### Description of the task to be completed?
- Refactor the `resolve_booked_rooms_analytics` method in `schema_query.py` to query the database for events only once.
- Add a helper method `get_bookings_count_from_events` to format the events so that we can get the `period` and the `bookings`

### How should this be manually tested?
-  Make sure you have a large data set in your `events` and `room` model. 
- Run the query below to get `bookingsAnalyticsCount` and observe the difference between the execution time and that of `v2`
 
```
query {
  bookingsAnalyticsCount(startDate:"Jan 01 2017", endDate:"Dec 31 2019"){
     period
     bookings
  }
}

```

### What are the relevant pivotal tracker stories?
[#165850754](https://www.pivotaltracker.com/story/show/165850754)
### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

#### Any background context that you would like to provide:
Currently, if we query for the analytics count from let's say `Jan 01 2017` to `Dec 31 2019`, the current implementation is that:
    `all the months within this period are generated`
      &nbsp; `for each month, all the active rooms in the database are queried for`
       &nbsp; &nbsp; `for each room, all the events in that room are queried for`

SInce there are 36 months, and if we have 20 active rooms there will be a total of 720 database queries for this request.
This PR refactors the implementation so that the database is queried for the events just once, and this data is processed to give the booking counts.
