### PR TITLE
CON-182 Fix deleted rooms showing on locations

### DIFF
--- a/api/location/models.py
+++ b/api/location/models.py
@@ -31,7 +31,8 @@ class Location(Base, Utility):
     structure = Column(String, nullable=True)
     rooms = relationship(
         'Room', cascade="all, delete-orphan",
-        order_by="func.lower(Room.name)")
+        order_by="func.lower(Room.name)",
+        primaryjoin="and_(Location.id==Room.location_id, Room.state=='active')")
     __table_args__ = (
             Index(
                 'ix_unique_location_content',


### PR DESCRIPTION
## Description ##
This pull request fixes the `allLocations` query to return only rooms that are active

## How can This be tested ##
- Clone the repo: `git clone https://github.com/andela/mrm_api.git`
- Setup project according to `Readme.md`
- checkout to branch `story/CON-119-enable-admin-to-invite-users-as-admins`
- on insomnia
to fetch all locations use the query:
 ```
{
  allLocations{
    name
    rooms{
      name
      state
    }
  }
}
```

## Type of change ##
Please select the relevant option
- [x] Bugfix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## JIRA ##
[CON-182](https://andela-apprenticeship.atlassian.net/browse/CON-182)

## Relevant screenshots: ##
<img width="1048" alt="Screenshot 2019-07-24 at 13 35 44" src="https://user-images.githubusercontent.com/39084014/61788417-b0cb3180-ae1a-11e9-93b4-b3c4434f9a49.png">
