### PR TITLE
CON-119 Enable admin to invite users as admins

### DIFF
--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -112,7 +112,7 @@ query_user_email_response = {
 
 change_user_role_mutation = '''
 mutation{
-    changeUserRole(email:"mrmtestuser@andela.com", roleId: 1){
+    changeUserRole(email:"peter.walugembe@andela.com", roleId: 2){
         user{
             name
             roles{
@@ -172,19 +172,13 @@ mutation{
 }
 '''
 
-send_invitation_to_existent_user_response = {
-    "errors": [{
-        "message": "User already joined Converge",
-        "locations": [{
-            "line": 3,
-            "column": 5
-        }],
-        "path": ["inviteToConverge"]
-    }],
-    "data": {
-        "inviteToConverge": null
+send_invitation_to_invalid_email = '''
+mutation{
+    inviteToConverge(email: "peter.walugembe@gmail.com"){
+        email
     }
 }
+'''
 
 send_invitation_to_existent_user_response = {
     "errors": [{

--- a/helpers/email/email.py
+++ b/helpers/email/email.py
@@ -24,7 +24,9 @@ class EmailNotification:
                 user_name=kwargs.get('user_name'),
                 room_name=kwargs.get('room_name'),
                 event_title=kwargs.get('event_title'),
-                event_reject_reason=kwargs.get('event_reject_reason')
+                event_reject_reason=kwargs.get('event_reject_reason'),
+                new_role=kwargs.get('new_role'),
+                domain=kwargs.get('domain')
             ))
 
         return email.send()
@@ -33,13 +35,11 @@ class EmailNotification:
         """
         send email invite for user to join converge
         """
-        email = SendEmail(
-            "Invitation to join Converge", [email],
-            render_template('invite.html', name=admin,
-                            domain=Config.DOMAIN_NAME)
-            )
-
-        return email.send()
+        return EmailNotification.send_email_notification(
+            self, email=email, subject="Invitation to join Converge",
+            template='invite.html',
+            user_name=admin, domain=Config.DOMAIN_NAME
+        )
 
     def event_cancellation_notification(
         self, event, room_id, event_reject_reason
@@ -58,27 +58,31 @@ class EmailNotification:
         subject = 'Your room reservation was rejected'
         template = 'event_cancellation.html'
         return EmailNotification.send_email_notification(
-            self, email=email, subject=subject, template=template,
-            room_name=room_name, event_title=event_title,
+            self,
+            email=email,
+            subject=subject,
+            template=template,
+            room_name=room_name,
+            event_title=event_title,
             event_reject_reason=event_reject_reason
         )
 
-    def send_admin_invite_email(self, user_email, user_name):
+    def send_changed_role_email(self, user_email, user_name, new_role):
         """
-        send email notification when an admin is added
+        send email notification when user role is changed
             :params
-                - user_email: the email of the user being added as an admin
-                - user_name: the name of the user being added as an admin
+                - user_email: the email of the user whose role is changed
+                - user_name: the name of the user whose role is changed
         """
-        subject = 'Converge - You have been added as an admin'
-        template = 'admin_invite.html'
 
         return EmailNotification.send_email_notification(
             self,
             email=user_email,
-            subject=subject,
+            subject='Converge - Your role has been changed',
             user_name=user_name,
-            template=template
+            template='change_role.html',
+            new_role=new_role,
+            domain=Config.DOMAIN_NAME
         )
 
 

--- a/helpers/email/email_setup.py
+++ b/helpers/email/email_setup.py
@@ -30,7 +30,7 @@ class SendEmail:
             html=self.template,
             sender=self.sender)
 
-    @celery.task
+    @celery.task(name='asynchronous-email-notifications')
     def send_async_email(msg_dict):
         mail = Mail()
         msg = Message()

--- a/templates/change_role.html
+++ b/templates/change_role.html
@@ -40,12 +40,12 @@
                 </div>
                 <div class="rectangle-3" style="box-sizing: border-box;margin: 60px 138px;">
                     <p class="invite" style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;color: #6d6d6d;line-height: 21px;font-family: 'DINPro', 'Roboto', sans-serif !important;">
-                        You have been added as an Admin to Converge
+                        Your role on Converge has been changed to {{new_role}}.
                         <br><br>Regards,<br><strong>Converge Team</strong>
                     </p>
                 </div>
                 <div style="box-sizing: border-box;">
-                    <a href=http://converge-staging.andela.com/> <button type=" button" class="btn btn-primary" style="box-sizing: border-box;border-radius: 4px;margin: 0;font-family: 'DINPro', 'Roboto', sans-serif;font-size: 1rem;overflow: visible;text-transform: none;-webkit-appearance: button;display: inline-block;font-weight: 400;text-align: center;white-space: nowrap;vertical-align: middle;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;border: 1px solid transparent;padding: .375rem .75rem;transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;color: #fff;background-color: #007bff;border-color: #007bff;height: 44px;width: 174px;">Login
+                    <a href={{domain}}> <button type=" button" class="btn btn-primary" style="box-sizing: border-box;border-radius: 4px;margin: 0;font-family: 'DINPro', 'Roboto', sans-serif;font-size: 1rem;overflow: visible;text-transform: none;-webkit-appearance: button;display: inline-block;font-weight: 400;text-align: center;white-space: nowrap;vertical-align: middle;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;border: 1px solid transparent;padding: .375rem .75rem;transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;color: #fff;background-color: #007bff;border-color: #007bff;height: 44px;width: 174px;">Login
                         to view</button></a>
                 </div>
                 <div style="box-sizing: border-box;">
@@ -64,7 +64,7 @@
         </div>
         <div class="subcription" style="box-sizing: border-box;height: 19.16px;width: 490px;color: #000111;font-family: 'DINPro', 'Roboto', sans-serif, sans-serif;font-size: 16px;line-height: 19px;text-align: center;margin: auto;padding-top: 15px;">
             <p style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;">Click <span style="box-sizing: border-box;"><a
-                        id="link" href="https://converge-staging.andela.com/preference" style="box-sizing: border-box;color: #999999;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
+                        id="link" href="{{domain}}/preference" style="box-sizing: border-box;color: #999999;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
                         <strong>here</strong></a></span> if you wish to unsubscribe</p>
         </div>
     </div>

--- a/templates/invite.html
+++ b/templates/invite.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="rectangle-3" style="box-sizing: border-box;margin: 60px 138px;">
                     <p class="invite" style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;color: #6d6d6d;line-height: 21px;font-family: 'DINPro', 'Roboto', sans-serif !important;">
-                        {{name}} invited you to join converge.
+                        {{user_name}} invited you to join converge.
                         Sign up with the link below to get started.
                     </p>
                 </div>
@@ -61,7 +61,7 @@
         </div>
         <div class="subcription" style="box-sizing: border-box;height: 19.16px;width: 490px;color: #999999;font-family: 'DINPro', 'Roboto', sans-serif, sans-serif;font-size: 16px;line-height: 19px;text-align: center;margin: auto;padding-top: 15px;">
             <p style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;">You can change
-                your <span style="box-sizing: border-box;"><a id="link" href="https://converge-staging.andela.com/preference" style="box-sizing: border-box;color: #999999;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
+                your <span style="box-sizing: border-box;"><a id="link" href="{{domain}}/preference" style="box-sizing: border-box;color: #999999;text-decoration: underline;background-color: transparent;-webkit-text-decoration-skip: objects;">
                         subscription</a></span> settings anytime.</p>
         </div>
     </div>

--- a/tests/test_user/test_change_user_role.py
+++ b/tests/test_user/test_change_user_role.py
@@ -1,4 +1,4 @@
-from tests.base import BaseTestCase, CommonTestCases, change_test_user_role
+from tests.base import BaseTestCase, CommonTestCases
 from fixtures.user.user_fixture import (
     change_user_role_mutation, change_user_role_mutation_response,
     change_user_role_to_non_existence_role_mutation,
@@ -15,8 +15,6 @@ sys.path.append(os.getcwd())
 
 
 class TestChangeUserRole(BaseTestCase):
-
-    @change_test_user_role
     def test_change_user_role(self):
         """
         Testing change of user role

--- a/tests/test_user/test_invite_email.py
+++ b/tests/test_user/test_invite_email.py
@@ -2,7 +2,8 @@ from tests.base import BaseTestCase, CommonTestCases
 from fixtures.user.user_fixture import (
     send_invitation_to_existent_user_query,
     send_invitation_to_existent_user_response,
-    send_invitation_to_nonexistent_user_query)
+    send_invitation_to_nonexistent_user_query,
+    send_invitation_to_invalid_email)
 
 
 class InviteUser(BaseTestCase):
@@ -15,3 +16,8 @@ class InviteUser(BaseTestCase):
         CommonTestCases.admin_token_assert_in(
             self, send_invitation_to_nonexistent_user_query,
             "beverly.kololi@andela.com")
+
+    def test_admin_invite_to_invalid_email(self):
+        CommonTestCases.admin_token_assert_in(
+            self, send_invitation_to_invalid_email,
+            "Use a valid andela email")


### PR DESCRIPTION
## Description ##
This pull request sends email notifications to users:
  - When they are being invited to join Converge
  - When their role is changed

## How can This be tested ##
- Clone the repo: `git clone https://github.com/andela/mrm_api.git`
- Setup project according to `Readme.md`
- checkout to branch `story/CON-119-enable-admin-to-invite-users-as-admins`
- on insomnia
to invite a user to Converge, use their valid Andela email to send the mutation:
 ```
mutation {
  inviteToConverge(email: "user.email@andela.com") {
    email
  }
}
```
to change a user role, use their valid Andela email to send the mutation:
 ```
mutation {
  changeUserRole(email: "user.email@andela.com", roleId: 1) {
    user {
      name
      email
      location
      roles {
        role
      }
    }
  }
}
```

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## JIRA ##
[CON-119](https://andela-apprenticeship.atlassian.net/browse/CON-119)

## Relevant screenshots: ##
<img width="614" alt="Screenshot 2019-07-10 at 18 22 35" src="https://user-images.githubusercontent.com/39084014/60981902-deef4280-a33f-11e9-984a-0154dfd689b1.png">
<img width="618" alt="Screenshot 2019-07-10 at 18 20 36" src="https://user-images.githubusercontent.com/39084014/60981923-e7e01400-a33f-11e9-9387-a93d46a694fc.png">
