### PR TITLE
#165903538 Fix all reponses query to filter by date range

### DIFF
--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -1,4 +1,14 @@
+import datetime
+
 null = None
+
+start_date = (datetime.date.today() - datetime.timedelta(
+    days=2)).strftime('%b %d %Y')
+end_date = datetime.date.today().strftime('%b %d %Y')
+invalid_start_date = (datetime.date.today() + datetime.timedelta(
+    days=10)).strftime('%b %d %Y')
+invalid_end_date = (datetime.date.today() + datetime.timedelta(
+    days=20)).strftime('%b %d %Y')
 
 room_response_query_sample = '''{
     roomResponse(roomId:1) {
@@ -32,59 +42,74 @@ get_room_response_query_data = {
 }
 
 get_room_response_query_by_date = '''
-query{
-    allRoomResponses(startDate: "2019 feb 20",
-     endDate: "2019 feb 25" ){
-        responses{
+query{{
+    allRoomResponses(startDate: "{}",
+     endDate: "{}" ){{
+        responses{{
             totalResponses
             roomName
-            response{
+            response{{
                 responseId
                 missingItems
-            }
-        }
-    }
-}
-'''
+            }}
+        }}
+    }}
+}}
+'''.format(start_date, end_date)
+
 get_room_response_query_with_invalid_date = '''
-query{
-    allRoomResponses(startDate: "2019 Dec 20",
-     endDate: "2019 Dec 25" ){
-        responses{
+query{{
+    allRoomResponses(startDate: "{}",
+     endDate: "{}" ){{
+        responses{{
             totalResponses
             roomName
-            response{
+            response{{
                 responseId
                 missingItems
-            }
-        }
-    }
-}
-'''
+            }}
+        }}
+    }}
+}}
+'''.format(invalid_start_date, invalid_end_date)
+
 get_room_response_query_with_higher_lower_limit = '''
-query{
-    allRoomResponses(startDate: "2019 feb 20",
-     endDate: "2019 feb 1" ){
-        responses{
+query{{
+allRoomResponses(startDate: "{}",
+     endDate: "{}" ){{
+        responses{{
             totalResponses
             roomName
-            response{
+            response{{
                 responseId
                 missingItems
-            }
-        }
-    }
-}
-'''
+            }}
+        }}
+    }}
+}}
+'''.format(end_date, start_date)
 
 get_room_response_query_by_date_query = {
-  "data": {
-    "allRoomResponses": {
-      "responses": [
+  'data': {
+    'allRoomResponses': {
+      'responses': [
         {
-          "totalResponses": 2,
-          "roomName": "Entebbe",
-          "response": []
+          'totalResponses': 2,
+          'roomName': 'Entebbe',
+          'response': [
+            {
+              'responseId': 2,
+              'missingItems': [
+                'Markers'
+              ]
+            },
+            {
+              'responseId': 1,
+              'missingItems':   [
+
+              ]
+            }
+          ]
         }
       ]
     }

--- a/tests/base.py
+++ b/tests/base.py
@@ -5,7 +5,7 @@ import jwt
 
 from flask_testing import TestCase
 from graphene.test import Client
-from datetime import datetime
+from datetime import datetime, timedelta
 from alembic import command, config
 
 from app import create_app
@@ -148,15 +148,18 @@ class BaseTestCase(TestCase):
                 question_id=1,
                 room_id=1,
                 rate=2,
-                created_date=datetime.now(),
+                created_date=datetime.now() - timedelta(
+                    days=1),
                 resolved=False,
             )
             response_1.save()
+
             response_2 = Response(
                 question_id=question_2.id,
                 room_id=room.id,
                 check=True,
-                created_date=datetime.now(),
+                created_date=datetime.now() - timedelta(
+                    days=1),
                 resolved=True,
             )
             response_2.save()


### PR DESCRIPTION
#### What does this PR do?
- The aim of this PR is to refactor the `allRoomResponses` query to allow filtering responses by date range

#### Description of Task to be completed?
- Fix query by date range
- Refactor endpoint to reduce complexity
- Remove unnecessary duplication

#### How should this be manually tested?
- Pull this branch `bg-fix-query-all-responses-by-date-range-165903538`
- Ensure that you have a number of responses in your database
- Run the query below for filtering by date range only
```
query{
    allRoomResponses(startDate: "jan 1 2019",
     endDate: "mar 10 2019"){
        responses{
            totalResponses
            roomName
            response{
                responseId
                
            }
        }
    }
} 
```
For filtering with additional parameters run the query below
```
query{
    allRoomResponses(startDate:"may 1 2019", endDate:"may 29 2019" ,upperLimitCount:5, lowerLimitCount:1, page:1, perPage:1){
        responses{         
            totalResponses
            roomName
          	roomId
            response{
                responseId
              	createdDate
              	missingItems
              	suggestion
              	resolved
            }
        }
    pages
    hasNext
    hasPrevious
    }

```

#### Any background context you want to provide?
n/a


#### What are the relevant pivotal tracker stories?
[#165903538](https://www.pivotaltracker.com/story/show/165903538)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

### Screenshots
*Filtering by date range only*
<img width="1074" alt="Screenshot 2019-05-22 at 15 50 13" src="https://user-images.githubusercontent.com/27801956/58238411-e5a20600-7d4f-11e9-9801-bf0107d9b401.png">

*Filtering with additional room name argument*
<img width="1194" alt="Screenshot 2019-05-24 at 10 08 44" src="https://user-images.githubusercontent.com/27801956/58309160-1778a280-7e0c-11e9-90a8-ef79bdc3d546.png">

*Filtering with additional multiple parameters*
<img width="1195" alt="Screenshot 2019-05-29 at 11 06 23" src="https://user-images.githubusercontent.com/27801956/58540543-41620880-8202-11e9-8172-e01653065989.png">
