### PR TITLE
#166374529 Restrict event query by location

### DIFF
--- a/helpers/calendar/events.py
+++ b/helpers/calendar/events.py
@@ -8,6 +8,7 @@ from graphql import GraphQLError
 
 from api.events.models import Events as EventsModel
 from api.room.models import Room as RoomModel
+from api.location.models import Location as LocationModel
 from .analytics_helper import CommonAnalytics
 from .credentials import Credentials, get_google_calendar_events
 
@@ -213,3 +214,14 @@ class CalendarEvents:
         rooms = RoomModel.query.filter_by(state='active')
         for room in rooms:
             self.sync_single_room_events(room)
+
+    def get_events_in_location(self, user, events):
+        events_in_location = []
+        location = LocationModel.query.filter_by(
+            name=user.location).first()
+        for event in events:
+            room = RoomModel.query.filter_by(
+                calendar_id=event.room.calendar_id).first()
+            if room.location_id == location.id:
+                events_in_location.append(event)
+        return events_in_location

--- a/tests/test_events/test_query_all_events.py
+++ b/tests/test_events/test_query_all_events.py
@@ -11,7 +11,7 @@ class TestEventsQuery(BaseTestCase):
         """
         Test a user can query for all events
         """
-        CommonTestCases.user_token_assert_equal(
+        CommonTestCases.admin_token_assert_equal(
             self,
             query_events,
             event_query_response


### PR DESCRIPTION
#### What does this PR do?
-This PR is to get daily events based on the location of the user making the request.

#### Description of Task to be completed?
- Refactor the query to return data based on user location
- Ensure existing tests pass

#### How should this be manually tested?
- Pull this branch `restrict-query-events-by-location-166374529`
- Add rooms from various locations and run sync data mutation to sync all events
- Run the following query 
```
query{
  allEvents(startDate: "Mar 28 2019", endDate: "Apr 28 2019"){
    day
    events{
      eventId
      eventTitle
    }
  }
}
```

#### Any background context you want to provide?
n/a

#### What are the relevant pivotal tracker stories?
[#166374529](https://www.pivotaltracker.com/story/show/166374529)