### PR TITLE
#166438308  fix get_room_by_name query to filter out archived rooms

### DIFF
--- a/api/room/schema_query.py
+++ b/api/room/schema_query.py
@@ -321,7 +321,8 @@ class Query(graphene.ObjectType):
         query = Room.get_query(info)
         if name == "":
             raise GraphQLError("Please input Room Name")
-        check_room_name = list(query.filter(RoomModel.name.ilike("%" + name + "%")).all())   # noqa: E501
+        check_room_name = list(query.filter(
+            RoomModel.name.ilike("%" + name + "%"),  RoomModel.state == "active").all())  # noqa: E501
         if not check_room_name:
             raise GraphQLError("Room not found")
         return check_room_name


### PR DESCRIPTION
#### What does this PR do?
Fix bug on querying rooms
#### Description of Task to be completed?
Currently, when we try to return a room by running its query we are able to return rooms that have been archived. This PR updates the query to only return rooms with an active state.
#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `bg-get-room-by-name-166438308`
4. When using Docker `make build`
5. run queries
 ` {
    getRoomByName(name:"Kampala"){
        name
    }
}`  Room with active state
`
{
    getRoomByName(name:"New York"){
        name
    }
}` Room with Archived state


#### What are the relevant pivotal tracker stories?
[#166438308](https://www.pivotaltracker.com/story/show/166438308)

#### Background context
N/A

Screenshots
<img width="1233" alt="Screenshot 2019-06-20 at 11 50 18 AM" src="https://user-images.githubusercontent.com/40821284/59845961-8fc47c00-9356-11e9-8a8b-602dadfe7867.png">
<img width="1241" alt="Screenshot 2019-06-20 at 11 50 29 AM" src="https://user-images.githubusercontent.com/40821284/59845970-97842080-9356-11e9-82cc-ff8380c915cc.png">


- [x]  My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Implementation works according to expectations