### PR TITLE
#166051871 Query device by device ID

### DIFF
--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -26,6 +26,61 @@ expected_response_devices = {
                                             }
                                             }
 
+query_device = '''
+        {
+        specificDevice(deviceId: 1){
+            id
+            lastSeen
+            dateAdded
+            name
+            location
+        }
+        }
+        '''
+
+expected_response_device = {
+    "data": {
+        "specificDevice": {
+            "id": "1",
+            "lastSeen": "2018-06-08T11:17:58.785136",  # noqa: E501
+            "dateAdded": "2018-06-08T11:17:58.785136",  # noqa: E501
+            "name": "Samsung",
+            "location": "Kampala"
+            }
+        }
+    }
+
+query_non_existent_device = '''
+        {
+        specificDevice(deviceId: 10000){
+            id
+            lastSeen
+            dateAdded
+            name
+            location
+        }
+        }
+        '''
+
+expected_error_non_existent_device_id = {
+    "errors": [
+        {
+            "message": "Device not found",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 9
+                }
+            ],
+            "path": [
+                "specificDevice"
+            ]
+        }
+    ],
+    "data": {
+        "specificDevice": null
+    }
+    }
 
 create_devices_query = '''
             mutation{

--- a/tests/test_devices/test_specific_device.py
+++ b/tests/test_devices/test_specific_device.py
@@ -1,0 +1,31 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.devices.devices_fixtures import (
+    query_device,
+    expected_response_device,
+    query_non_existent_device,
+    expected_error_non_existent_device_id
+)
+
+import sys
+import os
+sys.path.append(os.getcwd())
+
+
+class TestGetSpecificDevice(BaseTestCase):
+    """
+    Test that an admin can query to get
+    a list of all devices in their location
+    """
+    def test_specific_device(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_device,
+            expected_response_device
+        )
+
+    def test_get_non_existing_device(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_non_existent_device,
+            expected_error_non_existent_device_id
+        )


### PR DESCRIPTION
#### What does this PR do?
Enables a user to fetch a specific device using the device Id

#### Description of Task to be completed?
- add a query to fetch device by device ID
- test query to fetch specific device
#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `ft-query-device-by-deviceID-166051871`
3. on insomnia send query
 ```
 {
  specificDevice(deviceId: 1) {
    name
    deviceType
    location
    room {
      name
    }
  }
}
```
#### What are the relevant pivotal tracker stories?
[#166051871](https://www.pivotaltracker.com/story/show/166051871)
#### Screenshots (if appropriate)
<img width="936" alt="Screenshot 2019-05-17 at 17 40 11" src="https://user-images.githubusercontent.com/39084014/57937264-3dfb8280-78ce-11e9-9a95-2abf45c99290.png">
