### PR TITLE
#166150047 Limit worker connections and timeout

### DIFF
--- a/docker/dev/start_gunicorn.sh
+++ b/docker/dev/start_gunicorn.sh
@@ -4,4 +4,4 @@ while ! nc -z database 5432; do
 done
 cd /app
 export $(cat .env | xargs)
-gunicorn manage:app --worker-class gevent -b 0.0.0.0:8000 --reload --log-syslog
+gunicorn manage:app --worker-class gevent --worker-connections 1000 --timeout 30 -b 0.0.0.0:8000 --reload --log-syslog

--- a/docker/prod/start_gunicorn.sh
+++ b/docker/prod/start_gunicorn.sh
@@ -4,4 +4,4 @@ export $(cat .env | xargs)
 # run migrations
 alembic upgrade head
 # run gunicorn
-gunicorn manage:app --worker-class gevent -b 0.0.0.0:8000 --reload --log-syslog
+gunicorn manage:app --worker-class gevent --worker-connections 1000 --timeout 30 -b 0.0.0.0:8000 --reload --log-syslog


### PR DESCRIPTION
#### What does this PR do?
Additional configuration for gunicorn to limit the worker connections to 1000 and introduce a timeout of 30 seconds.

#### Description of Task to be completed?
- Added a gunicorn worker connection limit of 1000
- Added a gunicorn timeout of 30 seconds

#### How should this be manually tested?
N/A

#### What are the relevant pivotal tracker stories?
[#166150047](https://www.pivotaltracker.com/story/show/166150047)
