### PR TITLE
#166285991 Allow admin to search users by name

### DIFF
--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -278,3 +278,50 @@ query {
     }
 }
 '''
+
+query_user_by_name = '''
+    query{
+        userByName(userName:"Peter Adeoye"){
+            name
+            email
+        }
+    }
+'''
+
+query_user_by_name_response = {
+    'data': {
+        'userByName': [{
+            'name': 'Peter Adeoye',
+            'email': 'peter.adeoye@andela.com'
+        }]
+    }
+}
+
+query_non_existing_user_by_name = '''
+    query{
+        userByName(userName:"unknown user"){
+            name
+            email
+        }
+    }
+'''
+
+query_non_existing_user_by_name_response = {
+    "errors": [
+        {
+            "message": "User not found",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 9
+                }
+            ],
+            "path": [
+                "userByName"
+            ]
+        }
+    ],
+    "data": {
+        "userByName": null
+    }
+}

--- a/tests/test_user/test_query_user.py
+++ b/tests/test_user/test_query_user.py
@@ -5,7 +5,9 @@ from fixtures.user.user_fixture import (
     paginated_users_query, paginated_users_response,
     get_users_by_location, get_users_by_location_and_role,
     get_user_by_role_reponse, get_users_by_role,
-    filter_user_by_location
+    filter_user_by_location,
+    query_user_by_name, query_user_by_name_response,
+    query_non_existing_user_by_name, query_non_existing_user_by_name_response
 )
 from helpers.database import db_session
 from api.user.models import User
@@ -76,7 +78,7 @@ class TestQueryUser(BaseTestCase):
         """
         CommonTestCases.admin_token_assert_equal(
             self, get_users_by_role, get_user_by_role_reponse
-            )
+        )
 
     def test_get_users_by_location_and_role(self):
         """
@@ -84,7 +86,7 @@ class TestQueryUser(BaseTestCase):
         """
         CommonTestCases.user_token_assert_in(
             self, get_users_by_location_and_role, "No users found"
-            )
+        )
 
     def test_query_users_by_location(self):
         """
@@ -94,4 +96,24 @@ class TestQueryUser(BaseTestCase):
             self,
             filter_user_by_location,
             "Location id does not exist"
+        )
+
+    def test_query_user_by_name(self):
+        """
+        Test query a user by name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_user_by_name,
+            query_user_by_name_response
+        )
+
+    def test_query_user_by_invalid_name(self):
+        """
+        Test query a user by invalid name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_non_existing_user_by_name,
+            query_non_existing_user_by_name_response
         )


### PR DESCRIPTION
### What does this PR do?

Allow admin to search users by name

#### Description of Task to be completed?

In order to ease navigating to a specific user, this PR makes it possible to search for a specific user by name

#### How should this be manually tested?
- git pull and checkout to the branch ft-query-user-by-name-166285991
-  run application
- Run the following query
```
query{
  userByName(userName:"onyeka mmakwe"){
     email
     name
     location
  }
}

```
#### What are the relevant pivotal tracker stories?
[166285991](https://www.pivotaltracker.com/story/show/166285991)

### Background information
None

### Screenshots
<img width="1193" alt="Screenshot 2019-06-04 at 12 02 13 AM" src="https://user-images.githubusercontent.com/27890903/58840069-3244e580-865c-11e9-8619-f077abf5699d.png">

- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

