### PR TITLE
#166147378 Consolidate analytics queries into one

### DIFF
--- a/api/analytics/all_analytics_query.py
+++ b/api/analytics/all_analytics_query.py
@@ -1,0 +1,74 @@
+import graphene
+from helpers.auth.admin_roles import admin_roles
+from helpers.calendar.all_analytics_helper import (
+    AllAnalyticsHelper, Event, BookingsCount
+)
+from helpers.calendar.analytics_helper import CommonAnalytics
+from helpers.auth.authentication import Auth
+from api.room.schema import Room
+
+
+class ConsolidatedAnalytics(graphene.ObjectType):
+    room_name = graphene.String()
+    number_of_meetings = graphene.Int()
+    bookings_count = graphene.List(BookingsCount)
+    cancellations = graphene.Int()
+    cancellations_percentage = graphene.Float()
+    checkins_percentage = graphene.Float()
+    checkins = graphene.Int()
+    app_bookings = graphene.Int()
+    app_bookings_percentage = graphene.Float()
+    percentage_share = graphene.Float()
+    period = graphene.Int()
+    events = graphene.List(
+        Event,
+        description='Returns all the events in that room'
+    )
+    auto_cancellations = graphene.Int()
+
+
+class AllAnalytics(graphene.ObjectType):
+    analytics = graphene.List(ConsolidatedAnalytics)
+    bookings = graphene.Int()
+
+
+class Query(graphene.ObjectType):
+    all_analytics = graphene.Field(
+        AllAnalytics,
+        start_date=graphene.String(),
+        end_date=graphene.String(),
+        description="Query that returns a list of all analytics")
+
+    @Auth.user_roles('Admin', 'Default User')
+    def resolve_all_analytics(self, info, **kwargs):
+        start_date = kwargs.get('start_date')
+        end_date = kwargs.get('end_date')
+        unconverted_dates = {
+            'start': start_date,
+            'end': end_date
+        }
+        location_id = admin_roles.user_location_for_analytics_view()
+        start_date, end_date = CommonAnalytics.all_analytics_date_validation(
+            self, start_date, end_date
+        )
+        query = Room.get_query(info)
+        room_analytics, bookings = AllAnalyticsHelper.get_all_analytics(
+            self, query, start_date, end_date, location_id, unconverted_dates)
+        analytics = []
+        for analytic in room_analytics:
+            current_analytic = ConsolidatedAnalytics(
+                room_name=analytic['room_name'],
+                number_of_meetings=analytic['number_of_meetings'],
+                checkins_percentage=analytic['checkins_percentage'],
+                bookings_count=analytic['bookings_count'],
+                cancellations=analytic['cancellations'],
+                checkins=analytic['checkins'],
+                cancellations_percentage=analytic['cancellations_percentage'],
+                app_bookings=analytic['app_bookings'],
+                app_bookings_percentage=analytic['app_bookings_percentage'],
+                percentage_share=analytic['percentage_share'],
+                events=analytic['room_events'],
+                auto_cancellations=analytic['auto_cancellations']
+            )
+            analytics.append(current_analytic)
+        return AllAnalytics(bookings=bookings, analytics=analytics)

--- a/fixtures/analytics/query_all_analytics_fixtures.py
+++ b/fixtures/analytics/query_all_analytics_fixtures.py
@@ -1,0 +1,85 @@
+null = None
+
+all_analytics_query = '''
+    query {
+        allAnalytics(startDate:"jul 11 2018", endDate:"jul 12 2018") {
+            bookings
+            analytics{
+                roomName
+                cancellations
+                autoCancellations
+                numberOfMeetings
+                checkins
+                checkinsPercentage
+                percentageShare
+                appBookings
+                appBookingsPercentage
+                bookingsCount{
+                    period
+                    bookings
+                }
+                events{
+                    durationInMinutes
+                }
+            }
+        }
+    }
+'''
+
+all_analytics_query_response = {
+    "data": {
+        "allAnalytics": {
+            "bookings": 1,
+            "analytics": [
+                {
+                    "roomName": "Entebbe",
+                    "cancellations": 0,
+                    "autoCancellations": 0,
+                    "numberOfMeetings": 1,
+                    "checkins": 0,
+                    "checkinsPercentage": 0.0,
+                    "percentageShare": 100.0,
+                    "appBookings": 0,
+                    "appBookingsPercentage": 0.0,
+                    "bookingsCount": [
+                        {
+                            "period": "Jul 11 2018",
+                            "bookings": 1
+                        }
+                    ],
+                    "events": [
+                        {
+                            "durationInMinutes": 45
+                        }
+                    ]
+                },
+            ]
+        }
+    }
+}
+
+analytics_query_for_date_ranges = '''
+    query {
+        allAnalytics(startDate:"jul 11 2019", endDate:"jul 12 2018") {
+            bookings
+            analytics{
+                roomName
+                cancellations
+                autoCancellations
+                numberOfMeetings
+                checkins
+                checkinsPercentage
+                percentageShare
+                appBookings
+                appBookingsPercentage
+                bookingsCount{
+                    period
+                    bookings
+                }
+                events{
+                    durationInMinutes
+                }
+            }
+        }
+    }
+'''

--- a/helpers/calendar/all_analytics_helper.py
+++ b/helpers/calendar/all_analytics_helper.py
@@ -1,0 +1,109 @@
+import graphene
+import dateutil.parser
+from graphql import GraphQLError
+from utilities.utility import percentage_formater
+from helpers.calendar.analytics_helper import CommonAnalytics
+
+
+class Event(graphene.ObjectType):
+    duration_in_minutes = graphene.Int()
+
+
+class BookingsCount(graphene.ObjectType):
+    period = graphene.String()
+    bookings = graphene.Int()
+
+
+class AllAnalyticsHelper:
+
+    def bookings_count(self, unconverted_dates, events):
+        """
+        Get bookings count and period in a given room
+        """
+        start_date = unconverted_dates['start']
+        day_after_end_date = unconverted_dates['end']
+        bookings_count = []
+        parsed_start_date = dateutil.parser.parse(start_date)
+        parsed_end_date = dateutil.parser.parse(day_after_end_date)
+        number_of_days = (parsed_end_date - parsed_start_date).days
+
+        if number_of_days <= 30:
+            dates = CommonAnalytics.get_list_of_dates(
+                start_date, number_of_days)
+            for date in dates:
+                bookings = 0
+                string_date = dateutil.parser.parse(
+                    date[0]).strftime("%b %d %Y")
+                for event in events:
+                    if dateutil.parser.parse(event.start_time[:10]).strftime("%b %d %Y") == string_date: # noqa
+                        bookings += 1
+                output = BookingsCount(
+                    period=string_date,
+                    bookings=bookings)
+                bookings_count.append(output)
+        else:
+            dates = CommonAnalytics.get_list_of_month_dates(
+                start_date,
+                parsed_start_date,
+                day_after_end_date,
+                parsed_end_date)
+            for date in dates:
+                string_month = dateutil.parser.parse(date[0]).strftime("%B")
+                bookings = 0
+                for event in events:
+                    if dateutil.parser.parse(event.start_time[:10]).strftime("%B") == string_month: # noqa
+                        bookings += 1
+                output = BookingsCount(
+                    period=string_month,
+                    bookings=bookings)
+                bookings_count.append(output)
+
+        return bookings_count
+
+    def get_all_analytics(self, query, start_date, end_date, location_id, unconverted_dates): # noqa
+        """
+        Get all room analytics
+        """
+        rooms = query.filter_by(state="active", location_id=location_id).all()
+        room_analytics = []
+        bookings = 0
+        for room in rooms:
+            cancellations = 0
+            checkins = 0
+            events = []
+            try:
+                events_result = CommonAnalytics.get_all_events_in_a_room(
+                    self, room.id, start_date, end_date)
+            except GraphQLError:
+                continue
+            bookings_count = AllAnalyticsHelper.bookings_count(self, unconverted_dates, events_result) # noqa
+            bookings += len(events_result)
+            for event in events_result:
+                if event.checked_in:
+                    checkins += 1
+                if event.cancelled:
+                    cancellations += 1
+                duaration_in_minutes = CommonAnalytics.get_time_duration_for_event(self, event.start_time, event.end_time) # noqa
+                current_event = Event(
+                    duration_in_minutes=duaration_in_minutes)
+                events.append(current_event)
+            room_analytic = {
+                'number_of_meetings': len(events_result),
+                'room_name': room.name,
+                'cancellations': cancellations,
+                'checkins': checkins,
+                'cancellations_percentage': percentage_formater(cancellations, bookings), # noqa
+                'checkins_percentage': percentage_formater(checkins, bookings),
+                # TODO - work on app_bookings and autocancellation logic
+                'app_bookings': cancellations,  # Place holder
+                'app_bookings_percentage': percentage_formater(cancellations, bookings), # noqa
+                'percentage_share': percentage_formater(
+                    len(events_result), bookings
+                ),
+                'room_events': events,
+                'bookings_count': bookings_count,
+                'auto_cancellations': 0  # Placeholder
+            }
+            room_analytics.append(room_analytic)
+            room_analytics.sort(key=lambda x: x['number_of_meetings'], reverse=True) # noqa
+        return room_analytics, bookings

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -41,6 +41,17 @@ class CommonAnalytics:
         end_date = (datetime.strptime(end_date, "%b %d %Y") + relativedelta(days=1)).isoformat() + 'Z'  # noqa: E501
         return(start_date, end_date)
 
+    def all_analytics_date_validation(self, start_date, end_date):
+        """
+        Checks that the start date is not greater than end date
+        """
+        start_date, end_date = CommonAnalytics.convert_dates(
+            self, start_date, end_date
+        )
+        if start_date > end_date:
+            raise GraphQLError('Earlier date should be lower than later date')
+        return (start_date, end_date)
+
     def validate_current_date(self, start_date, end_date):
         """
         Checks for today's date

--- a/schema.py
+++ b/schema.py
@@ -16,6 +16,7 @@ import api.tag.schema
 import api.office_structure.schema
 import api.response.schema_query
 import api.structure.schema
+import api.analytics.all_analytics_query
 
 
 class Query(
@@ -30,7 +31,8 @@ class Query(
         api.response.schema.Query,
         api.response.schema_query.Query,
         api.question.schema.Query,
-        api.structure.schema.Query
+        api.structure.schema.Query,
+        api.analytics.all_analytics_query.Query,
 ):
     """Root for converge Graphql queries"""
     pass

--- a/tests/test_analytics/test_all_analytics_query.py
+++ b/tests/test_analytics/test_all_analytics_query.py
@@ -1,0 +1,32 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.analytics.query_all_analytics_fixtures import (
+    all_analytics_query,
+    all_analytics_query_response,
+    analytics_query_for_date_ranges
+)
+
+
+class TestAllAnalytics(BaseTestCase):
+
+    def test_all_analytics_query(self):
+        """
+        Tests a user can query for analytics
+        """
+
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            all_analytics_query,
+            all_analytics_query_response
+        )
+
+    def test_analytics_query_for_date_range(self):
+        """
+        Tests the date range to ensure start
+        date is smaller than end date
+        """
+
+        CommonTestCases.admin_token_assert_in(
+            self,
+            analytics_query_for_date_ranges,
+            "Earlier date should be lower than later date"
+        )

--- a/utilities/utility.py
+++ b/utilities/utility.py
@@ -51,6 +51,18 @@ def listen_for_after_flush_event(target, child, parent_id):
         pass
 
 
+def percentage_formater(portion, total):
+    """ Calculates the percentage of the entered portion to the total and returns it
+        :params
+        - portion, total
+    """
+    try:
+        percentage = (portion/total) * 100
+        return percentage
+    except ZeroDivisionError:
+        return 0
+
+
 class Utility(object):
 
     def save(self):


### PR DESCRIPTION
#### What does this PR do?

Create a query for the analytics page

#### Description of Task to be completed?

Currently, the analytics page runs at least six queries, this PR makes one query to be used by the analytics page to optimise the response time.

#### How should this be manually tested?
- git pull and checkout to the branch ft-refactor-analytics-queries-166147378
- run application
- Run the following query
```
query {
  allAnalytics(startDate: "May 1 2019", endDate: "May 22 2020"){
    bookings
    analytics{
      roomName
      cancellations
      autoCancellations
      numberOfMeetings
      checkins
      checkinsPercentage
      percentageShare
      appBookings
      appBookingsPercentage
      bookingsCount{
        period
        bookings
      }
      events{
        durationInMinutes
    	}
    }
  }
}

```
### What are the relevant pivotal tracker stories?
[166147378](https://www.pivotaltracker.com/story/show/166147378)

### Background information
None

### Screenshots
<img width="1432" alt="Screenshot 2019-05-22 at 16 24 42" src="https://user-images.githubusercontent.com/33450849/58178169-5bee2c00-7cae-11e9-9d97-b4ea1bf4828b.png">



- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
