### PR TITLE
#166285928 Enable admin to query device by name

### DIFF
--- a/api/devices/schema.py
+++ b/api/devices/schema.py
@@ -103,6 +103,13 @@ class Query(graphene.ObjectType):
             \n- device_id: A unique identifier of the device"
     )
 
+    device_by_name = graphene.List(
+        Devices,
+        device_name=graphene.String(),
+        description="Returns device details and accepts the argument\
+            \n- device_name: The name of the device"
+    )
+
     def resolve_all_devices(self, info):
         query = Devices.get_query(info)
         location_id = admin_roles.user_location_for_analytics_view()
@@ -122,6 +129,19 @@ class Query(graphene.ObjectType):
             raise GraphQLError("Device not found")
 
         return device
+
+    @Auth.user_roles('Admin')
+    def resolve_device_by_name(self, info, device_name):
+        devices = Devices.get_query(info)
+        device_name = ''.join(device_name.split()).lower()
+        if not device_name:
+            raise GraphQLError("Please provide the device name")
+        found_devices = []
+        for device in devices:
+            exact_name = ''.join(device.name.split()).lower()
+            if device_name in exact_name:
+                found_devices.append(device)
+        return found_devices
 
 
 class Mutation(graphene.ObjectType):

--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -218,3 +218,34 @@ create_device_query_invalid_room = '''
 non_existant_id_response = "DeviceId not found"
 devices_query = '/mrm?query='+create_devices_query
 devices_query_response = b'{"data":{"createDevice":{"device":{"name":"Apple tablet","location":"Kenya","deviceType":"External Display"}}}}'  # noqaE501
+
+search_device_by_name = '''
+    query{
+        deviceByName(deviceName:"Samsung"){
+            id
+            name
+            deviceType
+        }
+    }
+'''
+
+search_non_existing_device = '''
+    query{
+        deviceByName(deviceName:"Apple"){
+            id
+            name
+            deviceType
+        }
+    }
+'''
+search_non_existing_device_response = {'data': {'deviceByName': []}}
+
+search_device_by_name_expected_response = {
+    'data': {
+        'deviceByName': [{
+            'id': '1',
+            'name': 'Samsung',
+            'deviceType': 'External Display'
+            }]
+        }
+    }

--- a/tests/test_devices/test_specific_device.py
+++ b/tests/test_devices/test_specific_device.py
@@ -5,10 +5,12 @@ from fixtures.devices.devices_fixtures import (
     query_non_existent_device,
     expected_error_non_existent_device_id
 )
-
-import sys
-import os
-sys.path.append(os.getcwd())
+from fixtures.devices.devices_fixtures import (
+    search_device_by_name,
+    search_non_existing_device,
+    search_device_by_name_expected_response,
+    search_non_existing_device_response
+)
 
 
 class TestGetSpecificDevice(BaseTestCase):
@@ -28,4 +30,18 @@ class TestGetSpecificDevice(BaseTestCase):
             self,
             query_non_existent_device,
             expected_error_non_existent_device_id
+        )
+
+    def test_search_device_by_name(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            search_device_by_name,
+            search_device_by_name_expected_response
+        )
+
+    def test_search_non_existing_device(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            search_non_existing_device,
+            search_non_existing_device_response
         )


### PR DESCRIPTION
### What does this PR do?

Enable admin to query device by name

#### Description of Task to be completed?

At the moment, one can query a device by id, this PR makes it possible to query a device by name

#### How should this be manually tested?
- git pull and checkout to the branch ft-query-device-by-name-166285928
-  run application
- Run the following query
```
query{
  deviceByName(deviceName:"apple tablet"){
    id
    name
    deviceType
    room{
      name
    }
  }
}
```
#### What are the relevant pivotal tracker stories?
[166285928](https://www.pivotaltracker.com/story/show/166285928)

### Background information
None

### Screenshots
<img width="1183" alt="Screenshot 2019-06-01 at 18 48 50" src="https://user-images.githubusercontent.com/33450849/58750661-f8c67b80-849d-11e9-85dd-295e5d15e553.png">



- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations


