### PR TITLE
#166210077 Fix bookings count and percentage share

### DIFF
--- a/fixtures/analytics/query_all_analytics_fixtures.py
+++ b/fixtures/analytics/query_all_analytics_fixtures.py
@@ -1,85 +1,98 @@
-null = None
-
 all_analytics_query = '''
     query {
-        allAnalytics(startDate:"jul 11 2018", endDate:"jul 12 2018") {
-            bookings
-            analytics{
-                roomName
-                cancellations
-                autoCancellations
-                numberOfMeetings
-                checkins
-                checkinsPercentage
-                percentageShare
-                appBookings
-                appBookingsPercentage
-                bookingsCount{
-                    period
-                    bookings
-                }
-                events{
-                    durationInMinutes
-                }
-            }
+      allAnalytics(startDate:"jul 11 2018", endDate:"jul 12 2018") {
+          checkinsPercentage
+          appBookingsPercentage
+          autoCancellationsPercentage
+          cancellationsPercentage
+          bookings
+          analytics{
+            roomName
+            cancellations
+            cancellationsPercentage
+            autoCancellations
+            numberOfBookings
+            checkins
+            checkinsPercentage
+            bookingsPercentageShare
+            appBookings
+            appBookingsPercentage
+            events{
+              durationInMinutes
+              }
+          }
+          bookingsCount{
+            totalBookings
+            period
+          }
         }
-    }
+  }
 '''
 
 all_analytics_query_response = {
-    "data": {
-        "allAnalytics": {
-            "bookings": 1,
-            "analytics": [
-                {
-                    "roomName": "Entebbe",
-                    "cancellations": 0,
-                    "autoCancellations": 0,
-                    "numberOfMeetings": 1,
-                    "checkins": 0,
-                    "checkinsPercentage": 0.0,
-                    "percentageShare": 100.0,
-                    "appBookings": 0,
-                    "appBookingsPercentage": 0.0,
-                    "bookingsCount": [
-                        {
-                            "period": "Jul 11 2018",
-                            "bookings": 1
-                        }
-                    ],
-                    "events": [
-                        {
-                            "durationInMinutes": 45
-                        }
-                    ]
-                },
-            ]
+  "data": {
+    "allAnalytics": {
+      "checkinsPercentage": 0.0,
+      "appBookingsPercentage": 0.0,
+      "autoCancellationsPercentage": 0.0,
+      "cancellationsPercentage": 0.0,
+      "bookings": 1,
+      "analytics": [
+        {
+          "roomName": "Entebbe",
+          "cancellations": 0,
+          "cancellationsPercentage": 0.0,
+          "autoCancellations": 0,
+          "numberOfBookings": 1,
+          "checkins": 0,
+          "checkinsPercentage": 0.0,
+          "bookingsPercentageShare": 100.0,
+          "appBookings": 0,
+          "appBookingsPercentage": 0.0,
+          "events": [
+            {
+              "durationInMinutes": 45
+            }
+          ]
         }
+      ],
+      "bookingsCount": [
+        {
+          "period": "Jul 11 2018",
+          "totalBookings": 1
+        }
+      ]
     }
+  }
 }
 
 analytics_query_for_date_ranges = '''
     query {
-        allAnalytics(startDate:"jul 11 2019", endDate:"jul 12 2018") {
-            bookings
-            analytics{
-                roomName
-                cancellations
-                autoCancellations
-                numberOfMeetings
-                checkins
-                checkinsPercentage
-                percentageShare
-                appBookings
-                appBookingsPercentage
-                bookingsCount{
-                    period
-                    bookings
-                }
-                events{
-                    durationInMinutes
-                }
-            }
+      allAnalytics(startDate:"jul 11 2020", endDate:"jul 12 2018") {
+          checkinsPercentage
+          appBookingsPercentage
+          autoCancellationsPercentage
+          cancellationsPercentage
+          bookings
+          analytics{
+            roomName
+            cancellations
+            cancellationsPercentage
+            autoCancellations
+            numberOfBookings
+            checkins
+            checkinsPercentage
+            bookingsPercentageShare
+            appBookings
+            appBookingsPercentage
+            events{
+              durationInMinutes
+              }
+          }
+          bookingsCount{
+            totalBookings
+            period
+          }
         }
-    }
+  }
 '''

--- a/helpers/calendar/all_analytics_helper.py
+++ b/helpers/calendar/all_analytics_helper.py
@@ -1,8 +1,8 @@
 import graphene
 import dateutil.parser
 from graphql import GraphQLError
-from utilities.utility import percentage_formater
 from helpers.calendar.analytics_helper import CommonAnalytics
+from utilities.utility import percentage_formater
 
 
 class Event(graphene.ObjectType):
@@ -11,7 +11,7 @@ class Event(graphene.ObjectType):
 
 class BookingsCount(graphene.ObjectType):
     period = graphene.String()
-    bookings = graphene.Int()
+    total_bookings = graphene.Int()
 
 
 class AllAnalyticsHelper:
@@ -22,11 +22,10 @@ class AllAnalyticsHelper:
         """
         start_date = unconverted_dates['start']
         day_after_end_date = unconverted_dates['end']
-        bookings_count = []
         parsed_start_date = dateutil.parser.parse(start_date)
         parsed_end_date = dateutil.parser.parse(day_after_end_date)
         number_of_days = (parsed_end_date - parsed_start_date).days
-
+        bookings_count = []
         if number_of_days <= 30:
             dates = CommonAnalytics.get_list_of_dates(
                 start_date, number_of_days)
@@ -39,7 +38,7 @@ class AllAnalyticsHelper:
                         bookings += 1
                 output = BookingsCount(
                     period=string_date,
-                    bookings=bookings)
+                    total_bookings=bookings)
                 bookings_count.append(output)
         else:
             dates = CommonAnalytics.get_list_of_month_dates(
@@ -48,16 +47,14 @@ class AllAnalyticsHelper:
                 day_after_end_date,
                 parsed_end_date)
             for date in dates:
-                string_month = dateutil.parser.parse(date[0]).strftime("%B")
-                bookings = 0
-                for event in events:
-                    if dateutil.parser.parse(event.start_time[:10]).strftime("%B") == string_month: # noqa
-                        bookings += 1
+                string_month = dateutil.parser.parse(date[0]).strftime("%b %Y")
                 output = BookingsCount(
                     period=string_month,
-                    bookings=bookings)
+                    total_bookings=0)
+                for event in events:
+                    if dateutil.parser.parse(event.start_time[:10]).strftime("%b %Y") == string_month: # noqa
+                        output.total_bookings += 1
                 bookings_count.append(output)
-
         return bookings_count
 
     def get_all_analytics(self, query, start_date, end_date, location_id, unconverted_dates): # noqa
@@ -67,43 +64,70 @@ class AllAnalyticsHelper:
         rooms = query.filter_by(state="active", location_id=location_id).all()
         room_analytics = []
         bookings = 0
+        total_checkins = 0
+        total_app_bookings = 0
+        total_auto_cancellations = 0
+        total_cancellations = 0
+        bookings_count = []
+        all_events = []
         for room in rooms:
+            events = []
+            duaration_in_minutes = 0
             cancellations = 0
             checkins = 0
-            events = []
+            auto_cancellations = 0
+            app_bookings = 0
             try:
                 events_result = CommonAnalytics.get_all_events_in_a_room(
                     self, room.id, start_date, end_date)
             except GraphQLError:
                 continue
-            bookings_count = AllAnalyticsHelper.bookings_count(self, unconverted_dates, events_result) # noqa
+            all_events += events_result
             bookings += len(events_result)
             for event in events_result:
                 if event.checked_in:
                     checkins += 1
+                if event.app_booking:
+                    app_bookings += 1
+                if event.auto_cancelled:
+                    auto_cancellations += 1
                 if event.cancelled:
                     cancellations += 1
-                duaration_in_minutes = CommonAnalytics.get_time_duration_for_event(self, event.start_time, event.end_time) # noqa
-                current_event = Event(
-                    duration_in_minutes=duaration_in_minutes)
-                events.append(current_event)
+                duaration_in_minutes += CommonAnalytics.get_time_duration_for_event( # noqa
+                    self, event.start_time, event.end_time
+                )
+            current_event = Event(
+                duration_in_minutes=duaration_in_minutes)
+            events.append(current_event)
+            total_checkins += checkins
+            total_app_bookings += app_bookings
+            total_auto_cancellations += auto_cancellations
+            total_cancellations += cancellations
+            num_of_events = len(events_result)
             room_analytic = {
-                'number_of_meetings': len(events_result),
+                'number_of_meetings': num_of_events,
                 'room_name': room.name,
+                'num_of_events': num_of_events,
+                'room_events': events,
                 'cancellations': cancellations,
                 'checkins': checkins,
-                'cancellations_percentage': percentage_formater(cancellations, bookings), # noqa
-                'checkins_percentage': percentage_formater(checkins, bookings),
-                # TODO - work on app_bookings and autocancellation logic
-                'app_bookings': cancellations,  # Place holder
-                'app_bookings_percentage': percentage_formater(cancellations, bookings), # noqa
-                'percentage_share': percentage_formater(
-                    len(events_result), bookings
+                'auto_cancellations': auto_cancellations,
+                'cancellations_percentage': percentage_formater(
+                    cancellations, num_of_events
                 ),
-                'room_events': events,
-                'bookings_count': bookings_count,
-                'auto_cancellations': 0  # Placeholder
+                'checkins_percentage': percentage_formater(
+                    checkins, num_of_events
+                ),
+                'app_bookings': app_bookings,
+                'app_bookings_percentage': percentage_formater(app_bookings, num_of_events) # noqa
             }
             room_analytics.append(room_analytic)
             room_analytics.sort(key=lambda x: x['number_of_meetings'], reverse=True) # noqa
-        return room_analytics, bookings
+        percentages_dict = {
+            'total_checkins': total_checkins,
+            'total_auto_cancellations': total_auto_cancellations,
+            'total_app_bookings': total_app_bookings,
+            'total_cancellations': total_cancellations
+        }
+        bookings_count += AllAnalyticsHelper.bookings_count(self, unconverted_dates, all_events) # noqa
+        return room_analytics, bookings, percentages_dict, bookings_count


### PR DESCRIPTION
#### What does this PR do?

Fix the bookings count, percentage share tally, auto cancellations and app_bookings logic.

#### Description of Task to be completed?

Currently, the bookings count for different periods does not tally to the total number of meetings in a room, percentage share is off, the duration in minutes is returned for every event and overall percentages have also been added.
The app_bookings and auto_cancellations logic has also been added.

#### How should this be manually tested?
- git pull and checkout to the branch bg-fix-bookings-and-percentages-166210077
- run application
- Run the following query
```
query {
  allAnalytics(startDate: "Jan 11 2018", endDate: "may 11 2019"){
    checkinsPercentage
    appBookingsPercentage
    autoCancellationsPercentage
    cancellationsPercentage
    bookings
    analytics{
      roomName
      cancellations
      cancellationsPercentage
      autoCancellations
      numberOfBookings
      checkins
      checkinsPercentage
      bookingsPercentageShare
      appBookings
      appBookingsPercentage
      events{
        durationInMinutes
        }
    }
    bookingsCount{
       totalBookings 
       period
      }
  }
}
```
### What are the relevant pivotal tracker stories?
[166210077](https://www.pivotaltracker.com/story/show/166210077

### Background information
None

### Screenshots

<img width="1430" alt="Screenshot 2019-05-23 at 23 32 03" src="https://user-images.githubusercontent.com/33450849/58311403-8d333d00-7e11-11e9-9a24-12468ecf6dbc.png">


- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
