### PR TITLE
#166377619 Fix filter on rooms using room labels

### DIFF
--- a/fixtures/room/filter_room_fixtures.py
+++ b/fixtures/room/filter_room_fixtures.py
@@ -179,3 +179,69 @@ filter_rooms_by_invalid_tag_error_response = {
         "filterRoomsByTag": None
     }
 }
+
+filter_rooms_by_room_labels = '''query {
+  allRooms(roomLabels:"Wing"){
+   rooms{
+      name
+      capacity
+      roomType
+      imageUrl
+      roomLabels
+        }
+    }
+}
+    '''
+
+filter_rooms_by_room_labels_response = {
+    "data": {
+        "allRooms": {
+            "rooms": [
+                {
+                    "name": "Entebbe",
+                    "capacity": 6,
+                    "roomType": "meeting",
+                    "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",  # noqa: E501
+                    "roomLabels": ["1st Floor", "Wing A"]
+                }
+            ]
+        }
+    }
+}
+filter_rooms_by_location_room_labels = '''query {
+  allRooms(roomLabels:"Wing", location:"Kampala"){
+   rooms{
+      name
+      capacity
+      roomType
+      imageUrl
+      roomLabels
+        }
+    }
+}
+    '''
+filter_rooms_by_resource = '''query {
+  allRooms(resources:"Markers"){
+   rooms{
+      name
+      capacity
+      roomType
+      imageUrl
+      roomLabels
+        }
+    }
+}
+    '''
+
+filter_rooms_by_location_resource = '''query {
+  allRooms(resources:"Markers", location:"Kampala"){
+   rooms{
+      name
+      capacity
+      roomType
+      imageUrl
+      roomLabels
+        }
+    }
+}
+    '''

--- a/helpers/auth/authentication.py
+++ b/helpers/auth/authentication.py
@@ -28,7 +28,10 @@ class Authentication:
     """
 
     def get_token(self):
-        token = request.headers['Authorization'].split()[1]
+        try:
+            token = request.headers['Authorization'].split()[1]
+        except BaseException:
+            token = None
         return token
 
     def decode_token(self):

--- a/tests/test_rooms/test_query_rooms.py
+++ b/tests/test_rooms/test_query_rooms.py
@@ -26,10 +26,11 @@ class QueryRooms(BaseTestCase):
         self.assertEqual(execute_query, expected_response)
 
     def test_paginate_room_query(self):
-        response = self.app_test.post('/mrm?query='+paginated_rooms_query)
-        paginate_query = json.loads(response.data)
-        expected_response = paginated_rooms_response
-        self.assertEqual(paginate_query, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            paginated_rooms_query,
+            paginated_rooms_response
+        )
 
     @patch("api.room.schema_query.get_google_api_calendar_list", spec=True,
            return_value=get_calendar_list_mock_data())

--- a/tests/test_rooms/test_room_filter.py
+++ b/tests/test_rooms/test_room_filter.py
@@ -12,8 +12,17 @@ from fixtures.room.filter_room_fixtures import (
     filter_rooms_by_wings_and_floors,
     filter_rooms_by_wings_and_floors_response,
     filter_rooms_by_non_existent_room_label,
-    filter_rooms_by_non_existent_room_label_response
+    filter_rooms_by_non_existent_room_label_response,
+    filter_rooms_by_room_labels,
+    filter_rooms_by_room_labels_response,
+    filter_rooms_by_location_room_labels,
+    filter_rooms_by_resource,
+    filter_rooms_by_location_resource
 )
+from fixtures.room.assign_resource_fixture import (
+    assign_resource_mutation,
+    assign_resource_mutation_response
+    )
 
 sys.path.append(os.getcwd())
 
@@ -53,4 +62,42 @@ class RoomsFilter(BaseTestCase):
             self,
             filter_rooms_by_non_existent_room_label,
             filter_rooms_by_non_existent_room_label_response
+        )
+
+    def test_filter_room_by_location_room_label(self):
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_location_room_labels,
+            filter_rooms_by_room_labels_response
+        )
+
+    def test_filter_room_by_room_label(self):
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_room_labels,
+            filter_rooms_by_room_labels_response
+        )
+
+    def test_filter_room_by_resource(self):
+        CommonTestCases.admin_token_assert_equal(
+           self,
+           assign_resource_mutation,
+           assign_resource_mutation_response,
+        )
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_resource,
+            filter_rooms_by_room_labels_response
+        )
+
+    def test_filter_room_by_location_resource(self):
+        CommonTestCases.admin_token_assert_equal(
+           self,
+           assign_resource_mutation,
+           assign_resource_mutation_response,
+        )
+        CommonTestCases.user_token_assert_equal(
+            self,
+            filter_rooms_by_location_resource,
+            filter_rooms_by_room_labels_response
         )


### PR DESCRIPTION
#### What does this PR do?

Fix the room filter to ensure that you can filter for rooms using room labels.

#### Description of Task to be completed?

Currently, when running the allRooms query using the `location` and `room label`, it will only filter based on location. Filtering on `room label` alone returns rooms with all the room labels specified. This PR seeks to fix this to ensure that you can query for `room label`. The location will automatically be fetched from the user's token since we only want users to filter based off a user's location. In the event that a user does not provide a token, we will return a list of all rooms available. We also fix fetching a resource by fixing the logic that checks for room resources in a room rather than resources in the database.

#### How should this be manually tested?
- git pull and checkout to the branch bg-fix-room-filters-166377619
- run application
- Run the following query. Take note of the `locationId` and ensure that it only returns room in your location.
```
query {
  allRooms(roomLabels:"Office 1"){
   rooms{
        name
    	roomLabels
        locationId
        }
    }
}
```
- Run the following query to get resources in a room.
```
query {
  allRooms(resources:"pen"){
   rooms{
      name
    capacity
      roomType
      imageUrl
      locationId
      roomLabels
  }
}
}
```
- Rerun the same query without the token to get a list of all rooms. Take note of the `locationId` and ensure that it only returns all rooms in the database.
### What are the relevant pivotal tracker stories?
[166377619](https://www.pivotaltracker.com/story/show/166377619)

### Background information
- Ensure you have rooms present with at least 1 label.
- Ensure you have a resource assigned to a room.

### Screenshots

#### Room Labels with a user token
![image](https://user-images.githubusercontent.com/31338414/59049383-8506e300-8890-11e9-835c-8597e61bd46d.png)

#### Room Labels without a user token
![image](https://user-images.githubusercontent.com/31338414/59049396-8a642d80-8890-11e9-81c0-c1cfda8ccc90.png)


- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
