### PR TITLE
#165903102 Fix createResponse mutation

### DIFF
--- a/api/response/schema.py
+++ b/api/response/schema.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import graphene
 from helpers.auth.authentication import Auth
 from graphene_sqlalchemy import SQLAlchemyObjectType
@@ -67,6 +68,7 @@ class CreateResponse(graphene.Mutation):
         query = Room.get_query(info)
         responses = []
         errors = []
+        present_date = datetime.now().strftime('%Y/%m/%d %H:%M:%S')
         room = query.filter_by(id=kwargs['room_id']).first()
         if not room:
             raise GraphQLError("Non-existent room id")
@@ -77,6 +79,9 @@ class CreateResponse(graphene.Mutation):
                 errors.append(
                     "Response to question {} was not saved because it does not exist".format(each_response.question_id)) # noqa
                 continue
+            if present_date < question.start_date:
+                errors.append(
+                    "The start date for the response to this question is yet to commence. Try on {}".format(question.start_date)) # noqa
             question_type = question.question_type
             each_response['room_id'] = kwargs['room_id']
             responses, errors = create_response(question_type,

--- a/helpers/response/create_response.py
+++ b/helpers/response/create_response.py
@@ -1,51 +1,55 @@
 from datetime import datetime
 from api.response.models import Response
 from api.room_resource.models import Resource
+from api.room.models import RoomResource
 
 
 def create_response(question_type, errors, responses, **kwargs):
-    if question_type.lower() == 'rate':
-        if 'rate' in kwargs and kwargs['rate']:
-            rating = [1, 2, 3, 4, 5]
-            if kwargs['rate'] not in rating:
-                errors.append(
-                    'Please rate between 1 and 5 for question {}'.format(
-                        kwargs['question_id']))
-                return responses, errors
-            rating = Response(
-                rate=kwargs['rate'],
-                room_id=kwargs['room_id'],
-                question_id=kwargs['question_id'],
-                created_date=datetime.now())
-            rating.save()
-            responses.append(rating)
-    if question_type.lower() == 'check':
-        if 'missing_items' in kwargs and kwargs['missing_items']:
-            response = Response(
-                check=True,
-                room_id=kwargs['room_id'],
-                question_id=kwargs['question_id'],
-                created_date=datetime.now())
-            response.save()
-            for item_id in kwargs['missing_items']:
+    if question_type.lower() == 'rate' and 'rate' in kwargs and kwargs['rate']: # noqa
+        rating = [1, 2, 3, 4, 5]
+        if kwargs['rate'] not in rating:
+            errors.append(
+                'Please rate between 1 and 5 for question {}'.format(
+                    kwargs['question_id']))
+            return responses, errors
+        rating = Response(
+            rate=kwargs['rate'],
+            room_id=kwargs['room_id'],
+            question_id=kwargs['question_id'],
+            created_date=datetime.now())
+        rating.save()
+        responses.append(rating)
+    elif question_type.lower() == 'check' and 'missing_items' in kwargs and kwargs['missing_items']: # noqa
+        response = Response(
+            check=True,
+            room_id=kwargs['room_id'],
+            question_id=kwargs['question_id'],
+            created_date=datetime.now())
+        response.save()
+        for item_id in kwargs['missing_items']:
+            missing_item = None
+            room_missing_item = RoomResource.query.filter_by(
+                resource_id=item_id, room_id=kwargs['room_id']).first()
+            if room_missing_item:
                 missing_item = Resource.query.filter_by(
-                    id=item_id, room_id=kwargs['room_id']).first()
-                if not missing_item:
-                    response.delete()
-                    errors.append('Response to question {} was not saved because one of the resource provided does not exist'.format(kwargs['question_id'])) # noqa
-                    return responses, errors
-                response.missing_resources.append(
-                    missing_item
-                )
-                response.save()
+                    id=item_id).first()
+            if missing_item is None:
+                response.delete()
+                errors.append('Response to question {} was not saved because one of the resources provided was not assigned to the room'.format(kwargs['question_id'])) # noqa
+                return responses, errors
+            response.missing_resources.append(
+                missing_item
+            )
+            response.save()
             responses.append(response)
