### PR TITLE
#166285961 search resource by name

### DIFF
--- a/fixtures/room_resource/resource_fixture.py
+++ b/fixtures/room_resource/resource_fixture.py
@@ -1,0 +1,80 @@
+null = None
+
+resource_query = '''
+        {
+            resourceByName(searchName: "Speakers") {
+                name
+                room {
+                    room {
+                        name
+                    }
+                    quantity
+                }
+            }
+        }
+    '''
+
+blank_resource_query = '''
+        {
+            resourceByName(searchName: "") {
+                name
+                room {
+                    room {
+                        name
+                    }
+                    quantity
+                }
+            }
+        }
+    '''
+
+resource_response = {
+    "data": {
+        "resourceByName": [
+            {
+                "name": "Speakers",
+                "room": []
+            }
+        ]
+    }
+}
+
+none_existing_resource_response = {
+    "errors": [
+        {
+            "message": "No Matching Resource",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 13
+                }
+            ],
+            "path": [
+                "resourceByName"
+            ]
+        }
+    ],
+    "data": {
+        "resourceByName": null
+    }
+}
+
+search_blank_name_response = {
+    "errors": [
+        {
+            "message": "Please input Resource Name",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 13
+                }
+            ],
+            "path": [
+                "resourceByName"
+            ]
+        }
+    ],
+    "data": {
+        "resourceByName": null
+    }
+}

--- a/tests/test_room_resource/test_resource_by_name.py
+++ b/tests/test_room_resource/test_resource_by_name.py
@@ -1,0 +1,44 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.room_resource.room_resource_fixtures import (
+    resource_mutation_query
+)
+from fixtures.room_resource.resource_fixture import (
+    resource_query,
+    blank_resource_query,
+    resource_response,
+    none_existing_resource_response,
+    search_blank_name_response
+)
+
+
+class TestResourceByName(BaseTestCase):
+    """
+    Test that an admin can query to get
+    a specific resource using resource name
+    """
+    def test_resource_by_name(self):
+        CommonTestCases.admin_token_assert_in(
+            self,
+            resource_mutation_query,
+            "Speakers"
+        )
+
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            resource_query,
+            resource_response
+        )
+
+    def test_none_existing_resource_name(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            resource_query,
+            none_existing_resource_response
+        )
+
+    def test_blank_resource_name(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            blank_resource_query,
+            search_blank_name_response
+        )


### PR DESCRIPTION
#### What does this PR do?
Enables an admin to search for a resource using resource name

#### Description of Task to be completed?
- query for a resource using resource name
- test query to fetch resource by name

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to `Readme.md`
3. checkout to branch `ft-search-resource-by-name-166285961`
3. on insomnia send query
 ```
 {
  resourceByName(name: "table") {
    name
    room {
      room {
        name
      }
      quantity
    }
  }
}
```
#### What are the relevant pivotal tracker stories?
[#166285961](https://www.pivotaltracker.com/story/show/166285961)
#### Screenshots (if appropriate)
<img width="948" alt="Screenshot 2019-05-29 at 14 37 06" src="https://user-images.githubusercontent.com/39084014/58555846-38cdfa00-8223-11e9-8e6c-fa493b2d05fe.png">

