### PR TITLE
#165907624 Refactor create device mutation 

### DIFF
--- a/api/devices/schema.py
+++ b/api/devices/schema.py
@@ -12,6 +12,7 @@ from api.location.models import Location as LocationModel
 from utilities.validations import validate_empty_fields
 from utilities.utility import update_entity_fields
 from helpers.room_filter.room_filter import location_join_room
+from helpers.auth.user_details import get_user_from_db
 from helpers.auth.admin_roles import admin_roles
 
 
@@ -19,8 +20,7 @@ class Devices(SQLAlchemyObjectType):
     """
         Returns the device payload with the fields
         [id: ID!, name: String!, deviceType: String!,
-         dateAdded: DateTime!, lastSeen: DateTime!,
-         location: String!, roomId: Int and room: Room)
+         dateAdded: DateTime!, lastSeen: DateTime!
     """
     class Meta:
         model = DevicesModel
@@ -34,7 +34,6 @@ class CreateDevice(graphene.Mutation):
         name = graphene.String(required=True)
         room_id = graphene.Int(required=True)
         device_type = graphene.String(required=True)
-        location = graphene.String()
     device = graphene.Field(Devices)
 
     @Auth.user_roles('Admin')
@@ -45,13 +44,12 @@ class CreateDevice(graphene.Mutation):
             ).first()
         if not room_location:
             raise GraphQLError("Room not found")
-        admin_roles.update_delete_rooms_create_resource(
-            room_id=kwargs['room_id']
-        )
+        user = get_user_from_db()
         device = DevicesModel(
             **kwargs,
             date_added=datetime.now(),
-            last_seen=datetime.now()
+            last_seen=datetime.now(),
+            location=user.location
         )
         device.save()
 
@@ -129,8 +127,7 @@ class Mutation(graphene.ObjectType):
         description="Creates a new device with the arguments\
             \n- device_name: The name field of the device[required]\
             \n- room_id: Unique identifier of a room where the device is found\
-            [required]\n- device_type: The type field of the device[required]\
-            \n- location: The location of the device")
+            [required]\n- device_type: The type field of the device[required]")
     update_device = UpdateDevice.Field(
         description="Updates a given device details given the arguments\
             \n- device_id: Unique identifier of the tag\

--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -87,8 +87,7 @@ create_devices_query = '''
             createDevice(
                 name:"Apple tablet",
                 deviceType:"External Display",
-                roomId:1,
-                location:"Kenya",
+                roomId:1
             ){
                 device{
                 name
@@ -104,7 +103,7 @@ expected_create_devices_response = {
                                             "createDevice": {
                                                 "device": {
                                                     "name": "Apple tablet",
-                                                    "location": "Kenya",
+                                                    "location": "Kampala",
                                                     "deviceType": "External Display"  # noqa : E501
                                                     }
                                                     }
@@ -116,8 +115,7 @@ mutation{
             createDevice(
                 name:"Apple tablet",
                 deviceType:"External Display",
-                roomId:4,
-                location:"Kenya",
+                roomId:4
             ){
                 device{
                 name
@@ -203,8 +201,7 @@ create_device_query_invalid_room = '''
             createDevice(
                 name:"Apple tablet",
                 deviceType:"External Display",
-                roomId:6,
-                location:"Kenya",
+                roomId:6
             ){
                 device{
                 name
@@ -217,4 +214,4 @@ create_device_query_invalid_room = '''
 
 non_existant_id_response = "DeviceId not found"
 devices_query = '/mrm?query='+create_devices_query
-devices_query_response = b'{"data":{"createDevice":{"device":{"name":"Apple tablet","location":"Kenya","deviceType":"External Display"}}}}'  # noqaE501
+devices_query_response = b'{"data":{"createDevice":{"device":{"name":"Apple tablet","location":"Kampala","deviceType":"External Display"}}}}'  # noqaE501

--- a/tests/test_devices/test_create_device.py
+++ b/tests/test_devices/test_create_device.py
@@ -2,7 +2,6 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.devices.devices_fixtures import (
     devices_query,
     devices_query_response,
-    create_devices_query,
     create_device_query_invalid_room
 )
 
@@ -22,16 +21,6 @@ class TestCreateDevice(BaseTestCase):
         headers = {"Authorization": "Bearer" + " " + ADMIN_TOKEN}
         query = self.app_test.post(devices_query, headers=headers)
         self.assertEqual(query.data, devices_query_response)
-
-    def test_create_device_in_room_that_is_not_in_admin_location(self):
-        """
-        Test for creation of device in a different location
-        """
-        CommonTestCases.lagos_admin_token_assert_in(
-            self,
-            create_devices_query,
-            "You are not authorized to make changes in Kampala"
-        )
 
     def test_create_device_in_nonexistent_room_throws_errors(self):
         """


### PR DESCRIPTION
#### What does this PR do?
- Sets device location to location from admin's token
- Removes location field from createDevice mutation

#### Description of Task to be completed?
When an admin is adding a new device, the device location field should be set to the location that is in the admin's token.

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `ch-refactor-create-device-165907624`
3. run the following query:

```
mutation {
  createDevice (
    name: "samsung s3rt7",
    roomId: 1,
    deviceType: "tablet"
  ) {
    device {
      name
      location
    }
  }
}
```

#### Screenshots
![image](https://user-images.githubusercontent.com/26174035/58472662-a5bb9400-813e-11e9-86bd-245e10a974da.png)

### What are the relevant pivotal tracker stories?
[#165907624](https://www.pivotaltracker.com/story/show/165907624)


The `location` field would be the location in your token.

- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

