### PR TITLE
CON-170-story(user-location): enable admin change user location

### DIFF
--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -325,3 +325,119 @@ query_non_existing_user_by_name_response = {
         "userByName": null
     }
 }
+
+change_user_location_invalid_user_mutation = '''
+       mutation {
+        changeUserLocation(email: "someinvaliduser@andela.com", locationId: 1) {
+          user {
+            name
+            location
+          }
+        }
+      }
+   '''
+
+
+change_user_location_invalid_user_response = {
+    "errors": [
+      {
+        "message": "User not found",
+        "locations": [
+          {
+            "line": 3,
+            "column": 9
+          }
+        ],
+        "path": [
+          "changeUserLocation"
+        ]
+      }
+    ],
+    "data": {
+      "changeUserLocation": null
+    }
+}
+
+change_user_location_invalid_location_id_mutation = '''
+      mutation {
+      changeUserLocation(email: "peter.walugembe@andela.com", locationId: 90) {
+        user {
+          name
+          location
+        }
+      }
+    }
+  '''
+
+change_user_location_invalid_location_id_response = {
+  "errors": [
+    {
+      "message": "the location supplied does not exist",
+      "locations": [
+        {
+          "line": 3,
+          "column": 7
+        }
+      ],
+      "path": [
+        "changeUserLocation"
+      ]
+    }
+  ],
+  "data": {
+    "changeUserLocation": null
+  }
+}
+
+change_user_location_to_same_location_mutation = '''
+       mutation {
+        changeUserLocation(email: "peter.walugembe@andela.com", locationId: 1) {
+          user {
+            name
+            location
+          }
+        }
+      }
+   '''
+
+change_user_location_to_same_location_response = {
+  "errors": [
+    {
+      "message": "user already in this location",
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ],
+      "path": [
+        "changeUserLocation"
+      ]
+    }
+  ],
+  "data": {
+    "changeUserLocation": null
+  }
+}
+
+change_user_location_valid_input_mutation = '''
+       mutation {
+        changeUserLocation(email: "peter.walugembe@andela.com", locationId: 2) {
+          user {
+            name
+            location
+          }
+        }
+      }
+   '''
+
+change_user_location_valid_input_response = {
+  "data": {
+    "changeUserLocation": {
+      "user": {
+        "name": "Peter Walugembe",
+        "location": "Nairobi"
+      }
+    }
+  }
+}

--- a/helpers/auth/authentication.py
+++ b/helpers/auth/authentication.py
@@ -135,12 +135,13 @@ class Authentication:
                         raise GraphQLError("The database cannot be reached")
                     for value in response['values']:
                         if user.email == value["email"]:
-                            if value['location']:
-                                user.location = value['location'][
+                            if value['location'] and not user.location:
+                                user_location = value['location'][
                                     'name'
                                 ] or "Nairobi"
+                                user.location = user_location
                                 user.save()
-                                check_and_add_location(user.location)
+                                check_and_add_location(user_location)
                     if user.roles and user.roles[0].role in expected_args:
                         return func(*args, **kwargs)
                     else:

--- a/tests/test_user/test_change_user_location.py
+++ b/tests/test_user/test_change_user_location.py
@@ -1,0 +1,51 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.user.user_fixture import (
+    change_user_location_valid_input_mutation,
+    change_user_location_valid_input_response,
+    change_user_location_invalid_user_mutation,
+    change_user_location_invalid_user_response,
+    change_user_location_invalid_location_id_mutation,
+    change_user_location_invalid_location_id_response,
+    change_user_location_to_same_location_mutation,
+    change_user_location_to_same_location_response
+)
+
+
+class TestChangeUserLocation(BaseTestCase):
+
+    def test_change_user_location_valid_input(self):
+        """
+        Test to change the location of a user with valid email and location_id
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, change_user_location_valid_input_mutation,
+            change_user_location_valid_input_response
+        )
+
+    def test_change_user_location_invalid_user(self):
+        """
+        Test that the supplied email must be for an existing user
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, change_user_location_invalid_user_mutation,
+            change_user_location_invalid_user_response
+        )
+
+    def test_change_user_location_invalid_location_id(self):
+        """
+        Test that the supplied location must exist in the database
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, change_user_location_invalid_location_id_mutation,
+            change_user_location_invalid_location_id_response
+        )
+
+    def test_change_user_location_same_location(self):
+        """
+        Test that the supplied location must be different from the user's
+        current location
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, change_user_location_to_same_location_mutation,
+            change_user_location_to_same_location_response
+        )


### PR DESCRIPTION
## Description ##
This pull request ensures an admin can change the location of a user.

## How can This be tested ##
Use the mutation below to change a user's location
 ```
mutation {
  changeUserLocation(email: "david.njoki@andela.com", locationId: 3) {
    user {
      name
      location
    }
  }
}

```



## Type of change ##
Please select the relevant option
- [ ] Bug fix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## JIRA ##
[CON-170](https://andela-apprenticeship.atlassian.net/browse/CON-170)
