### PR TITLE
#166409352 Implement resource filtering by labels

### DIFF
--- a/fixtures/room_resource/get_room_resource_fixtures.py
+++ b/fixtures/room_resource/get_room_resource_fixtures.py
@@ -1,4 +1,25 @@
 null = None
+filter_resources_by_labels = '''
+    query {
+        allResources(resourceLabels:"1st Floor, Wing A"){
+                    resources{
+                      name
+                    }
+              }
+        }
+'''
+
+filter_resources_by_labels_response = {
+    "data": {
+        "allResources": {
+            "resources": [
+                {
+                    "name": "Markers"
+                }
+            ]
+        }
+    }
+}
 
 resource_query = '''
     query {
@@ -47,18 +68,18 @@ get_paginated_room_resources = '''
 '''
 
 get_paginated_room_resources_response = {
-  "data": {
-    "allResources": {
-      "resources": [
-        {
-          "name": "Markers"
+    "data": {
+        "allResources": {
+            "resources": [
+                {
+                    "name": "Markers"
+                }
+            ],
+            "hasNext": False,
+            "hasPrevious": False,
+            "pages": 1
         }
-      ],
-      "hasNext": False,
-      "hasPrevious": False,
-      "pages": 1
     }
-  }
 }
 
 filter_unique_resources = '''
@@ -151,16 +172,16 @@ query
 }'''
 
 get_resource_by_room_id_response_by_admin = {
-  "data": {
-    "getResourcesByRoomId": {
-      "roomResources": [
-        {
-          "name": "Markers",
-          "id": "1"
+    "data": {
+        "getResourcesByRoomId": {
+            "roomResources": [
+                {
+                    "name": "Markers",
+                    "id": "1"
+                }
+            ]
         }
-      ]
     }
-  }
 }
 
 get_resource_by_non_existing_room_id = '''

--- a/helpers/room_filter/room_filter.py
+++ b/helpers/room_filter/room_filter.py
@@ -1,5 +1,6 @@
 from api.room.models import Room as RoomModel, RoomResource
 from api.room_resource.models import Resource
+from api.room.models import RoomResource as RoomResourceModel
 from api.location.models import Location
 from api.room.models import Room
 from sqlalchemy import String, func, cast
@@ -28,6 +29,19 @@ def room_join_location(query):
     """
     query_location = query.join(Location.rooms)
     return query_location
+
+
+def room_resources_join_room(query):
+    """
+    Join room_resources model upto room model via foreign keys
+    :param
+        queryset
+    :return
+        queryset
+    """
+    assigned_resources_query = query.join(RoomResourceModel).join(
+        RoomModel).filter(RoomModel.state == "active")
+    return assigned_resources_query
 
 
 def location_join_room():

--- a/tests/test_room_resource/test_get_resource_list.py
+++ b/tests/test_room_resource/test_get_resource_list.py
@@ -12,12 +12,14 @@ from fixtures.room_resource.get_room_resource_fixtures import (
     get_paginated_resources_inexistent_page,
     get_resource_by_room_id,
     get_resource_by_room_id_response_by_admin,
-    get_resource_by_non_existing_room_id
+    get_resource_by_non_existing_room_id,
+    filter_resources_by_labels,
+    filter_resources_by_labels_response
 )
 from fixtures.room.assign_resource_fixture import (
     assign_resource_mutation,
     assign_resource_mutation_response
-    )
+)
 from helpers.database import db_session
 from fixtures.token.token_fixture import USER_TOKEN
 
@@ -71,9 +73,9 @@ class TestGetRoomResource(BaseTestCase):
         '''
         # assign resource to a room
         CommonTestCases.admin_token_assert_equal(
-           self,
-           assign_resource_mutation,
-           assign_resource_mutation_response,
+            self,
+            assign_resource_mutation,
+            assign_resource_mutation_response,
         )
         CommonTestCases.admin_token_assert_equal(
             self,
@@ -101,4 +103,21 @@ class TestGetRoomResource(BaseTestCase):
             self,
             get_resource_by_room_id,
             "You are not authorized to perform this action"
+        )
+
+    def test_filter_room_resource_by_labels(self):
+        '''
+            Test filtering room resources by labels like
+            buildings, floor, wings
+        '''
+        # assign resource to a room
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            assign_resource_mutation,
+            assign_resource_mutation_response,
+        )
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            filter_resources_by_labels,
+            filter_resources_by_labels_response
         )


### PR DESCRIPTION
### What does this PR do?
Enables an admin to filter resources by labels like buildings, floors, wings.

### Description of the task to be completed?
- Add tests
- Add `resourceLabels` to query to enable filtering by building, floors or wings.

### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Cd into the cloned repo and checkout to `ft-filter-assigned-resources-by-wings-floors-building-166409352` branch
3. Run the migration to setup the database (if you haven’t)  
5. Run the query below to filter resource by labels
```
{
  allResources(resourceLabels:"Office 1"){
    resources{
      name
    }
  }
}
```

### Any background context you want to provide?
Currently, the `allResources` query returns a list of all resources in the platform. This PR introduces a filter mechanism using the labels like building, floors or wings to filter resources (usually assigned to a room) that match the filter criteria. The `resourceLabels` argument takes a string that can be comma separated.

### Screenshot
<img width="1298" alt="Screenshot 2019-06-06 at 7 20 05 PM" src="https://user-images.githubusercontent.com/13919080/59056451-26416980-8890-11e9-819a-0a991a7d16d2.png">


### What are the relevant pivotal tracker stories?
[#166409352](https://www.pivotaltracker.com/story/show/166409352)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations