### PR TITLE
#166323569 Paginate daily room events

### DIFF
--- a/fixtures/events/events_query_fixtures.py
+++ b/fixtures/events/events_query_fixtures.py
@@ -1,12 +1,14 @@
 query_events = '''
     query{
         allEvents(startDate: "Jul 9 2018", endDate: "Jul 20 2018"){
-            day
-            events{
-                id
-                roomId
-                room{
-                    name
+            DailyRoomEvents {
+                day
+                events{
+                    id
+                    roomId
+                    room{
+                        name
+                    }
                 }
             }
         }
@@ -14,15 +16,225 @@ query_events = '''
 '''
 event_query_response = {
     'data': {
-        'allEvents': [{
-            'day': 'Wed Jul 11 2018',
-            'events': [{
-                'id': '1',
-                'roomId': 1,
-                'room': {
-                    'name': 'Entebbe'
-                    }
-                }]
+        'allEvents': {
+            'DailyRoomEvents': [{
+                'day': 'Wed Jul 11 2018',
+                'events': [{
+                    'id': '1',
+                    'roomId': 1,
+                    'room': {
+                        'name': 'Entebbe'
+                        }
+                    }]
             }]
         }
     }
+}
+
+query_events_with_pagination = '''
+    query{
+        allEvents(startDate: "Jul 9 2018",
+                  endDate: "Jul 20 2018",
+                  page:1,
+                  perPage: 2){
+            DailyRoomEvents {
+                day
+                events{
+                    id
+                    roomId
+                    room{
+                        name
+                    }
+                }
+            },
+            hasNext,
+            hasPrevious,
+            pages,
+            queryTotal
+        }
+    }
+'''
+
+event_query_with_pagination_response = {
+    'data': {
+        'allEvents': {
+            'DailyRoomEvents': [{
+                'day': 'Wed Jul 11 2018',
+                'events': [{
+                    'id': '1',
+                    'roomId': 1,
+                    'room': {
+                        'name': 'Entebbe'
+                        }
+                    }]
+            }],
+            'hasNext': False,
+            'hasPrevious': False,
+            'pages': 1,
+            'queryTotal': 1
+        }
+    }
+}
+
+query_events_page_without_per_page = '''
+query{
+  allEvents(startDate: "Mar 28 2019", endDate: "Mar 29 2019", page: 1){
+    DailyRoomEvents {
+      day
+      events {
+        eventTitle
+      }
+    }
+    hasNext
+    hasPrevious
+    pages
+    queryTotal
+
+  }
+}
+'''
+
+event_query_page_without_per_page_response = {
+  "errors": [
+    {
+      "message": "perPage argument missing",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "allEvents"
+      ]
+    }
+  ],
+  "data": {
+    "allEvents": None
+  }
+}
+
+query_events_per_page_without_page = '''
+query{
+  allEvents(startDate: "Mar 28 2019", endDate: "Mar 29 2019", perPage: 1){
+    DailyRoomEvents {
+      day
+      events {
+        eventTitle
+      }
+    }
+    hasNext
+    hasPrevious
+    pages
+    queryTotal
+
+  }
+}
+'''
+
+event_query_perPage_without_page_response = {
+  "errors": [
+    {
+      "message": "page argument missing",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "allEvents"
+      ]
+    }
+  ],
+  "data": {
+    "allEvents": None
+  }
+}
+
+
+query_events_invalid_page = '''
+query{
+  allEvents(
+      startDate: "Mar 28 2019",
+      endDate: "Mar 29 2019",
+      page: 0,
+      perPage:1
+      ){
+    DailyRoomEvents {
+      day
+      events {
+        eventTitle
+      }
+    }
+    hasNext
+    hasPrevious
+    pages
+    queryTotal
+
+  }
+}
+'''
+
+event_query_invalid_page_response = {
+  "errors": [
+    {
+      "message": "page must be at least 1",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "allEvents"
+      ]
+    }
+  ],
+  "data": {
+    "allEvents": None
+  }
+}
+
+query_events_invalid_per_page = '''
+query{
+  allEvents(
+      startDate: "Mar 28 2019",
+      endDate: "Mar 29 2019",
+      page: 1,
+      perPage:0
+      ){
+    DailyRoomEvents {
+      day
+      events {
+        eventTitle
+      }
+    }
+    hasNext
+    hasPrevious
+    pages
+    queryTotal
+
+  }
+}
+'''
+
+event_query_invalid_per_page_response = {
+  "errors": [
+    {
+      "message": "perPage must be at least 1",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "allEvents"
+      ]
+    }
+  ],
+  "data": {
+    "allEvents": None
+  }
+}

--- a/tests/test_events/test_query_all_events.py
+++ b/tests/test_events/test_query_all_events.py
@@ -1,7 +1,17 @@
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.events.events_query_fixtures import (
     query_events,
-    event_query_response
+    event_query_response,
+    query_events_with_pagination,
+    event_query_with_pagination_response,
+    query_events_page_without_per_page,
+    event_query_page_without_per_page_response,
+    query_events_per_page_without_page,
+    event_query_perPage_without_page_response,
+    query_events_invalid_page,
+    event_query_invalid_page_response,
+    query_events_invalid_per_page,
+    event_query_invalid_per_page_response
 )
 
 
@@ -15,4 +25,54 @@ class TestEventsQuery(BaseTestCase):
             self,
             query_events,
             event_query_response
+        )
+
+    def test_query_events_with_pagination(self):
+        """
+        Test a user can query for all events with pagination
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_events_with_pagination,
+            event_query_with_pagination_response
+        )
+
+    def test_query_events_missing_per_page(self):
+        """
+        Test to show that per_page is required if page is supplied
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_events_page_without_per_page,
+            event_query_page_without_per_page_response
+        )
+
+    def test_query_events_missing_page(self):
+        """
+        Test to show that page is required if per_page is supplied
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_events_per_page_without_page,
+            event_query_perPage_without_page_response
+        )
+
+    def test_query_events_invalid_page(self):
+        """
+        Test to show that page must be a positive integer
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_events_invalid_page,
+            event_query_invalid_page_response
+        )
+
+    def test_query_events_invalid_per_page(self):
+        """
+        Test to show that per_page must be a positive integer
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_events_invalid_per_page,
+            event_query_invalid_per_page_response
         )


### PR DESCRIPTION
### What does this PR do?
With this PR, we can query for paginated daily room events

#### Description of Task to be completed?

Currently, the query for daily room events is not paginated. We want to paginate this query.

#### How should this be manually tested?
- Run the following query for paginated daily room events
```
query{
  allEvents(startDate: "Mar 28 2019", endDate: "Mar 29 2019", page:1, perPage: 1){
    DailyRoomEvents {
       day
       events {
          eventTitle
       }
      }
    hasNext
    hasPrevious
    pages
    queryTotal
  }
}

```
#### What are the relevant pivotal tracker stories?
[166323569](https://www.pivotaltracker.com/story/show/166323569)

### Background information
None

![image](https://user-images.githubusercontent.com/12197866/58803991-a8b7f800-8608-11e9-8ef0-0bd9fad349c5.png)


- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations


