### PR TITLE
#166332095 Add day of event to events query

### DIFF
--- a/fixtures/events/events_query_fixtures.py
+++ b/fixtures/events/events_query_fixtures.py
@@ -1,23 +1,28 @@
 query_events = '''
     query{
         allEvents(startDate: "Jul 9 2018", endDate: "Jul 20 2018"){
-            id
-            room{
-                name
+            day
+            events{
+                id
+                roomId
+                room{
+                    name
+                }
             }
-            eventTitle
         }
     }
 '''
 event_query_response = {
     'data': {
-        'allEvents':
-        [{
-            'id': '1',
-            'room': {
-                'name': 'Entebbe'
-                },
-            'eventTitle': 'Onboarding'
-        }]
+        'allEvents': [{
+            'day': 'Wed Jul 11 2018',
+            'events': [{
+                'id': '1',
+                'roomId': 1,
+                'room': {
+                    'name': 'Entebbe'
+                    }
+                }]
+            }]
+        }
     }
-}

--- a/helpers/calendar/analytics_helper.py
+++ b/helpers/calendar/analytics_helper.py
@@ -10,6 +10,8 @@ from helpers.auth.admin_roles import admin_roles
 from flask import request
 from flask_json import JsonError
 from api.events.models import Events as EventsModel
+import pytz
+from dateutil import parser
 
 
 class EventsDuration(graphene.ObjectType):
@@ -209,3 +211,19 @@ class CommonAnalytics:
             dates.remove(last_month)
         dates.append([last_month_start_date, end_date])
         return dates
+
+    @staticmethod
+    def get_all_events_and_dates(query, start_date, end_date):
+        all_events = query.filter(
+            EventsModel.state == 'active',
+            EventsModel.end_time < end_date,
+            EventsModel.start_time > start_date
+            ).all()
+        all_dates = []
+        for event in all_events:
+            CommonAnalytics.format_date(event.start_time)
+            event_start_date = parser.parse(
+                event.start_time).astimezone(pytz.utc)
+            day_of_event = event_start_date.strftime("%a %b %d %Y")
+            all_dates.append(day_of_event)
+        return all_events, all_dates


### PR DESCRIPTION
### What does this PR do?

Fix the events query

#### Description of Task to be completed?

At the moment, the events query returns all the events, this PR returns day and the events that took place on that day

#### How should this be manually tested?
- git pull and checkout to the branch bg-fix-events-query-166332095
-  run application
- Run the following query
```
query{
  allEvents(startDate: "may 20 2019", endDate: "may 29  2019"){
    day
    events{
      id
      roomId
      room{
        name
      }
    }
	}
}
```
#### What are the relevant pivotal tracker stories?
[166332095](https://www.pivotaltracker.com/story/show/166332095)

### Background information
None

### Screenshots
<img width="1193" alt="Screenshot 2019-05-29 at 18 48 24" src="https://user-images.githubusercontent.com/33450849/58571835-3380a780-8243-11e9-95d0-301b340dfdb1.png">


- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations


