### PR TITLE
CON-139 Fix questions query

### DIFF
--- a/api/question/schema.py
+++ b/api/question/schema.py
@@ -201,7 +201,7 @@ class Query(graphene.ObjectType):
     def resolve_all_questions(self, info, start_date=None, end_date=None):
         # get all questions
         query = Question.get_query(info)
-        questions = query.filter(QuestionModel.is_active)
+        questions = query.filter(QuestionModel.state == "active").all()
         questions_by_range = filter_questions_by_date_range(
                                                             questions,
                                                             start_date, end_date

--- a/fixtures/questions/get_question_fixtures.py
+++ b/fixtures/questions/get_question_fixtures.py
@@ -216,6 +216,9 @@ get_all_questions_query_response = {
         "allQuestions": [
             {
                 "questionType": "rate"
+            },
+            {
+                "questionType": "input"
             }
         ]
     }
@@ -245,6 +248,9 @@ all_questions_query_no_date_range_response = {
             },
             {
                 "questionType": "check"
+            },
+            {
+                "questionType": "input"
             }
         ]
     }


### PR DESCRIPTION
#### Description
When a question is created, the is_active field is FALSE by default. The admin needs to view all questions in order to activate a question.  Currently, the all questions query returns only active questions. The query needs to fetch all active an inactive questions to enable the admin to activate the questions from the front end. This PR fixes this issue.

#### How this should be manually tested
Clone the repo: git clone https://github.com/andela/mrm_api.git.
Setup the project as per the README.md.
Checkout to branch bug/CON-139-fix-questions-query.
Run the following query:
```
{
  allQuestions{
    id
    questionType
    questionTitle
    questionResponseCount
    checkOptions
    isActive
    state
  }
}
```


#### Type of change
- [x] Bug fix (nonbreaking change which fixes an issue)
- [ ] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [x] End to end
- [x] Integration

#### Checklist:
- [x] My code follows the style guide for this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Screenshots
**Fetch all questions**
![image](https://user-images.githubusercontent.com/41931013/61936003-708fbe80-af94-11e9-81eb-f383d4808970.png)


#### Jira
[CON-139](https://andela-apprenticeship.atlassian.net/jira/software/projects/CON/boards/15/backlog?label=backend&selectedIssue=CON-139)
