### PR TITLE
CON-86-story Enable admin resolve/unresolve multiple responses at once

### DIFF
--- a/api/response/schema.py
+++ b/api/response/schema.py
@@ -9,18 +9,9 @@ from api.room.schema import Room
 from api.question.models import Question as QuestionModel
 from helpers.pagination.paginate import ListPaginate
 from helpers.response.create_response import (
-    create_response, Rate, SelectedOptions, TextArea, MissingItems
+    ResponseData, ResponseDetail, map_response_type,
+    create_response, create_response_details
 )
-from helpers.response.create_response import map_response_type
-
-
-class ResponseData(graphene.Union):
-    class Meta:
-        types = (Rate, SelectedOptions, TextArea, MissingItems)
-
-    @classmethod
-    def resolve_type(cls, instance, info):
-        return type(instance)
 
 
 class Response(SQLAlchemyObjectType):
@@ -34,20 +25,16 @@ class Response(SQLAlchemyObjectType):
     response = graphene.Field(ResponseData)
 
 
-class ResponseDetail(graphene.ObjectType):
-    id = graphene.Int()
-    room_id = graphene.Int()
-    created_date = graphene.DateTime()
-    response = graphene.Field(ResponseData)
-    question_type = graphene.String()
-    resolved = graphene.Boolean()
-
-
 class RoomResponses(graphene.ObjectType):
     room_id = graphene.Int()
     room_name = graphene.String()
     total_responses = graphene.Int()
     response = graphene.List(ResponseDetail)
+
+
+class HandledResponses(graphene.ObjectType):
+    total_responses = graphene.Int()
+    responses = graphene.List(ResponseDetail)
 
 
 class PaginatedResponse(graphene.ObjectType):
@@ -220,13 +207,46 @@ class HandleRoomResponse(graphene.Mutation):
             room_response.question_type.name
         )(room_response.response)
         return HandleRoomResponse(
-            room_response=ResponseDetail(
-                id=room_response.id,
-                created_date=room_response.created_date,
-                response=response,
-                room_id=room_response.room_id,
-                question_type=room_response.question_type.name,
-                resolved=room_response.resolved
+            room_response=create_response_details(response, room_response)
+        )
+
+
+class HandleMultipleResponse(graphene.Mutation):
+    """
+        Returns handled responses on marking or unmarking
+        multiple responses as resolved
+    """
+    class Arguments:
+        responses = graphene.List(graphene.Int, required=True)
+        resolved = graphene.Boolean()
+
+    handledResponses = graphene.Field(HandledResponses)
+
+    @Auth.user_roles('Admin')
+    def mutate(self, info, responses, resolved):
+        handled_responses = []
+        query_responses = Response.get_query(info)
+        for response in responses:
+            room_response = query_responses.filter(
+                ResponseModel.id == response).first()
+            if not room_response:
+                raise GraphQLError(
+                    "Response " + str(response) + " does not exist"
+                )
+        for response in responses:
+            room_response = query_responses.filter(
+                ResponseModel.id == response).first()
+            room_response.resolved = resolved
+            room_response.save()
+            response = map_response_type(
+                room_response.question_type.name
+            )(room_response.response)
+            response = create_response_details(response, room_response)
+            handled_responses.append(response)
+        return HandleMultipleResponse(
+            handledResponses=HandledResponses(
+                responses=handled_responses,
+                total_responses=len(handled_responses)
             )
         )
 
@@ -241,4 +261,9 @@ class Mutation(graphene.ObjectType):
         description="Mutation to mark or unmark a response as resolved\
             \n- room_response: Field for the response inputs\
             \n- response_id: Unique key identifier of a room_response"
+    )
+    resolve_multiple_responses = HandleMultipleResponse.Field(
+        description="Mutation to mark or unmark multiple responses as resolved\
+            \n- responses: List field of the responses to be handle\
+            \n- resolved: Boolean field to set resolved as true or false"
     )

--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -41,6 +41,23 @@ get_room_response_query_data = {
     }
 }
 
