### PR TITLE
CON-171 Send email to invitees when event is auto-canceled

### DIFF
--- a/helpers/email/email.py
+++ b/helpers/email/email.py
@@ -14,7 +14,7 @@ class EmailNotification:
         """
         send email notifications after a given activity has occured
         """
-        recipients = [kwargs.get('email')]
+        recipients = kwargs.get('email')
 
         email = SendEmail(
             kwargs.get('subject'), recipients,
@@ -36,7 +36,7 @@ class EmailNotification:
         send email invite for user to join converge
         """
         return EmailNotification.send_email_notification(
-            self, email=email, subject="Invitation to join Converge",
+            self, email=[email], subject="Invitation to join Converge",
             template='invite.html',
             user_name=admin, domain=Config.DOMAIN_NAME
         )
@@ -51,8 +51,9 @@ class EmailNotification:
             - room_id: Id of the room rejecting the event
             - event_reject_reason: Reason for rejecting the event
         """
+        attendees = event['attendees']
+        email = [attendee['email'] for attendee in attendees]
         event_title = event['summary']
-        email = event['organizer']['email']
         room = RoomModel.query.filter_by(id=room_id).first()
         room_name = room.name
         subject = 'Your room reservation was rejected'
@@ -77,7 +78,7 @@ class EmailNotification:
 
         return EmailNotification.send_email_notification(
             self,
-            email=user_email,
+            email=[user_email],
             subject='Converge - Your role has been changed',
             user_name=user_name,
             template='change_role.html',


### PR DESCRIPTION
### Description
This PR adds the capability to send both the organizer or host and invitees an email notification when the event is auto-canceled. The event is auto-canceled after 10 minutes of no check-in.
### Type of change
This is a new feature.
### How Has This Been Tested?

- Clone the repo: git clone https://github.com/andela/mrm_api.git.
- Setup the project as per the ` README.md `.
- Checkout to branch ` story/CON-171-send-invitees-email-when-event-is-autocancelled `.
- Create an event on your google calendar and invite a few people. While creating your event on google calendar, add the mrm-api ` converge dummy room` as your room.
- Run the following mutation to sync your new event with the database ` syncEventData `.
```
mutation {
    syncEventData{
        message
    }
}
```
- Run the following mutation to trigger event cancellation.
```
mutation {
    cancelEvent(
        calendarId:"calendar_id",
        eventId:"event_id",
        eventTitle:"demo title",
        numberOfParticipants: 2,
        startTime:"meeting_start_time",
        endTime:"meeting_end_time") {
        event {
            eventId
            roomId
            checkedIn
            cancelled
            room {
                id
                name
                calendarId
            }
        }
    }
}
```
Ensure to match your `calendarId`, `eventId`, `startTime` and `endTime` as per your event in the events table in the database.
### JIRA
[CON-171](https://andela-apprenticeship.atlassian.net/browse/CON-171)