### PR TITLE
#166539920 update device last seen to equal checkin time value

### DIFF
--- a/fixtures/analytics/query_all_analytics_fixtures.py
+++ b/fixtures/analytics/query_all_analytics_fixtures.py
@@ -54,6 +54,23 @@ all_analytics_query_response = {
               "durationInMinutes": 45
             }
           ]
+        },
+        {
+          "roomName": "Tana",
+          "cancellations": 0,
+          "cancellationsPercentage": 0.0,
+          "autoCancellations": 0,
+          "numberOfBookings": 0,
+          "checkins": 0,
+          "checkinsPercentage": 0.0,
+          "bookingsPercentageShare": 0.0,
+          "appBookings": 0,
+          "appBookingsPercentage": 0.0,
+          "events": [
+            {
+              "durationInMinutes": 0
+            }
+          ]
         }
       ],
       "bookingsCount": [

--- a/fixtures/events/event_checkin_fixtures.py
+++ b/fixtures/events/event_checkin_fixtures.py
@@ -38,6 +38,28 @@ event_checkin_response = {
     }
 }
 
+event_2_checkin_mutation = '''mutation {
+    eventCheckin(
+        calendarId:"andela.com_3730313534393638323232@resource.calendar.google.com",
+        eventId:"test_id6", eventTitle:"Onboarding 2", numberOfParticipants: 4,
+        startTime:"2019-07-10T09:00:00Z",
+        endTime:"2018-07-10T09:45:00Z",
+        checkInTime:"2018-07-10T09:00:00Z"){
+            event{
+                eventId
+                roomId
+                checkedIn
+                cancelled
+                room{
+                    id
+                    name
+                    calendarId
+                }
+            }
+        }
+    }
+'''
+
 wrong_calendar_id_checkin_mutation = '''mutation {
     eventCheckin(
         calendarId:"fake_calendar_id",
@@ -83,6 +105,29 @@ cancel_event_mutation = '''
 '''
 
 cancel_event_respone = "Event cancelled but email not sent"
+
+cancel_event_invalid_start_time = '''
+    mutation {
+        cancelEvent(
+        calendarId:"andela.com_3630363835303531343031@resource.calendar.google.com",
+        eventId:"test_id5", eventTitle:"Onboarding", numberOfParticipants: 4,
+        startTime:"invalid",
+        endTime:"2018-07-10T09:45:00Z")
+        {
+            event{
+                eventId
+                roomId
+                checkedIn
+                cancelled
+                room{
+                    id
+                    name
+                    calendarId
+                }
+            }
+        }
+    }
+'''
 
 checkin_mutation_for_event_existing_in_db = '''mutation {
     eventCheckin(

--- a/fixtures/location/all_locations_fixtures.py
+++ b/fixtures/location/all_locations_fixtures.py
@@ -35,6 +35,18 @@ expected_query_all_locations = {
                                 "description": "The description"
                             }
                         ]
+                    },
+                    {
+                        "name": "Tana",
+                        "roomType": "meeting",
+                        "capacity": 14,
+                        "roomTags": [
+                            {
+                                "name": "Block-B",
+                                "color": "green",
+                                "description": "The description"
+                            }
+                        ]
                     }
                 ]
             },
@@ -87,10 +99,18 @@ all_location_no_hierachy = '''{
 
 expected_all_location_no_hierachy = {
     'data': {'allLocations': [
-        {'rooms': [{'name': 'Entebbe',
+        {'rooms': [
+                {
+                    'name': 'Entebbe',
                     'roomType': 'meeting',
-                    'capacity': 6}
-                   ]},
+                    'capacity': 6
+                },
+                {
+                    'name': 'Tana',
+                    'roomType': 'meeting',
+                    'capacity': 14
+                },
+            ]},
         {'rooms': []},
         {'rooms': []}
     ]

--- a/fixtures/location/rooms_in_location_fixtures.py
+++ b/fixtures/location/rooms_in_location_fixtures.py
@@ -17,6 +17,12 @@ expected_query_get_rooms_in_location = {
                 "capacity": 6,
                 "roomType": "meeting",
                 "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+            },
+            {
+                "name": "Tana",
+                "capacity": 14,
+                "roomType": "meeting",
+                "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
             }
         ]
     }

--- a/fixtures/room/create_room_fixtures.py
+++ b/fixtures/room/create_room_fixtures.py
@@ -237,12 +237,20 @@ db_rooms_query = '''
 
 db_rooms_query_response = {
     "data": {
-        "rooms": [{
+        "rooms": [
+            {
                 "name": "Entebbe",
                 "capacity": 6,
                 "roomType": "meeting",
                 "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
-            }]
+            },
+            {
+                "name": "Tana",
+                "capacity": 14,
+                "roomType": "meeting",
+                "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+            }
+        ]
     }
 }
 
@@ -253,6 +261,18 @@ query_rooms_response = {
                 {
                     "name": "Entebbe",
                     "capacity": 6,
+                    "roomType": "meeting",
+                    "roomTags": [
+                        {
+                            "name": "Block-B",
+                            "color": "green"
+                        }
+                    ],
+                    "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+                },
+                {
+                    "name": "Tana",
+                    "capacity": 14,
                     "roomType": "meeting",
                     "roomTags": [
                         {

--- a/fixtures/room/filter_room_fixtures.py
+++ b/fixtures/room/filter_room_fixtures.py
@@ -43,6 +43,12 @@ filter_rooms_by_location_response = {
                     "capacity": 6,
                     "roomType": "meeting",
                     "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+                },
+                {
+                    "name": "Tana",
+                    "capacity": 14,
+                    "roomType": "meeting",
+                    "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
                 }
             ]
         }
@@ -181,7 +187,7 @@ filter_rooms_by_invalid_tag_error_response = {
 }
 
 filter_rooms_by_room_labels = '''query {
-  allRooms(roomLabels:"Wing"){
+  allRooms(roomLabels:"Wing A"){
    rooms{
       name
       capacity
@@ -209,7 +215,7 @@ filter_rooms_by_room_labels_response = {
     }
 }
 filter_rooms_by_location_room_labels = '''query {
-  allRooms(roomLabels:"Wing", location:"Kampala"){
+  allRooms(roomLabels:"Wing A", location:"Kampala"){
    rooms{
       name
       capacity

--- a/fixtures/room/query_room_fixtures.py
+++ b/fixtures/room/query_room_fixtures.py
@@ -32,9 +32,9 @@ paginated_rooms_response = {
                     "name": "Entebbe"
                 }
             ],
-            "hasNext": False,
+            "hasNext": True,
             "hasPrevious": False,
-            "pages": 1
+            "pages": 2
         }
     }
 }

--- a/helpers/devices/devices.py
+++ b/helpers/devices/devices.py
@@ -1,0 +1,14 @@
+from graphql import GraphQLError
+from api.devices.models import Devices as DeviceModel
+from api.devices.schema import Devices as DeviceSchema
+
+
+def update_device_last_seen(info, room_id, check_in_time):
+    device_query = DeviceSchema.get_query(info)
+    device = device_query.filter(
+                DeviceModel.room_id == room_id
+            ).first()
+    if not device:
+        raise GraphQLError("Room device not found")
+    device.last_seen = check_in_time
+    device.save()

--- a/tests/base.py
+++ b/tests/base.py
@@ -90,6 +90,16 @@ class BaseTestCase(TestCase):
                         room_labels=["1st Floor", "Wing A"])
             room.save()
             room.room_tags.append(tag)
+            room_2 = Room(name='Tana',
+                        room_type='meeting',
+                        capacity=14,
+                        location_id=location.id,
+                        structure_id='851ae8b3-48dd-46b5-89bc-ca3f8111ad87',
+                        calendar_id='andela.com_3730313534393638323232@resource.calendar.google.com',  # noqa: E501
+                        image_url="https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",  # noqa: E501
+                        room_labels=["1st Floor", "Wing B"])
+            room_2.save()
+            room_2.room_tags.append(tag)
             resource = Resource(name='Markers',
                                 quantity=3)
             resource.save()
@@ -98,7 +108,8 @@ class BaseTestCase(TestCase):
                 date_added="2018-06-08T11:17:58.785136",
                 name="Samsung",
                 location="Kampala",
-                device_type="External Display"
+                device_type="External Display",
+                room_id=1
             )
             device.save()
             question_1 = Question(

--- a/tests/test_events/test_event_checkin.py
+++ b/tests/test_events/test_event_checkin.py
@@ -4,10 +4,12 @@ from unittest.mock import patch
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.events.event_checkin_fixtures import (
     event_checkin_mutation,
+    event_2_checkin_mutation,
     event_checkin_response,
     wrong_calendar_id_checkin_mutation,
     cancel_event_mutation,
     cancel_event_respone,
+    cancel_event_invalid_start_time,
     checkin_mutation_for_event_existing_in_db,
     response_for_event_existing_in_db_checkin
 )
@@ -53,6 +55,17 @@ class TestEventCheckin(BaseTestCase):
             "This Calendar ID is invalid"
         )
 
+    def test_checkin_room_with_no_device(self):
+        """
+        Test that user can not checkin to a room
+        without a device assigned to the room
+        """
+        CommonTestCases.user_token_assert_in(
+            self,
+            event_2_checkin_mutation,
+            "Room device not found"
+        )
+
     @patch("api.events.schema.get_single_calendar_event", spec=True)
     def test_cancel_event(self, mocked_method):
         '''
@@ -63,6 +76,18 @@ class TestEventCheckin(BaseTestCase):
             self,
             cancel_event_mutation,
             cancel_event_respone
+        )
+
+    @patch("api.events.schema.get_single_calendar_event", spec=True)
+    def test_cancel_event_with_invalid_start_time(self, mocked_method):
+        '''
+        Test that user can not cancel event with invalid start time
+        '''
+        mocked_method.return_value = get_events_mock_data()['items'][0]
+        CommonTestCases.user_token_assert_in(
+            self,
+            cancel_event_invalid_start_time,
+            'Invalid start time'
         )
 
     @patch("api.events.schema.get_single_calendar_event", spec=True)


### PR DESCRIPTION
#### What does this PR do?
updates device last seen when checking in to an event or when canceling an event

#### Description of Task to be completed?
- modify event check-in mutation
- modify cancel event mutation
- fix tests

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to `Readme.md`
3. checkout to branch `ft-device-last-seen-to-equal-checkin-time-166539920`
4. on insomnia to check-in to an event send the mutation
 ```
 mutation {
  eventCheckin(calendarId: "andela.com_38393338303730373538@resource.calendar.google.com", eventId: "041t6mhogr8cq7i8vvr2h36d9p", eventTitle: "First LFA On-Boarding", startTime: "2019-04-25T05:00:00-07:00", endTime: "2019-04-25T06:00:00-07:00", numberOfParticipants: 13, checkInTime: "2019-04-25T05:02:00-07:00") {
    event {
      eventTitle
      room{
        name
        devices{
          name
          lastSeen
        }
      }
    }
  }
}
```
5. on insomnia to cancel an event send the mutation
 ```
 mutation {
  cancelEvent(calendarId: "andela.com_38393338303730373538@resource.calendar.google.com", eventId: "041t6mhogr8cq7i8vvr2h36d9p", eventTitle: "First LFA On-Boarding", startTime: "2019-04-25T04:00:00-07:00", endTime: "2019-04-25T05:00:00-07:00", numberOfParticipants: 13) {
    event {
      eventTitle
      startTime
      room {
        name
        devices {
          name
          lastSeen
        }
      }
    }
  }
}
```
#### What are the relevant pivotal tracker stories?
[#166539920](https://www.pivotaltracker.com/story/show/166539920)
#### Screenshots (if appropriate)
<img width="945" alt="Screenshot 2019-06-11 at 16 50 56" src="https://user-images.githubusercontent.com/39084014/59278557-de915800-8c6a-11e9-9a50-3ee7425c565c.png">
<img width="959" alt="Screenshot 2019-06-11 at 17 02 50" src="https://user-images.githubusercontent.com/39084014/59278571-e8b35680-8c6a-11e9-81ed-192163b704f5.png">

