### PR TITLE
#166208042 Indicate auto-cancellations and app-bookings

### DIFF
--- a/api/events/schema.py
+++ b/api/events/schema.py
@@ -74,7 +74,8 @@ class CancelEvent(graphene.Mutation):
                 end_time=kwargs['end_time'],
                 number_of_participants=kwargs['number_of_participants'],
                 checked_in=False,
-                cancelled=True)
+                cancelled=True,
+                auto_cancelled=True)
             event.save()
         calendar_event = get_single_calendar_event(
                                                     kwargs['calendar_id'],
@@ -150,6 +151,7 @@ def check_event_in_db(instance, info, event_check, **kwargs):
         event_id=kwargs['event_id']).scalar()
     if event and event_check == 'cancelled':
         event.cancelled = True
+        event.auto_cancelled = True
         event.save()
         return room_id, event
     elif event and event_check == 'checked_in':

--- a/helpers/calendar/events.py
+++ b/helpers/calendar/events.py
@@ -1,3 +1,4 @@
+import os
 import datetime
 import re
 
@@ -177,6 +178,11 @@ class CalendarEvents:
                     existing_event.save()
 
                 elif not event.get("status") == "cancelled":
+                    app_booking = False
+                    devices_email = os.getenv('MAIL_USERNAME')
+                    organizer = event.get("organizer")
+                    if organizer and organizer.get('email') == devices_email:
+                        app_booking = True
                     new_event = EventsModel(
                         event_id=event.get("id"),
                         recurring_event_id=event.get("recurringEventId"),
@@ -187,6 +193,7 @@ class CalendarEvents:
                         end_time=event["end"].get(
                             "dateTime") or event["end"].get("date"),
                         number_of_participants=number_of_attendees,
+                        app_booking=app_booking,
                         checked_in=False,
                         cancelled=False
                     )


### PR DESCRIPTION
#### What does this PR do?

This PR ensures bookings made from the app and events that are auto-canceled are indicated.

#### Description of Task to be completed?

Currently, there is no way to differentiate between events that were auto-canceled and those that were checked-in and later ended. Also, events that are booked using the app and those that were booked using the google calendar cannot be differentiated. This PR ensures these issues are resolved.

#### How should this be manually tested?
- You might need to clear your events model to enable you to see the new events after sync
- Change the calendar id of one of your rooms to `andela.com_3131313630383336383038@resource.calendar.google.com` as this calendar has bookings with the mobile app. Make sure the `next_sync_token_column` is null
- Set all rooms to `archived` except the one you just changed the calendarId
- Sync your database with the sync events mutation
```
mutation{
    syncEventData{
        message
        }
    }
```
- Check your events model for the new events
- Confirm there are events with  the `app_booking` column set to true `True`
- 
###
- Use the cancel event mutation to cancel a valid event. Note that the cancel event mutation is the same mutation used by the android device for (10 min) auto-cancellation.
- You should see the `auto_cancelled` column for that event set to True.

```
mutation {
        cancelEvent(
        calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
        eventId:"test_id5", eventTitle:"Onboarding", numberOfParticipants: 4,
        startTime:"2018-07-10T09:00:00Z",
        endTime:"2018-07-10T09:45:00Z")
        {
            event{
                eventId
                roomId
                checkedIn
                cancelled
                room{
                    id
                    name
                    calendarId
                }
            }
        }
    }

```
### What are the relevant pivotal tracker stories?
[#166208042](https://www.pivotaltracker.com/story/show/166208042)

- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
