### PR TITLE
CON-205 Fix new user account creation error

### DIFF
--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -108,6 +108,7 @@ class Query(graphene.ObjectType):
         response = PaginatedUsers(**kwargs)
         return response
 
+    @Auth.user_roles('Admin', 'Default User', 'Super_Admin')
     def resolve_user(self, info, email):
         # Returns a specific user.
         query = User.get_query(info)

--- a/fixtures/room/create_room_fixtures.py
+++ b/fixtures/room/create_room_fixtures.py
@@ -46,6 +46,35 @@ room_mutation_query_response = {'data': {'createRoom': {
 }
 }
 
+room_mutation_different_location_query = '''
+ mutation {
+        createRoom(
+          name: "Syne",
+          calendarId: "andela.com_3836323338323230343935@resource.calendar.google.com",  # noqa: E501
+          roomType: "Meeting",
+          capacity: 1,
+          locationId: 2,
+          roomTags: [1],
+          structureId: "b05fc5f2-b4aa-4f48-a8fb-30bdcc3fc968",
+          imageUrl: "http://url.com",
+          roomLabels: ["Epic tower", "1st Floor"]) {
+            room {
+                name
+                roomType
+                capacity
+                locationId,
+                calendarId,
+                structureId,
+                imageUrl
+                roomTags {
+                  name
+                  color
+                }
+                roomLabels
+            }
+        }
+    }
+'''
 
 room_mutation_response = {
     "data": {

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -96,7 +96,7 @@ paginated_users_response = {
 
 query_user_by_email = '''
  query {
-  user(email: "mrm@andela.com"){
+  user(email: "peter.walugembe@andela.com"){
     email
   }
 }
@@ -105,7 +105,7 @@ query_user_by_email = '''
 query_user_email_response = {
     "data": {
         "user": {
-            "email": "mrm@andela.com",
+            "email": "peter.walugembe@andela.com",
         }
     }
 }

--- a/fixtures/user_role/user_role_fixtures.py
+++ b/fixtures/user_role/user_role_fixtures.py
@@ -74,24 +74,37 @@ user_role_query_response = {
     }
 }
 
-query_user_by_user_email = '''
+query_users_by_user_role = '''
 query {
-  user(email:"mrm@andela.com"){
-    roles
-    {
-      role
+  users(roleId:1){
+    users{
+      roles
+      {
+        role
+      }
     }
   }
 }
 '''
 
-query_user_by_user_email_response = {
+query_users_by_user_role_response = {
     "data": {
-        "user": {
-            "roles": [
-                {
-                    "role": "Admin"
-                }
+        "users": {
+            "users": [
+              {
+                "roles": [
+                    {
+                        "role": "Admin"
+                    }
+                ]
+              },
+              {
+                "roles": [
+                    {
+                        "role": "Admin"
+                    }
+                ]
+              }
             ]
         }
     }
@@ -142,30 +155,6 @@ change_unavailable_user_role_mutation_response = {
     ],
     "data": {
         "changeUserRole": null
-    }
-}
-
-query_user_by_user_email = '''
-query {
-  user(email:"mrm@andela.com"){
-    name
-    roles{
-      role
-    }
-  }
-}
-'''
-
-query_user_by_user_email_response = {
-    "data": {
-        "user": {
-            "name": "test test",
-            "roles": [
-                {
-                    "role": "Admin"
-                }
-            ]
-        }
     }
 }
 

--- a/helpers/auth/authentication.py
+++ b/helpers/auth/authentication.py
@@ -133,15 +133,21 @@ class Authentication:
                         user = User.query.filter_by(email=email).first()
                     except Exception:
                         raise GraphQLError("The database cannot be reached")
-                    for value in response['values']:
-                        if user.email == value["email"]:
-                            if value['location'] and not user.location:
-                                user_location = value['location'][
-                                    'name'
-                                ] or "Nairobi"
-                                user.location = user_location
-                                user.save()
-                                check_and_add_location(user_location)
+                    user_values = response['values']
+                    if len(user_values):
+                        for value in user_values:
+                            if user.email == value["email"]:
+                                if value['location'] and not user.location:
+                                    user_location = value['location'][
+                                        'name'
+                                    ] or "Nairobi"
+                                    user.location = user_location
+                                    user.save()
+                                    check_and_add_location(user_location)
+                    else:  # pragma: no cover
+                        if not user.location:
+                            user.location = "Nairobi"
+                            user.save()
                     if user.roles and user.roles[0].role in expected_args:
                         return func(*args, **kwargs)
                     else:

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -8,6 +8,7 @@ from fixtures.helpers.decorators_fixtures import (
 )
 from fixtures.room.create_room_fixtures import (
     room_mutation_query,
+    room_mutation_different_location_query,
     room_name_empty_mutation,
     room_mutation_query_duplicate_name,
     room_mutation_query_duplicate_name_response,
@@ -101,8 +102,8 @@ class TestCreateRoom(BaseTestCase):
         """
         CommonTestCases.lagos_admin_token_assert_in(
             self,
-            room_mutation_query,
-            "You are not authorized to make changes in Kampala"
+            room_mutation_different_location_query,
+            "You are not authorized to make changes in Nairobi"
         )
 
     def test_room_mutation_invalid_tag(self):

--- a/tests/test_user/test_query_user.py
+++ b/tests/test_user/test_query_user.py
@@ -51,18 +51,11 @@ class TestQueryUser(BaseTestCase):
         )
 
     def test_query_users_by_email(self):
-        user = User(email='mrm@andela.com',
-                    name="test test",
-                    picture="www.andela.com/test")
-        user.save()
-        db_session().commit()
-
-        execute_query = self.client.execute(
+        CommonTestCases.admin_token_assert_equal(
+            self,
             query_user_by_email,
-            context_value={'session': db_session})
-
-        expected_responese = query_user_email_response
-        self.assertEqual(execute_query, expected_responese)
+            query_user_email_response
+        )
 
     def test_get_users_by_location_error(self):
         """

--- a/tests/test_user_roles/test_query_user_role.py
+++ b/tests/test_user_roles/test_query_user_role.py
@@ -10,8 +10,8 @@ from fixtures.user_role.user_role_fixtures import (
     change_unavailable_user_role_mutation_response,
     user_role_query, user_role_query_response,
     change_user_role_mutation_response,
-    query_user_by_user_email,
-    query_user_by_user_email_response,
+    query_users_by_user_role,
+    query_users_by_user_role_response,
     assign_invalid_user_role_mutation,
     assign_invalid_user_role_response)
 from helpers.database import db_session
@@ -55,20 +55,11 @@ class TestQueryUserRole(BaseTestCase):
         self.assertEqual(execute_query, expected_responese)
 
     def test_query_users_role_by_role(self):
-        user = User(email='mrm@andela.com', location="Lagos",
-                    name="test test",
-                    picture="www.andela.com/testuser")
-        user.save()
-        role = base.role
-        user.roles.append(role)
-        db_session().commit()
-
-        execute_query = self.client.execute(
-            query_user_by_user_email,
-            context_value={'session': db_session})
-
-        expected_response = query_user_by_user_email_response
-        self.assertEqual(execute_query, expected_response)
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_users_by_user_role,
+            query_users_by_user_role_response
+        )
 
     @change_test_user_role
     def test_change_user_role(self):


### PR DESCRIPTION
## Description ##
This pull request adds authentication decorator to the `resolve_user` method. Currently, this endpoint is not protected and this precludes any new user trying to access it from being saved to the database as in the case of protected endpoints. 
Also, the details of some users are not returned from the Andela API. This means such users are saved into our DB without location details. This PR ensures the location of such users defaults to `Nairobi`. 

## How can This be tested ##
- Clone the repo: `git clone https://github.com/andela/mrm_api.git`
- Setup project according to `Readme.md`
- checkout to branch `bug/secure-get-user-endpoint`
- delete your user details on the local database
- on insomnia send a request to the endpoint below
 ```

query {
  user(email: "validandelaemail@andela.com") {
    email
    name
  }
}

```

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### JIRA
[CON-205](https://andela-apprenticeship.atlassian.net/browse/CON-205)