### PR TITLE
#165939988 Enable room update without structure id

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -189,7 +189,8 @@ class UpdateRoom(graphene.Mutation):
     @Auth.user_roles('Admin')
     def mutate(self, info, room_id, **kwargs):
         validate_empty_fields(**kwargs)
-        validate_structure_id(**kwargs)
+        if kwargs.get('structure_id'):
+            validate_structure_id(**kwargs)
         query_room = Room.get_query(info)
         active_rooms = query_room.filter(RoomModel.state == "active")
         room = active_rooms.filter(RoomModel.id == room_id).first()

--- a/fixtures/room/room_update_fixtures.py
+++ b/fixtures/room/room_update_fixtures.py
@@ -12,7 +12,18 @@ query_update_all_fields = '''mutation{
     }
 }
 '''
-
+query_update_without_structure_id = '''mutation{
+    updateRoom(roomId: 1, name: "Jinja", capacity: 8,
+    roomType: "board room",
+    roomTags: [1]){
+        room{
+            name
+            capacity
+            roomType
+        }
+    }
+}
+'''
 expected_query_update_all_fields = {
     "data": {
         "updateRoom": {

--- a/tests/test_rooms/test_update_room.py
+++ b/tests/test_rooms/test_update_room.py
@@ -6,7 +6,8 @@ from fixtures.room.room_update_fixtures import (
     query_update_all_fields,
     query_without_room_id,
     query_room_id_non_existant,
-    update_with_empty_field
+    update_with_empty_field,
+    query_update_without_structure_id
 )
 
 
@@ -41,3 +42,13 @@ class TestUpdateRoom(BaseTestCase):
             self,
             update_with_empty_field,
             "name is required field")
+
+    def test_update_without_structure_id(self):
+        """
+        Tests one can update a room without
+        providing structure id
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            query_update_without_structure_id,
+            "Jinja")


### PR DESCRIPTION
#### What does this PR do?

Enable room update without providing the structure id

#### Description of Task to be completed?
Currently, when updating the room, the mutation requires the structure id to always be provided and 
goes on to run the structure id validation which returns structure does not exist when there is no id, this
PR makes sure the validation method is only called when the structure id is in the keyword arguments 
(kwargs)

#### How should this be manually tested?
- git pull and checkout to the branch bg-room-update-165939988
- run application
- Run the following mutation to update a room
```
mutation{
    updateRoom(roomId: 5, name: "Jinja", capacity: 8,
    roomTags: [1]){
        room{
            name
            capacity
            roomType
        }
    }
}
```
#### What are the relevant pivotal tracker stories?
[165939988](https://www.pivotaltracker.com/story/show/165939988)

### Background information
None

### Screenshots
Without structure_id
<img width="1095" alt="Screenshot 2019-05-10 at 20 02 09" src="https://user-images.githubusercontent.com/33450849/57543956-9a0a5800-735e-11e9-80c1-5be132985851.png">

With structure_id
<img width="1254" alt="Screenshot 2019-05-10 at 20 02 42" src="https://user-images.githubusercontent.com/33450849/57543984-ad1d2800-735e-11e9-88a0-7b539301334f.png">



### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

