### PR TITLE
#166034806 Paginate room responses on getRoomResponse

### DIFF
--- a/api/response/schema.py
+++ b/api/response/schema.py
@@ -6,6 +6,7 @@ from utilities.validations import validate_empty_fields
 from graphql import GraphQLError
 from api.room.schema import Room
 from api.question.models import Question as QuestionModel
+from helpers.pagination.paginate import ListPaginate
 from helpers.response.create_response import create_response
 
 
@@ -15,6 +16,31 @@ class Response(SQLAlchemyObjectType):
     """
     class Meta:
         model = ResponseModel
+
+
+class ResponseDetail(graphene.ObjectType):
+    response_id = graphene.Int()
+    suggestion = graphene.String()
+    missing_items = graphene.List(graphene.String)
+    created_date = graphene.DateTime()
+    rating = graphene.Int()
+    resolved = graphene.Boolean()
+
+
+class RoomResponses(graphene.ObjectType):
+    room_id = graphene.Int()
+    room_name = graphene.String()
+    total_responses = graphene.Int()
+    response = graphene.List(ResponseDetail)
+
+
+class PaginatedResponse(graphene.ObjectType):
+    pages = graphene.Int()
+    query_total = graphene.Int()
+    has_next = graphene.Boolean()
+    has_previous = graphene.Boolean()
+    current_page = graphene.Int()
+    responses = graphene.List(RoomResponses)
 
 
 class ResponseInputs(graphene.InputObjectType):
@@ -69,21 +95,95 @@ class Query(graphene.ObjectType):
     """
         Query to get the room response
     """
-    get_room_response = graphene.List(
-        Response,
+    get_room_response = graphene.Field(
+        PaginatedResponse,
         room_id=graphene.Int(),
+        page=graphene.Int(),
+        per_page=graphene.Int(),
         description="Returns a list of responses of a room. Accepts the arguments\
-            \n- room_id: Unique identifier of a room"
-    )
+            \n- room_id: Unique identifier of a room\
+            \n- page: Page number of responses\
+            \n- per_page: Number of room responses per page")
+
+    def map_room_responses(self, responses):
+        mapped_response = []
+        missing_resource = []
+        for response in responses:
+            response_id = response.id
+            suggestion = response.text_area
+            created_date = response.created_date
+            rating = response.rate
+            resolved = response.resolved
+            if len(response.missing_resources) > 0:
+                for resource in response.missing_resources:
+                    resource_name = resource.name
+                    missing_resource.append(resource_name)
+                response_in_room = ResponseDetail(
+                    response_id=response_id,
+                    suggestion=suggestion,
+                    created_date=created_date,
+                    rating=rating,
+                    missing_items=missing_resource,
+                    resolved=resolved)
+                mapped_response.append(response_in_room)
+            else:
+                missing_items = response.missing_resources
+                response_in_room = ResponseDetail(
+                    response_id=response_id,
+                    suggestion=suggestion,
+                    created_date=created_date,
+                    rating=rating,
+                    missing_items=missing_items,
+                    resolved=resolved)
+                mapped_response.append(response_in_room)
+        return mapped_response
 
     @Auth.user_roles('Admin')
     def resolve_get_room_response(self, info, **kwargs):
         # Get the room's feedback
+        page = kwargs.get('page')
+        per_page = kwargs.get('per_page')
         query = Response.get_query(info)
         room_feedback = query.filter_by(room_id=kwargs['room_id'])
         if room_feedback.count() < 1:
-            raise GraphQLError("No Feedback Found")
-        return room_feedback
+            raise GraphQLError("This room\
+ doesn't exist or doesn't have feedback.")
+
+        if page and per_page:
+            responses = room_feedback.offset((page * per_page) - per_page)\
+                .limit(per_page)
+            paginated_response = ListPaginate(
+                iterable=room_feedback.all(),
+                per_page=per_page,
+                page=page)
+            has_previous = paginated_response.has_previous
+            has_next = paginated_response.has_next
+            current_page = paginated_response.page
+            pages = paginated_response.pages
+            query_total = paginated_response.query_total
+
+            mapped_responses = Query.map_room_responses(self, responses)
+            all_room_responses = []
+            room_response = RoomResponses(response=mapped_responses,
+                                          room_id=kwargs['room_id'],
+                                          total_responses=len(mapped_responses),
+                                          room_name=room_feedback[0].room.name)
+            all_room_responses.append(room_response)
+            return PaginatedResponse(responses=all_room_responses,
+                                     has_previous=has_previous,
+                                     has_next=has_next,
+                                     query_total=query_total,
+                                     current_page=current_page,
+                                     pages=pages)
+
+        mapped_responses = Query.map_room_responses(self, room_feedback)
+        all_room_responses = []
+        room_response = RoomResponses(response=mapped_responses,
+                                      room_id=kwargs['room_id'],
+                                      total_responses=len(mapped_responses),
+                                      room_name=room_feedback[0].room.name)
+        all_room_responses.append(room_response)
+        return PaginatedResponse(responses=all_room_responses)
 
 
 class HandleRoomResponse(graphene.Mutation):

--- a/fixtures/response/user_response_check.py
+++ b/fixtures/response/user_response_check.py
@@ -74,44 +74,82 @@ create_check_response = {
 
 filter_question_by_room = '''
 {
-  getRoomResponse(roomId: 1) {
-    room {
-      capacity
-      name
-      roomType
+  getRoomResponse(roomId: 1, perPage: 1, page: 1) {
+    responses {
+      roomName
+      roomId
+      response {
+        rating
+        suggestion
+      }
     }
   }
 }
 '''
 
 filter_question_by_room_response = {
-    "data": {
-        "getRoomResponse": [
-          {
-            "room": {
-              "capacity": 6,
-              "name": "Entebbe",
-              "roomType": "meeting"
+  "data": {
+    "getRoomResponse": {
+      "responses": [
+        {
+          "roomName": "Entebbe",
+          "roomId": 1,
+          "response": [
+            {
+              "rating": 2,
+              "suggestion": None
             }
-          },
-          {
-            "room": {
-              "capacity": 6,
-              "name": "Entebbe",
-              "roomType": "meeting"
-            }
-          }
-        ]
+          ]
+        }
+      ]
     }
+  }
+}
+
+filter_response_by_room_with_pagination = '''
+{
+  getRoomResponse(roomId: 1, perPage: 1, page: 1) {
+    responses {
+      roomName
+      roomId
+      response {
+        rating
+        suggestion
+      }
+    }
+  }
+}
+'''
+
+filter_response_by_room_with_pagination_response = {
+  "data": {
+    "getRoomResponse": {
+      "responses": [
+        {
+          "roomName": "Entebbe",
+          "roomId": 1,
+          "response": [
+            {
+              "rating": 2,
+              "suggestion": None
+            }
+          ]
+        }
+      ]
+    }
+  }
 }
 
 filter_question_by_invalid_room = '''
 {
-  getRoomResponse(roomId: 100) {
-    room {
-      id
-      name
-      roomType
+  getRoomResponse(roomId: 100, perPage: 1, page: 1) {
+    responses {
+      roomName
+      roomId
+      response {
+        rating
+        suggestion
+      }
     }
   }
 }
@@ -120,7 +158,7 @@ filter_question_by_invalid_room = '''
 
 filter_question_by_invalid_room_response = {
     "errors": [{
-        "message": "No Feedback Found",
+        "message": "This room doesn't exist or doesn't have feedback.",
         "locations": [{
             "line": 3,
             "column": 3

--- a/tests/test_response/test_user_response.py
+++ b/tests/test_response/test_user_response.py
@@ -13,7 +13,9 @@ from fixtures.response.user_response_check import (
     filter_question_by_room,
     filter_question_by_room_response,
     filter_question_by_invalid_room,
-    filter_question_by_invalid_room_response
+    filter_question_by_invalid_room_response,
+    filter_response_by_room_with_pagination,
+    filter_response_by_room_with_pagination_response
 )
 from fixtures.response.user_response_suggestions import (
     create_suggestion_question,
@@ -124,4 +126,15 @@ class TestCreateResponse(BaseTestCase):
             self,
             filter_question_by_invalid_room,
             filter_question_by_invalid_room_response
+        )
+
+    def test_filter_response_by_room_id_with_pagination(self):
+        """
+        Testing filter response by roomid with pagination
+
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            filter_response_by_room_with_pagination,
+            filter_response_by_room_with_pagination_response
         )


### PR DESCRIPTION
 ### What does this PR do?
 - It helps to paginate the responses received while running the `getRoomResponse` query.

### Description of the task to be completed?
- Modified the `getRoomResponse` resolver function to paginate responses instead of sending them all.

### How should this be manually tested?
- Pull this branch ft-paginate-room-responses-166034806
- Make sure your application containers are running
- Run the following query

```
query {
  getRoomResponse (
    roomId: 1,
    page: 1,
    perPage: 2
  ) {
    responses {
      totalResponses
      response {
        rating
        missingItems
        suggestion
      }
    }
    hasNext
    hasPrevious
    pages
  }
}

```
- The `hasNext`, `hasPrevious` and `pages` fields are pagination metadata that'll eventually be used on the frontend.
- `Responses` returns an array of responses which the amount has been specified in the `perPage` query.
- The `perPage` query param is the number of responses to be returned while the `page` query param is the page being requested for.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/26174035/58135138-30713000-7c21-11e9-9f48-69792b9937c9.png)


### What are the relevant pivotal tracker stories?
[#166034806](https://www.pivotaltracker.com/story/show/166034806)

#### Any background context that you would like to provide:
N/A
