### PR TITLE
#166377619 Fix filter on rooms using room labels

### DIFF
--- a/api/room/schema.py
+++ b/api/room/schema.py
@@ -157,9 +157,10 @@ class PaginatedRooms(Paginate):
         page = self.page
         per_page = self.per_page
         filter_data = self.filter_data
+        location_id = admin_roles.user_location_for_analytics_view()
         query = Room.get_query(info)
         exact_query = room_filter(query, filter_data)
-        active_rooms = exact_query.filter(RoomModel.state == "active")
+        active_rooms = exact_query.filter(RoomModel.state == "active", RoomModel.location_id==location_id)
         if not page:
             return active_rooms.order_by(func.lower(RoomModel.name)).all()
         page = validate_page(page)

--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -118,7 +118,6 @@ class Query(graphene.ObjectType):
         per_page=graphene.Int(),
         capacity=graphene.Int(),
         resources=graphene.String(),
-        location=graphene.String(),
         office=graphene.String(),
         devices=graphene.String(),
         description="Returns a list of paginated rooms. Accepts the arguments\

--- a/fixtures/room/filter_room_fixtures.py
+++ b/fixtures/room/filter_room_fixtures.py
@@ -179,3 +179,32 @@ filter_rooms_by_invalid_tag_error_response = {
         "filterRoomsByTag": None
     }
 }
+
+filter_rooms_by_location_room_labels = '''query {
+  allRooms(location:"Kampala", roomLabels:""){
+   rooms{
+      name
+      capacity
+      roomType
+      imageUrl
+      roomLabels
+        }
+    }
+}
+    '''
+
+filter_rooms_by_location_room_labels_response = {
+    "data": {
+        "allRooms": {
+            "rooms": [
+                {
+                    "name": "Entebbe",
+                    "capacity": 6,
+                    "roomType": "meeting",
+                    "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",  # noqa: E501
+                    "roomLabels": ["1st Floor", "Wing A"]
+                }
+            ]
+        }
+    }
+}

--- a/helpers/room_filter/room_filter.py
+++ b/helpers/room_filter/room_filter.py
@@ -1,4 +1,4 @@
-from api.room.models import Room as RoomModel
+from api.room.models import Room as RoomModel, RoomResource
 from api.room_resource.models import Resource
 from api.location.models import Location
 from api.room.models import Room
@@ -13,7 +13,7 @@ def resource_join_location(query):
     :return
         queryset
     """
-    query_room = query.join(Resource.room)
+    query_room = query.join(RoomResource.room)
     query_location = query_room.join(Location)
     return query_location
 
@@ -40,6 +40,15 @@ def location_join_resources():
     return location_query
 
 
+def filter_room_labels(query, room_labels):
+    room_labels = room_labels.split(",")
+    for room_label in room_labels:
+        query = query.filter(func.lower(
+            cast(RoomModel.room_labels, String)).contains(
+                room_label.lower().strip()))
+    return query
+
+
 def room_filter(query, filter_data):  # noqa: ignore=C901
     """
     Filters for rooms by given specifics and
@@ -50,42 +59,23 @@ def room_filter(query, filter_data):  # noqa: ignore=C901
     :return
         List of rooms
     """
-    location = filter_data.pop("location", None)
+
     capacity = filter_data.pop("capacity", None)
     resources = filter_data.pop("resources", None)
     room_labels = filter_data.get("room_labels")
 
-    if location and not (resources or capacity):
-        query = room_join_location(query)
-        return query.filter(Location.name.ilike('%' + location + '%'))
-    elif capacity and not (resources or location):
+    if capacity and not (resources or room_labels):
         return query.filter(RoomModel.capacity == capacity)
-    elif resources and not (capacity or location):
-        query = query.join(Resource.room)
-        return query.filter(Resource.name.ilike('%' + resources + '%'))
-    elif (resources and capacity) and not location:
-        query = query.join(Resource.room)
-        query = query.filter(RoomModel.capacity == capacity)
-        return query.filter(Resource.name.ilike('%' + resources + '%'))
-    elif (capacity and location) and not resources:
-        query = room_join_location(query)
-        query = query.filter(RoomModel.capacity == capacity)
-        return query.filter(Location.name.ilike('%' + location + '%'))
-    elif (location and resources) and not capacity:
-        query = resource_join_location(query)
-        query = query.filter(Resource.name.ilike('%' + resources + '%'))
-        return query.filter(Location.name.ilike('%' + location + '%'))
-    elif (location and capacity and resources):
+    elif resources and not (capacity or room_labels):
+        query = query.join(RoomResource.room)
+        return query.filter(RoomResource.name.ilike('%' + resources + '%'))
+    elif capacity and not (resources or room_labels):
+        return query.filter(RoomModel.capacity == capacity)
+    elif capacity and resources:
         query = resource_join_location(query)
         query = query.filter(RoomModel.capacity == capacity)
-        query = query.filter(Resource.name.ilike('%' + resources + '%'))
-        return query.filter(Location.name.ilike('%' + location + '%'))
-    elif room_labels:
-        room_labels = room_labels.split(",")
-        for room_label in room_labels:
-            query = query.filter(func.lower(
-                cast(RoomModel.room_labels, String)).contains(
-                    room_label.lower().strip()))
-        return query
+        return query.filter(RoomResource.name.ilike('%' + resources + '%'))
+    elif room_labels and not (capacity or resources):
+        return filter_room_labels(query, room_labels)
     else:
         return query

--- a/tests/test_rooms/test_room_filter.py
+++ b/tests/test_rooms/test_room_filter.py
@@ -12,7 +12,9 @@ from fixtures.room.filter_room_fixtures import (
     filter_rooms_by_wings_and_floors,
     filter_rooms_by_wings_and_floors_response,
     filter_rooms_by_non_existent_room_label,
-    filter_rooms_by_non_existent_room_label_response
+    filter_rooms_by_non_existent_room_label_response,
+    filter_rooms_by_location_room_labels,
+    filter_rooms_by_location_room_labels_response
 )
 
 sys.path.append(os.getcwd())
@@ -53,4 +55,11 @@ class RoomsFilter(BaseTestCase):
             self,
             filter_rooms_by_non_existent_room_label,
             filter_rooms_by_non_existent_room_label_response
+        )
+
+    def test_filter_room_by_location_room_label(self):
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_location_room_labels,
+            filter_rooms_by_location_room_labels_response
         )


### PR DESCRIPTION
#### What does this PR do?

Fix the room filter to ensure that you can filter for rooms using room labels and location.

#### Description of Task to be completed?

Currently, when running the allRooms query using the `location` and `room label`, it will only filter based on location. Filtering on `room label` alone returns rooms with all the room labels specified. This PR seeks to fix this to ensure that you can query for both `location` and `room label`

#### How should this be manually tested?
- git pull and checkout to the branch bg-fix-room-filters-166377619
- run application
- Run the following query
```
query {
  allRooms(location:"Nairobi", roomLabels:"Office 1"){
   rooms{
      name
    	roomLabels
        }
    }
}
```
### What are the relevant pivotal tracker stories?
[166377619](https://www.pivotaltracker.com/story/show/166377619)

### Background information
- Ensure you have rooms present with at least 1 label.

### Screenshots

![image](https://user-images.githubusercontent.com/31338414/58709104-16beae00-83c2-11e9-88b9-4505cd81804f.png)


- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
