### PR TITLE
#165907624 Refactor create device mutation

### DIFF
--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -87,8 +87,7 @@ create_devices_query = '''
             createDevice(
                 name:"Apple tablet",
                 deviceType:"External Display",
-                roomId:1,
-                location:"Kenya",
+                roomId:1
             ){
                 device{
                 name
@@ -104,7 +103,7 @@ expected_create_devices_response = {
                                             "createDevice": {
                                                 "device": {
                                                     "name": "Apple tablet",
-                                                    "location": "Kenya",
+                                                    "location": "Kampala",
                                                     "deviceType": "External Display"  # noqa : E501
                                                     }
                                                     }
@@ -116,8 +115,7 @@ mutation{
             createDevice(
                 name:"Apple tablet",
                 deviceType:"External Display",
-                roomId:4,
-                location:"Kenya",
+                roomId:4
             ){
                 device{
                 name
@@ -203,8 +201,7 @@ create_device_query_invalid_room = '''
             createDevice(
                 name:"Apple tablet",
                 deviceType:"External Display",
-                roomId:6,
-                location:"Kenya",
+                roomId:6
             ){
                 device{
                 name
@@ -249,3 +246,4 @@ search_device_by_name_expected_response = {
             }]
         }
     }
+devices_query_response = b'{"data":{"createDevice":{"device":{"name":"Apple tablet","location":"Kampala","deviceType":"External Display"}}}}'  # noqaE501

--- a/tests/test_devices/test_create_device.py
+++ b/tests/test_devices/test_create_device.py
@@ -2,7 +2,6 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.devices.devices_fixtures import (
     devices_query,
     devices_query_response,
-    create_devices_query,
     create_device_query_invalid_room
 )
 
@@ -22,16 +21,6 @@ class TestCreateDevice(BaseTestCase):
         headers = {"Authorization": "Bearer" + " " + ADMIN_TOKEN}
         query = self.app_test.post(devices_query, headers=headers)
         self.assertEqual(query.data, devices_query_response)
-
-    def test_create_device_in_room_that_is_not_in_admin_location(self):
-        """
-        Test for creation of device in a different location
-        """
-        CommonTestCases.lagos_admin_token_assert_in(
-            self,
-            create_devices_query,
-            "You are not authorized to make changes in Kampala"
-        )
 
     def test_create_device_in_nonexistent_room_throws_errors(self):
         """


### PR DESCRIPTION

#### What does this PR do?
- Sets device location to location from admin's token
- Removes location field from createDevice mutation

#### Description of Task to be completed?
When an admin is adding a new device, the device location field should be set to the location that is in the admin's token.

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `ch-refactor-create-device-165907624`
3. run the following query:

```
mutation {
  createDevice (
    name: "samsung s3rt7",
    roomId: 1,
    deviceType: "tablet"
  ) {
    device {
      name
      location
    }
  }
}
```

#### Screenshots
![image](https://user-images.githubusercontent.com/26174035/58472662-a5bb9400-813e-11e9-86bd-245e10a974da.png)

### What are the relevant pivotal tracker stories?
[#165907624](https://www.pivotaltracker.com/story/show/165907624)


The `location` field would be the location in your token.

- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

