### PR TITLE
#166080260 modify getAllResponses to return only rooms with responses

### DIFF
--- a/api/response/schema_query.py
+++ b/api/response/schema_query.py
@@ -161,14 +161,15 @@ class Query(graphene.ObjectType):
             room_response = Response.get_query(info).filter_by(
                 room_id=room.id)
             response_count = room_response.count()
-            all_responses = Query.get_room_response(
-                self, room_response, room.id)
-            responses = RoomResponse(
-                room_id=room.id,
-                room_name=room_name,
-                total_responses=response_count,
-                response=all_responses)
-            response.append(responses)
+            if response_count:
+                all_responses = Query.get_room_response(
+                    self, room_response, room.id)
+                responses = RoomResponse(
+                    room_id=room.id,
+                    room_name=room_name,
+                    total_responses=response_count,
+                    response=all_responses)
+                response.append(responses)
         return response
 
     @Auth.user_roles('Admin')

--- a/helpers/response/query_response.py
+++ b/helpers/response/query_response.py
@@ -62,7 +62,8 @@ def validate_responses_by_room(data_type, function, **kwargs):
             kwargs['Query'], kwargs['info'], kwargs['upper_limit'],
             kwargs['lower_limit'])
         for room_response in filtered_response:
-            if room_response.room_name.lower() == kwargs['room'].lower():
+            if (room_response.room_name.lower() == kwargs['room'].lower()
+                    and room_response.response):
                 kwargs['filtered_search'].append(room_response)
         if kwargs['filtered_search']:
             return kwargs['filtered_search']


### PR DESCRIPTION
#### What does this PR do?
modifies the  `allRoomResponses` query  to return only rooms with responses

#### Description of Task to be completed?
- modify get_all_responses method in `api/response/schema_query.py `
- modify validate_responses_by_room method in `helpers/response/query_response.py`

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `ch-modify-getAllResponses-166080260`
3. on insomnia send query
 ```
 {
  allRoomResponses {
    responses {
      roomId
      roomName
      totalResponses
      response {
        responseId
        resolved
      }
    }
  }
}
```
#### Any background context you want to provide?
The `allRoomResponses` query used to return all rooms regardless of whether they had a response or not. The query had to be modified to return only rooms with responses

#### What are the relevant pivotal tracker stories?
[#166080260](https://www.pivotaltracker.com/story/show/166080260)

#### Screenshots (if appropriate)
<img width="951" alt="Screenshot 2019-05-22 at 09 46 39" src="https://user-images.githubusercontent.com/39084014/58152996-9fc53f00-7c76-11e9-994f-b9d42012cf59.png">