+get_resolved_room_responses_query = '''{
+    roomResponse(roomId:1, resolved:true) {
+        roomName,
+        totalResponses
+    }
+}
+'''
+
+get_resolved_room_responses_query_data = {
+    "data": {
+        "roomResponse": {
+            "roomName": "Entebbe",
+            "totalResponses": 1
+        }
+    }
+}
+
 get_room_response_query_by_date = '''
 query{{
     allRoomResponses(startDate: "{}",
@@ -285,6 +302,60 @@ summary_room_response_data = {
   }
 }
 
+all_resolved_room_response_query = '''{
+    allRoomResponses(resolved:true) {
+        responses {
+        roomName,
+        totalResponses,
+        response {
+          responseId,
+          response {
+            ... on Rate{
+              rate
+            }
+            ... on SelectedOptions{
+              options
+            }
+            ... on TextArea{
+              suggestion
+            }
+            ... on MissingItems{
+              missingItems{
+                name
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+}
+'''
+
+all_resolved_room_response_data = {
+  "data": {
+    "allRoomResponses": {
+      "responses": [
+        {
+          "roomName": "Entebbe",
+          "totalResponses": 1,
+          "response": [
+            {
+              "responseId": 2,
+              "response": {
+                "options": [
+                  "marker pen",
+                  "apple tv"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
 filter_by_response_query = '''
 query{
     allRoomResponses(upperLimitCount: 3, lowerLimitCount: 0 ){
@@ -418,6 +489,61 @@ filter_by_response_data = {
             ]
         }
     }
+}
+
+search_resolved_responses_by_room_name = '''
+query{
+    allRoomResponses(room:"Entebbe", resolved:true){
+        responses{
+            totalResponses
+            roomName
+            response{
+                responseId
+                response {
+                  ... on Rate{
+                    rate
+                  }
+                  ... on SelectedOptions{
+                    options
+                  }
+                  ... on TextArea{
+                    suggestion
+                  }
+                  ... on MissingItems{
+                    missingItems{
+                      name
+                      id
+                    }
+                  }
+                }
+            }
+        }
+    }
+}
+'''
+
+search_resolved_responses_by_room_name_data = {
+  "data": {
+    "allRoomResponses": {
+      "responses": [
+        {
+          "roomName": "Entebbe",
+          "totalResponses": 1,
+          "response": [
+            {
+              "responseId": 2,
+              "response": {
+                "options": [
+                  "marker pen",
+                  "apple tv"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
 }
 
 query_paginated_responses = '''
@@ -613,3 +739,120 @@ mark_a_user_response_as_unresolved_mutation_response = {
         }
     }
 }
+
+mark_multiple_as_resolved_mutation = '''
+    mutation{
+  resolveMultipleResponses(responses:[1], resolved:true){
+    handledResponses{
+      responses{
+        id
+        resolved
+        response{
+          ... on Rate{
+            rate
+          }
+          ... on TextArea{
+            suggestion
+          }
+          ... on SelectedOptions{
+            options
+          }
+          ... on MissingItems{
+            missingItems{
+              name
+            }
+        }
+        }
+      }
+      totalResponses
+    }
+  }
+}
+'''
+
+mark_multiple_as_resolved_response = {
+  "data": {
+    "resolveMultipleResponses": {
+      "handledResponses": {
+        "responses": [
+          {
+            "id": 1,
+            "resolved": True,
+            "response": {
+              "rate": 1
+            }
+          }
+        ],
+        "totalResponses": 1
+      }
+    }
+  }
+}
+
+mark_multiple_as_unresolved_mutation = '''
+    mutation{
+  resolveMultipleResponses(responses:[1], resolved:false){
+    handledResponses{
+      responses{
+        id
+        resolved
+        response{
+          ... on Rate{
+            rate
+          }
+          ... on TextArea{
+            suggestion
+          }
+          ... on SelectedOptions{
+            options
+          }
+          ... on MissingItems{
+            missingItems{
+              name
+            }
+        }
+        }
+      }
+      totalResponses
+    }
+  }
+}
+'''
+
+mark_multiple_as_unresolved_response = {
+  "data": {
+    "resolveMultipleResponses": {
+      "handledResponses": {
+        "responses": [
+          {
+            "id": 1,
+            "resolved": False,
+            "response": {
+              "rate": 1
+            }
+          }
+        ],
+        "totalResponses": 1
+      }
+    }
+  }
+}
+
+mark_multiple_as_resolved_with_invalid_id = '''
+    mutation{
+  resolveMultipleResponses(responses:[36], resolved:true){
+    handledResponses{
+      responses{
+        id
+        resolved
+        response{
+          ... on TextArea{
+          suggestion
+        }
+        }
+      }
+      totalResponses
+    }
+  }
+}
+'''

--- a/helpers/response/create_response.py
+++ b/helpers/response/create_response.py
@@ -23,6 +23,24 @@ class MissingItems(graphene.ObjectType):
     missing_items = graphene.List(Resource)
 
 
+class ResponseData(graphene.Union):
+    class Meta:
+        types = (Rate, SelectedOptions, TextArea, MissingItems)
+
+    @classmethod
+    def resolve_type(cls, instance, info):
+        return type(instance)
+
+
+class ResponseDetail(graphene.ObjectType):
+    id = graphene.Int()
+    room_id = graphene.Int()
+    created_date = graphene.DateTime()
+    response = graphene.Field(ResponseData)
+    question_type = graphene.String()
+    resolved = graphene.Boolean()
+
+
 def map_response_type(question_type):
     return {
             'check': lambda check_options: SelectedOptions(
@@ -124,3 +142,14 @@ def create_response(info, question_type, errors, responses, **kwargs): # noqa
     else:
         errors.append("Kindly respond to the right question type of {}".format(question_type))  # noqa
     return responses, errors
+
+
+def create_response_details(response, room_response):
+    return ResponseDetail(
+                id=room_response.id,
+                created_date=room_response.created_date,
+                response=response,
+                room_id=room_response.room_id,
+                question_type=room_response.question_type.name,
+                resolved=room_response.resolved
+            )

--- a/tests/test_response/test_resolved_responses.py
+++ b/tests/test_response/test_resolved_responses.py
@@ -1,0 +1,74 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.response.room_response_fixture import (
+    get_resolved_room_responses_query,
+    get_resolved_room_responses_query_data,
+    all_resolved_room_response_query,
+    all_resolved_room_response_data,
+    search_resolved_responses_by_room_name,
+    search_resolved_responses_by_room_name_data,
+    mark_multiple_as_resolved_mutation,
+    mark_multiple_as_unresolved_mutation,
+    mark_multiple_as_resolved_with_invalid_id,
+    mark_multiple_as_resolved_response,
+    mark_multiple_as_unresolved_response,
+)
+
+
+class TestRoomResponse(BaseTestCase):
+    def test_query_resolved_room_responses(self):
+        """
+        Test querying for resolved room responses
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, get_resolved_room_responses_query,
+            get_resolved_room_responses_query_data
+        )
+
+    def test_all_resolved_room_responses(self):
+        """
+        Test fetching all resolved responses in all rooms
+
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            all_resolved_room_response_query,
+            all_resolved_room_response_data
+        )
+
+    def test_search_resolved_responses_by_room_name(self):
+        """
+        Testing for searching all resolved room responses
+        by room name
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            search_resolved_responses_by_room_name,
+            search_resolved_responses_by_room_name_data
+        )
+
+    def test_mark_multiple_responses_as_resolved(self):
+        """
+            Tests that admin can mark multiple responses
+            as resolved
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, mark_multiple_as_resolved_mutation,
+            mark_multiple_as_resolved_response)
+
+    def test_mark_multiple_responses_as_unresolved(self):
+        """
+            Tests that admin can mark multiple responses
+            as unresolved
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, mark_multiple_as_unresolved_mutation,
+            mark_multiple_as_unresolved_response)
+
+    def test_mark_multiple_responses_as_resolved_with_invalid_id(self):
+        """
+            Tests that admin can not mark multiple responses
+            as resolved with invalid response Id
+        """
+        CommonTestCases.admin_token_assert_in(
+            self, mark_multiple_as_resolved_with_invalid_id,
+            "Response 36 does not exist")


### PR DESCRIPTION
## Description ##
This pull request:
- Enables admin to query only resolved responses
- Enables admin to mark multiple responses as resolved/unresolved at once

## How can This be tested ##
- Clone the repo: `git clone https://github.com/andela/mrm_api.git`
- Setup project according to `Readme.md`
- checkout to branch `story/CON-86-enable-admin-resolve-multiple-responses`
- on insomnia
to fetch all resolved responses send the query:
 ```
{
  allRoomResponses(resolved: true) {
    responses {
      roomName
      response {
        responseId
        response {
          __typename
          ... on Rate {
            rate
          }
          ... on SelectedOptions {
            options
          }
          ... on TextArea {
            suggestion
          }
          ... on MissingItems {
            missingItems {
              name
              id
            }
          }
        }
        resolved
      }
      totalResponses
    }
  }
}
```
to fetch resolved room responses send the query:
 ```
{
  roomResponse(roomId: 18, resolved: true) {
    roomName
    response {
      responseId
      response {
        __typename
        ... on Rate {
          rate
        }
        ... on SelectedOptions {
          options
        }
        ... on TextArea {
          suggestion
        }
        ... on MissingItems {
          missingItems {
            name
            id
          }
        }
      }
      resolved
    }
    totalResponses
  }
}
```
to fetch all resolved responses in a room using room name send the query:
 ```
{
  allRoomResponses(room:"kampala"resolved: true) {
    responses {
      roomName
      response {
        responseId
        response {
          __typename
          ... on Rate {
            rate
          }
          ... on SelectedOptions {
            options
          }
          ... on TextArea {
            suggestion
          }
          ... on MissingItems {
            missingItems {
              name
              id
            }
          }
        }
        resolved
      }
      totalResponses
    }
  }
}
```
to mark multiple responses as resolved or unresolved use the mutation:
 ```
mutation {
  resolveMultipleResponses(responses: [8, 9], resolved: false) {
    handledResponses {
      responses {
        id
        resolved
        response {
          __typename
          ... on Rate {
            rate
          }
          ... on SelectedOptions {
            options
          }
          ... on TextArea {
            suggestion
          }
          ... on MissingItems {
            missingItems {
              name
              id
            }
          }
        }
      }
      totalResponses
    }
  }
}
```

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## JIRA ##
[CON-86](https://andela-apprenticeship.atlassian.net/browse/CON-86)

## Relevant screenshots: ##
<img width="1010" alt="Screenshot 2019-06-26 at 14 53 42" src="https://user-images.githubusercontent.com/39084014/60178357-00224000-9824-11e9-933d-d79d824587d8.png">
<img width="1029" alt="Screenshot 2019-06-26 at 14 56 49" src="https://user-images.githubusercontent.com/39084014/60178376-1203e300-9824-11e9-8614-437659c652fa.png">
<img width="1141" alt="Screenshot 2019-06-26 at 15 00 02" src="https://user-images.githubusercontent.com/39084014/60178389-1d570e80-9824-11e9-9477-eb0dd116b86a.png">


