### PR TITLE
#166323569 Paginate daily room events (#419)

### DIFF
--- a/api/events/schema.py
+++ b/api/events/schema.py
@@ -10,6 +10,7 @@ from helpers.calendar.credentials import get_single_calendar_event
 from helpers.auth.authentication import Auth
 from helpers.calendar.analytics_helper import CommonAnalytics
 from helpers.auth.user_details import get_user_from_db
+from helpers.pagination.paginate import ListPaginate
 import pytz
 from dateutil import parser
 from datetime import datetime
@@ -218,15 +219,30 @@ class Mutation(graphene.ObjectType):
              event[required]")
 
 
+class PaginatedDailyRoomEvents(graphene.ObjectType):
+    """
+    Paginated result for daily room events
+    """
+    DailyRoomEvents = graphene.List(DailyRoomEvents)
+    has_previous = graphene.Boolean()
+    has_next = graphene.Boolean()
+    pages = graphene.Int()
+    query_total = graphene.Int()
+
+
 class Query(graphene.ObjectType):
-    all_events = graphene.List(
-        DailyRoomEvents,
+    all_events = graphene.Field(
+        PaginatedDailyRoomEvents,
         start_date=graphene.String(),
         end_date=graphene.String(),
-        description="Query that returns daily room events")
+        page=graphene.Int(),
+        per_page=graphene.Int(),
+        description="Query that returns paginated daily room events")
 
     @Auth.user_roles('Admin', 'Default User')
     def resolve_all_events(self, info, **kwargs):
+        page = kwargs.get('page')
+        per_page = kwargs.get('per_page')
         user = get_user_from_db()
         start_date, end_date = CommonAnalytics.all_analytics_date_validation(
             self, kwargs['start_date'], kwargs['end_date']
@@ -254,4 +270,23 @@ class Query(graphene.ObjectType):
                 )
             )
             all_days_events.sort(key=lambda x: datetime.strptime(x.day, "%a %b %d %Y"), reverse=True) # noqa
-        return all_days_events
+        if page and per_page:
+            if per_page < 1:
+                raise GraphQLError("per_page must be at least 1")
+            paginated_events = ListPaginate(
+                iterable=all_days_events,
+                per_page=per_page,
+                page=page)
+            has_previous = paginated_events.has_previous
+            has_next = paginated_events.has_next
+            current_page = paginated_events.current_page
+            pages = paginated_events.pages
+            query_total = paginated_events.query_total
+            return PaginatedDailyRoomEvents(
+                                     DailyRoomEvents=current_page,
+                                     has_previous=has_previous,
+                                     has_next=has_next,
+                                     query_total=query_total,
+                                     pages=pages)
+
+        return PaginatedDailyRoomEvents(DailyRoomEvents=all_days_events)

--- a/fixtures/events/events_query_fixtures.py
+++ b/fixtures/events/events_query_fixtures.py
@@ -1,12 +1,14 @@
 query_events = '''
     query{
         allEvents(startDate: "Jul 9 2018", endDate: "Jul 20 2018"){
-            day
-            events{
-                id
-                roomId
-                room{
-                    name
+            DailyRoomEvents {
+                day
+                events{
+                    id
+                    roomId
+                    room{
+                        name
+                    }
                 }
             }
         }
@@ -14,15 +16,62 @@ query_events = '''
 '''
 event_query_response = {
     'data': {
-        'allEvents': [{
-            'day': 'Wed Jul 11 2018',
-            'events': [{
-                'id': '1',
-                'roomId': 1,
-                'room': {
-                    'name': 'Entebbe'
-                    }
-                }]
+        'allEvents': {
+            'DailyRoomEvents': [{
+                'day': 'Wed Jul 11 2018',
+                'events': [{
+                    'id': '1',
+                    'roomId': 1,
+                    'room': {
+                        'name': 'Entebbe'
+                        }
+                    }]
             }]
         }
     }
+}
+
+query_events_with_pagination = '''
+    query{
+        allEvents(startDate: "Jul 9 2018",
+                  endDate: "Jul 20 2018",
+                  page:1,
+                  perPage: 2){
+            DailyRoomEvents {
+                day
+                events{
+                    id
+                    roomId
+                    room{
+                        name
+                    }
+                }
+            },
+            hasNext,
+            hasPrevious,
+            pages,
+            queryTotal
+        }
+    }
+'''
+
+event_query_with_pagination_response = {
+    'data': {
+        'allEvents': {
+            'DailyRoomEvents': [{
+                'day': 'Wed Jul 11 2018',
+                'events': [{
+                    'id': '1',
+                    'roomId': 1,
+                    'room': {
+                        'name': 'Entebbe'
+                        }
+                    }]
+            }],
+            'hasNext': False,
+            'hasPrevious': False,
+            'pages': 1,
+            'queryTotal': 1
+        }
+    }
+}

--- a/tests/test_events/test_query_all_events.py
+++ b/tests/test_events/test_query_all_events.py
@@ -1,7 +1,9 @@
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.events.events_query_fixtures import (
     query_events,
-    event_query_response
+    event_query_response,
+    query_events_with_pagination,
+    event_query_with_pagination_response
 )
 
 
@@ -15,4 +17,14 @@ class TestEventsQuery(BaseTestCase):
             self,
             query_events,
             event_query_response
+        )
+
+    def test_query_events_with_pagination(self):
+        """
+        Test a user can query for all events with pagination
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_events_with_pagination,
+            event_query_with_pagination_response
         )


### PR DESCRIPTION
### What does this PR do?
With this PR, we can query for paginated daily room events

#### Description of Task to be completed?

Currently, the query for daily room events is not paginated. We want to paginate this query.

#### How should this be manually tested?
- Run the following query for paginated daily room events
```
query{
  allEvents(startDate: "Mar 28 2019", endDate: "Mar 29 2019", page:1, perPage: 1){
    DailyRoomEvents {
       day
       events {
          eventTitle
       }
      }
    hasNext
    hasPrevious
    pages
    queryTotal
  }
}

```
#### What are the relevant pivotal tracker stories?
[166323569](https://www.pivotaltracker.com/story/show/166323569)

### Background information
None

![image](https://user-images.githubusercontent.com/12197866/58803991-a8b7f800-8608-11e9-8ef0-0bd9fad349c5.png)


- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations


