### PR TITLE
CON-168 Restricting an admin from creating super admins. 

### DIFF
--- a/api/analytics/all_analytics_query.py
+++ b/api/analytics/all_analytics_query.py
@@ -56,7 +56,6 @@ class Query(graphene.ObjectType):
         admin_details = get_user_from_db()
         query = Role.get_query(info)
         admin_role = query.filter_by(id=admin_details.roles[0].id).first()
-        print(admin_role.role)
         # check that id is valid
         verify_location_id(kwargs)
         if admin_role.role == 'Super_Admin' and kwargs.get('location_id', None):


### PR DESCRIPTION
#### Description
This Pull request restricts an admin from creating a super admin. 

#### Context of the problem to be solved. 
On our application, a super admin can be created by an admin, this PR ensures that an admin is restricted from creating a super admin. 

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `story/CON-168-restricting-admin-to-create-superAdmins`
4. run the following query to change the role of a user. Make sure the email is valid and already exists in our database and its role_id = 2 or 1

```
mutation{
  changeUserRole(email:"email@andela.com", roleId: 3){
    user{
      id
      roles{
        id
      }
    }
  }
}
```

#### Type of Change
- [x] New feature (non-breaking change which adds functionality

#### How has this been tested
- [x] Unit tests
- [x] Integration tests

#### Checklist
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations



#### JIRA
[CON-168](https://andela-apprenticeship.atlassian.net/browse/CON-168)