-    if question_type.lower() == 'input':
-        if 'text_area' in kwargs and kwargs['text_area']:
-            suggestion = Response(
-                text_area=kwargs['text_area'],
-                room_id=kwargs['room_id'],
-                question_id=kwargs['question_id'],
-                created_date=datetime.now())
-            suggestion.save()
-            responses.append(suggestion)
+    elif question_type.lower() == 'input' and 'text_area' in kwargs and kwargs['text_area']: # noqa
+        suggestion = Response(
+            text_area=kwargs['text_area'],
+            room_id=kwargs['room_id'],
+            question_id=kwargs['question_id'],
+            created_date=datetime.now())
+        suggestion.save()
+        responses.append(suggestion)
+    else:
+        errors.append("Kindly respond to the right question type of {}".format(question_type)) # noqa
     return responses, errors

--- a/tests/test_response/test_user_response.py
+++ b/tests/test_response/test_user_response.py
@@ -20,7 +20,8 @@ from fixtures.response.user_response_check import (
 from fixtures.response.user_response_suggestions import (
     create_suggestion_question,
     create_suggestion_question_response,
-    make_suggestion_in_non_existent_room
+    make_suggestion_in_non_existent_room,
+    choose_wrong_question
 )
 
 
@@ -136,5 +137,15 @@ class TestCreateResponse(BaseTestCase):
         CommonTestCases.admin_token_assert_equal(
             self,
             filter_response_by_room_with_pagination,
-            filter_response_by_room_with_pagination_response
+            filter_response_by_room_with_pagination_response)
+
+    def test_response_for_wrong_question_type(self):
+        """
+        Test that a user cannot respond to a question
+        with the wrong question type
+        """
+        CommonTestCases.user_token_assert_in(
+            self,
+            choose_wrong_question,
+            "Kindly respond to the right question type"
         )


### PR DESCRIPTION
### What does this PR do
It ensures that the createResponse mutation works as described.
### Description of the task to be completed?
We should ensure that it should handle all the validations, and return a response object created instead of an error or blank response when performing mutations under the following conditions:
- Run create response mutation with all the required fields
![image](https://user-images.githubusercontent.com/31338414/57753910-f8845d00-76f5-11e9-8a20-375d59849b42.png)

- Run create response mutation with only the missing items being reported
![image](https://user-images.githubusercontent.com/31338414/57754007-2c5f8280-76f6-11e9-8146-11fab497a077.png)

- Run create response mutation with response type which is different from the question type
![image](https://user-images.githubusercontent.com/31338414/57754036-3f725280-76f6-11e9-9f8c-0b550bed510d.png)

- Run create response mutation when trying to respond to a question whose start date is yet to commence.
![image](https://user-images.githubusercontent.com/31338414/57754782-ef948b00-76f7-11e9-824d-de9789d7cb5a.png)


### Background information
- Ensure you have resources in your database.
- Ensure that one room has some resources in it.
- Ensure you have question types of `check`, `input` and `rate` to respond to. 
- The mutations for the responses for each of the question types are given below. Ensure that the `questionId` value matches the type in the `Question` table.
#### Check
```
mutation{
  createResponse(responses: [{questionId:1, missingItems:[1,2]}], roomId:1) {
    response{
      id
      questionId
      roomId
      check
      }
  }
}
```
#### Rate
```
mutation{
  createResponse(responses: [{questionId:1, rate:2}], roomId:1) {
    response{
      id
      questionId
      roomId
      }
  }
}
```
#### Input
```
mutation{
 createResponse(
   responses: [{questionId:3, textArea:"Any other suggestion"}], roomId:1) {
   response{
     id
     questionId
     roomId
     }
 }
}
```
- Ensure that at least one question's start date is way in advance to try and respond to.
### What are the relevant pivotal tracker stories?
[#165903102](https://www.pivotaltracker.com/story/show/165903102)
### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations