### PR TITLE
#166409230 Enable Admins filter devices by labels

### DIFF
--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -26,6 +26,24 @@ expected_response_devices = {
                                             }
                                             }
 
+query_devices_with_filter = '''
+        {
+        allDevices(deviceLabels: "1st Floor"){
+            id
+            lastSeen
+            dateAdded
+            name
+            location
+        }
+        }
+        '''
+
+expected_response_devices_with_filter = {
+                                "data": {
+                                    "allDevices": []
+                                    }
+                                }
+
 query_device = '''
         {
         specificDevice(deviceId: 1){

--- a/tests/test_devices/test_all_devices.py
+++ b/tests/test_devices/test_all_devices.py
@@ -1,7 +1,9 @@
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.devices.devices_fixtures import (
     query_devices,
-    expected_response_devices
+    query_devices_with_filter,
+    expected_response_devices,
+    expected_response_devices_with_filter
 )
 
 import sys
@@ -19,4 +21,11 @@ class TestAllDevices(BaseTestCase):
             self,
             query_devices,
             expected_response_devices
+        )
+
+    def test_all_devices_with_filter(self):
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_devices_with_filter,
+            expected_response_devices_with_filter
         )


### PR DESCRIPTION
#### What does this PR do?
Enable Admins filter devices by labels

#### Description of Task to be completed?
When an admin passes the `device_labels` field in the `allDevices` query, it filters the devices based on that label or labels (separated in commas).

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `ft-enable-admin-filter-devices-166409230`
3. run the following query:
```

query {
  allDevices(
    deviceLabels: "1st Floor"
  ){
    name
  }
}


```
#### Screenshots

![image](https://user-images.githubusercontent.com/26174035/59257490-f3032f80-8c2d-11e9-86f3-256d2f4489b8.png)


### What are the relevant pivotal tracker stories?
[#165907624](https://www.pivotaltracker.com/story/show/166409230)


The `location` field would be the location in your token.

- [x]  My code follows the style guidelines of this project
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have linted my code prior to submission
- [x] Implementation works according to expectations```