### PR TITLE
#165931398 Update  office structures

### DIFF
--- a/api/structure/schema.py
+++ b/api/structure/schema.py
@@ -5,9 +5,12 @@ from helpers.auth.authentication import Auth
 from helpers.structure.create_structure import create_structure
 from graphql import GraphQLError
 from helpers.auth.admin_roles import admin_roles
-from utilities.validations import validate_structure_id
 from api.room.schema import Room
 from api.room.models import Room as RoomModel
+from utilities.validations import (
+    validate_empty_fields,
+    validate_structure_id
+)
 from utilities.utility import update_entity_fields
 
 
@@ -92,11 +95,51 @@ class DeleteOfficeStructure(graphene.Mutation):
         return DeleteOfficeStructure(structure=structures)
 
 
+class UpdateOfficeStructure(graphene.Mutation):
+    """
+    Updates an office structure
+    """
+    class Arguments:
+        structure_id = graphene.String()
+        level = graphene.Int()
+        name = graphene.String()
+        parent_id = graphene.String()
+        parent_title = graphene.String()
+        tag = graphene.String()
+        location_id = graphene.Int()
+        position = graphene.Int()
+    structure = graphene.Field(Structure)
+
+    @Auth.user_roles('Admin')
+    def mutate(self, info, structure_id, **kwargs):
+        validate_empty_fields(**kwargs)
+        query = Structure.get_query(info)
+        active_structure = query.filter(
+            StructureModel.structure_id == structure_id,
+            StructureModel.state == "active").first()
+        if not active_structure:
+            raise GraphQLError('Structure not found')
+        update_entity_fields(active_structure, **kwargs)
+        active_structure.save()
+        return UpdateOfficeStructure(structure=active_structure)
+
+
 class Mutation(graphene.ObjectType):
     create_office_structure = CreateOfficeStructure.Field()
     delete_office_structure = DeleteOfficeStructure.Field(
         description="Deletes office structures and the rooms associated\
         \n- structure_ids: The structure_id of the structure(s)"
+    )
+    update_office_structure = UpdateOfficeStructure.Field(
+        description="Updates an office structure and takes the arguments\
+            \n- structure_id: The structure id for the office structure\
+            \n- level: The level of the office structure\
+            \n- name: The name of the office structure\
+            \n- parent_id: The parent id of the office structure\
+            \n- parent_title: The parent title of the structure\
+            \n- tag: Tags for the office structure\
+            \n- location_id: The location id of the office structure\
+            \n- position: The position of the office structure"
     )
 
 

--- a/fixtures/structure/update_structure_fixtures.py
+++ b/fixtures/structure/update_structure_fixtures.py
@@ -1,0 +1,56 @@
+update_office_structure_mutation = '''
+mutation {
+  updateOfficeStructure(
+      structureId: "b05fc5f2-b4aa-4f48-a8fb-30bdcc3fc968",
+      name:"St.Catherine's", level:3, parentTitle:"parent 5",
+      tag:"offices", position:4, locationId:1, parentId:"2") {
+    structure {
+      structureId
+      name
+      level
+      parentId
+      parentTitle
+      tag
+      position
+      locationId
+    }
+  }
+}
+'''
+
+update_office_structure_mutation_response = {
+  "data": {
+    "updateOfficeStructure": {
+      "structure": {
+        "structureId": "b05fc5f2-b4aa-4f48-a8fb-30bdcc3fc968",
+        "name": "St.Catherine's",
+        "level": 3,
+        "parentId": "2",
+        "parentTitle": "parent 5",
+        "tag": "offices",
+        "position": 4,
+        "locationId": 1
+      }
+    }
+  }
+}
+
+update_structure_invalid_id = '''
+mutation {
+  updateOfficeStructure(
+      structureId: "b05fc5f2-b4aa-4f48-a8fb-30bdcc3fc968-non-existent",
+      name:"St.Catherine's", level:3, parentTitle:"parent 5",
+      tag:"offices", position:4, locationId:1, parentId:"2") {
+    structure {
+      structureId
+      name
+      level
+      parentId
+      parentTitle
+      tag
+      position
+      locationId
+    }
+  }
+}
+'''

--- a/tests/test_structure/test_update_structure.py
+++ b/tests/test_structure/test_update_structure.py
@@ -1,0 +1,29 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.structure.update_structure_fixtures import (
+    update_office_structure_mutation,
+    update_office_structure_mutation_response,
+    update_structure_invalid_id
+)
+
+
+class TestUpdateOfficeStructure(BaseTestCase):
+    def test_office_structure_update(self):
+        """
+        Test that an admin can update an office structure
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_office_structure_mutation,
+            update_office_structure_mutation_response
+        )
+
+    def test_update_non_existing_structures(self):
+        """
+        Tests that updating non existing structure throws an
+        error
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_structure_invalid_id,
+            'Structure not found'
+        )


### PR DESCRIPTION
#### What does this PR do?

Update an office structure

#### Description of Task to be completed?
This PR gives a user with admin privileges the ability to update a given office structure 

#### How should this be manually tested?
- git pull and checkout to the branch ft-update-office-structure-165931398
- run application
- Run the following mutation
```
mutation {
  updateOfficeStructure(structureId: "b05fc5f2-b4aa-4f48-a8fb-30bdcc3fc968", name:"St.Catherine's", level:3, parentTitle:"parent 5", tag:"offices", position:4, locationId:1, parentId:"2") {
    structure {
      structureId
      name
      level
      parentId
      parentTitle
      tag
      position
      locationId
    }
  }
}
```
#### What are the relevant pivotal tracker stories?
[165931398](https://www.pivotaltracker.com/story/show/165931398)

### Background context
* Create an office structure
* Ensure the structure id generated is the same one used for the mutation above

### Screenshots
<img width="1195" alt="Screenshot 2019-05-30 at 14 58 50" src="https://user-images.githubusercontent.com/27801956/58631967-d5100380-82ec-11e9-9b17-e82d9e0959d7.png">


### Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
