### PR TITLE
#165849371 Add delete room push notification feature

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -229,6 +229,8 @@ class DeleteRoom(graphene.Mutation):
         admin_roles.update_delete_rooms_create_resource(room_id)
         update_entity_fields(exact_room, state="archived", **kwargs)
         exact_room.save()
+        requests.delete(url=Config.MRM_PUSH_URL + "/delete_room",
+                        params={"calendar_id": exact_room.calendar_id})
         return DeleteRoom(room=exact_room)
 
 


### PR DESCRIPTION
#### What does this PR do?
Add the delete room push notification endpoint to the delete room mutation.

#### Description of Task to be completed?
Once a room is deleted from the converge database we want to stop the room from listening for push notifications and delete it from the Redis database.

#### How should this be manually tested?

- git pull the branch `ft-delete-room-functionality-165849371`
- Ensure you have the `MRM_PUSH_URL` in the `.env`
- Ensure you have [setup](https://github.com/andela/mrm_push) mrm_push
- Call the `refresh` endpoint to add rooms to the database http://127.0.0.1:5000/refresh
- Run the deleteRoom mutation below:

```
mutation{
  deleteRoom(roomId:1){
      room{
        name
        capacity
        roomType
      }
  }
}
```
### Any background context you want to provide?
Testing this functionality involves ensuring that the two applications have been set and are working locally.

#### What are the relevant pivotal tracker stories?
[#165849371](https://www.pivotaltracker.com/story/show/165849371)