### PR TITLE
#166245190 Fix booking count and failing tests

### DIFF
--- a/fixtures/analytics/query_all_analytics_fixtures.py
+++ b/fixtures/analytics/query_all_analytics_fixtures.py
@@ -58,14 +58,17 @@ all_analytics_query_response = {
       ],
       "bookingsCount": [
         {
-          "period": "Jul 11 2018",
-          "totalBookings": 1
+          "totalBookings": 1,
+          "period": "Jul 11 2018"
+        },
+        {
+          'totalBookings': 0,
+          'period': 'Jul 12 2018'
         }
       ]
     }
   }
 }
-
 analytics_query_for_date_ranges = '''
     query {
       allAnalytics(startDate:"jul 11 2020", endDate:"jul 12 2018") {

--- a/helpers/calendar/all_analytics_helper.py
+++ b/helpers/calendar/all_analytics_helper.py
@@ -3,6 +3,7 @@ import dateutil.parser
 from graphql import GraphQLError
 from helpers.calendar.analytics_helper import CommonAnalytics
 from utilities.utility import percentage_formater
+from dateutil.relativedelta import relativedelta
 
 
 class Event(graphene.ObjectType):
@@ -24,7 +25,8 @@ class AllAnalyticsHelper:
         day_after_end_date = unconverted_dates['end']
         parsed_start_date = dateutil.parser.parse(start_date)
         parsed_end_date = dateutil.parser.parse(day_after_end_date)
-        number_of_days = (parsed_end_date - parsed_start_date).days
+        parsed_day_after_end_date = parsed_end_date + relativedelta(days=1)
+        number_of_days = (parsed_day_after_end_date - parsed_start_date).days
         bookings_count = []
         if number_of_days <= 30:
             dates = CommonAnalytics.get_list_of_dates(
@@ -45,7 +47,7 @@ class AllAnalyticsHelper:
                 start_date,
                 parsed_start_date,
                 day_after_end_date,
-                parsed_end_date)
+                parsed_day_after_end_date)
             for date in dates:
                 string_month = dateutil.parser.parse(date[0]).strftime("%b %Y")
                 output = BookingsCount(

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -191,6 +191,8 @@ class CommonAnalytics:
         number_of_months = 12 * diff.years + diff.months
         month_one_end = CommonAnalytics.get_last_day_of_month(start_dt)
         month_one_end_date = datetime.strptime(month_one_end, '%b %d %Y').isoformat() + 'Z'  # noqa E501
+        if diff.days >= 1:
+            number_of_months += 1
         dates.append([start_date, month_one_end_date])
 
         for num in range(1, number_of_months):
@@ -202,5 +204,8 @@ class CommonAnalytics:
 
         last_month_start = (end_dt.replace(day=1)).strftime("%b %d %Y")
         last_month_start_date = datetime.strptime(last_month_start, '%b %d %Y').isoformat() + 'Z'  # noqa E501
+        booked_dates = [n for n in dates if last_month_start_date in n]
+        for last_month in booked_dates:
+            dates.remove(last_month)
         dates.append([last_month_start_date, end_date])
         return dates


### PR DESCRIPTION
#### What does this PR do?

Fix the bookings count to display bookings for a today's date and fix failing tests.

#### Description of Task to be completed?

Currently, the bookings count will return an empty list when you query for today's bookings. It should return the booking date and the number of bookings for that day. 
This PR also adds a `__init__.py` file in the `test_analytics` folder.

#### How should this be manually tested?
- git pull and checkout to the branch bg-fix-failing-tests-166245190
- run application
- Run the following query
```
query {
  allAnalytics(startDate: "may 27 2019", endDate: "may 27 2019"){
    checkinsPercentage
    appBookingsPercentage
    autoCancellationsPercentage
    cancellationsPercentage
    bookings
    analytics{
      roomName
      cancellations
      cancellationsPercentage
      autoCancellations
      numberOfBookings
      checkins
      checkinsPercentage
      bookingsPercentageShare
      appBookings
      appBookingsPercentage
      events{
        durationInMinutes
        }
    }
    bookingsCount{
       totalBookings 
       period
      }
  }
}
```
### What are the relevant pivotal tracker stories?
[166245190](https://www.pivotaltracker.com/story/show/166245190)

### Background information
None

### Screenshots

![image](https://user-images.githubusercontent.com/31338414/58403071-7fc4bf80-806a-11e9-8d43-3d84f8de0c8d.png)

![image](https://user-images.githubusercontent.com/31338414/58403124-9703ad00-806a-11e9-916c-3956ee6c9f5d.png)


- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
