### PR TITLE
#166496472 Fix office structures query

### DIFF
--- a/api/structure/schema.py
+++ b/api/structure/schema.py
@@ -116,6 +116,7 @@ class Query(graphene.ObjectType):
         query = Structure.get_query(info)
         location_id = admin_roles.user_location_for_analytics_view()
         all_structures = query.filter(
+            StructureModel.state == "active",
             StructureModel.location_id == location_id).all()
         return all_structures
 


### PR DESCRIPTION
#### What does this PR do?

Fix the office structures query to return active structures only

#### Description of Task to be completed?

When the office structures query was worked on, the state column was not present and it queries all structures regardless of the state, this PR makes sure we return active structures only

#### How should this be manually tested?
- git pull and checkout to the branch 
- run application
- Run the following query
```
query{
  allStructures{
    id
    state
  }
}
```
### What are the relevant pivotal tracker stories?
[166496472](https://www.pivotaltracker.com/story/show/166496472)
### Background information
None

### Screenshots
N/A

- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations
