### PR TITLE
CON-168 Restrict an admin from creating super admins.

### DIFF
--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -16,6 +16,7 @@ from utilities.utility import update_entity_fields
 from api.role.schema import Role
 from api.role.models import Role as RoleModel
 from api.location.models import Location as LocationModel
+from helpers.user_role.restrict_admin import check_admin_restriction
 
 
 class User(SQLAlchemyObjectType):
@@ -186,13 +187,13 @@ class ChangeUserRole(graphene.Mutation):
         if new_role.role == current_user_role:
             raise GraphQLError('This role is already assigned to this user')
 
+        check_admin_restriction(new_role.role)
         exact_user.roles[0] = new_role
         exact_user.save()
 
         if not notification.send_changed_role_email(
                 email, exact_user.name, new_role.role):
             raise GraphQLError("Role changed but email not sent")
-
         return ChangeUserRole(user=exact_user)
 
 

--- a/fixtures/analytics/query_all_analytics_fixtures.py
+++ b/fixtures/analytics/query_all_analytics_fixtures.py
@@ -123,7 +123,7 @@ all_analytics_query_response_super_admin_with_invalid_locationid = {
             "message": "Location Id does not exist",
             "locations": [
                 {
-                    "line": 2,
+                    "line": 3,
                     "column": 7
                 }
             ],

--- a/fixtures/role/role_fixtures.py
+++ b/fixtures/role/role_fixtures.py
@@ -57,6 +57,9 @@ role_query_response = {
             {
                 "role": "Test"
             },
+            {
+                "role": "Super Admin"
+            },
         ]
     }
 }

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -112,7 +112,20 @@ query_user_email_response = {
 
 change_user_role_mutation = '''
 mutation{
-    changeUserRole(email:"peter.walugembe@andela.com", roleId: 2){
+    changeUserRole(email:"peter.walugembe@andela.com", roleId: 1){
+        user{
+            name
+            roles{
+                role
+            }
+        }
+    }
+}
+'''
+
+change_user_role_to_super_admin_mutation = '''
+mutation{
+    changeUserRole(email:"peter.walugembe@andela.com", roleId: 3){
         user{
             name
             roles{

--- a/helpers/user_role/restrict_admin.py
+++ b/helpers/user_role/restrict_admin.py
@@ -1,0 +1,15 @@
+from graphql import GraphQLError
+from helpers.auth.user_details import get_user_from_db
+from api.role.models import Role as RoleModel
+
+
+def check_admin_restriction(new_role):
+    '''
+        Restricting users who is not a super admin
+        from assigning the role 'super Admin.'
+    '''
+    admin_details = get_user_from_db()
+    admin_role = RoleModel.query.filter_by(
+        id=admin_details.roles[0].id).first()
+    if admin_role.role != 'Super Admin' and new_role == 'Super Admin':
+        raise GraphQLError('You are not authorized to assign this role')

--- a/tests/base.py
+++ b/tests/base.py
@@ -65,6 +65,8 @@ class BaseTestCase(TestCase):
             role.save()
             role_2 = Role(role="Test")
             role_2.save()
+            role_3 = Role(role="Super Admin")
+            role_3.save()
             admin_user.roles.append(role)
             lagos_admin.roles.append(role)
             tag = Tag(name='Block-B',
@@ -396,25 +398,12 @@ def change_test_user_role(func):
     return func_wrapper
 
 
-def change_test_user_role_to_super_admin(func):
+def change_user_role_to_super_admin(func):
     def func_wrapper(self):
-        user_role = Role(role='Super Admin')
-        user_role.save()
-        user = User(email='mrmtestuser@andela.com', name='Test user',
-                    location="Lagos", picture='www.andela.com/testuser')
-        user.save()
-        user.roles.append(user_role)
-        db_session().commit()
-    return func_wrapper
-
-
-def change_admin_user_role_to_super_admin(func):
-    def func_wrapper(self):
-        user_role = Role(role='Super Admin')
-        user_role.save()
+        super_admin_role = Role.query.filter_by(role='Super Admin').first()
         user = User.query.filter_by(email="peter.walugembe@andela.com").first()
         user.roles.pop()
-        user.roles.append(user_role)
+        user.roles.append(super_admin_role)
         user.save()
         db_session().commit()
         return func(self)

--- a/tests/test_analytics/test_all_analytics_query.py
+++ b/tests/test_analytics/test_all_analytics_query.py
@@ -1,14 +1,13 @@
 from tests.base import (
     BaseTestCase,
     CommonTestCases,
-    change_test_user_role_to_super_admin
+    change_user_role_to_super_admin
 )
 from fixtures.analytics.query_all_analytics_fixtures import (
     all_analytics_query,
     all_analytics_query_response,
     all_analytics_query_invalid_locationid,
     analytics_query_for_date_ranges,
-    all_analytics_query_response_super_admin,
     all_analytics_query_response_super_admin_with_invalid_locationid
 )
 
@@ -27,17 +26,17 @@ class TestAllAnalytics(BaseTestCase):
             all_analytics_query_response
         )
 
-    @change_test_user_role_to_super_admin
+    @change_user_role_to_super_admin
     def test_all_analytics_query_super_admin(self):
         """
         Tests that a super admin user can query for analytics
 
         """
 
-        CommonTestCases.super_admin_token_assert_equal(
+        CommonTestCases.admin_token_assert_equal(
             self,
             all_analytics_query,
-            all_analytics_query_response_super_admin
+            all_analytics_query_response
         )
 
         CommonTestCases.super_admin_token_assert_equal(

--- a/tests/test_logs/test_logs_endpoint.py
+++ b/tests/test_logs/test_logs_endpoint.py
@@ -1,13 +1,13 @@
 import os
 import sys
-from tests.base import BaseTestCase, change_admin_user_role_to_super_admin
+from tests.base import BaseTestCase, change_user_role_to_super_admin
 from fixtures.token.token_fixture import ADMIN_TOKEN
 
 sys.path.append(os.getcwd())
 
 
 class TestLogs(BaseTestCase):
-    @change_admin_user_role_to_super_admin
+    @change_user_role_to_super_admin
     def test_super_admin_can_view_logs(self):
         """
         Test successful display of the backend logs by the super admin

--- a/tests/test_user/test_change_user_role.py
+++ b/tests/test_user/test_change_user_role.py
@@ -6,8 +6,10 @@ from fixtures.user.user_fixture import (
     change_role_of_non_existing_user_mutation,
     assign_role_to_non_existing_user_mutation,
     change_user_role_with_already_assigned_role_mutation,
-    change_user_role_with_already_assigned_role_mutation_response
+    change_user_role_with_already_assigned_role_mutation_response,
+    change_user_role_to_super_admin_mutation
 )
+from tests.base import change_user_role_to_super_admin
 
 import sys
 import os
@@ -15,6 +17,7 @@ sys.path.append(os.getcwd())
 
 
 class TestChangeUserRole(BaseTestCase):
+    @change_user_role_to_super_admin
     def test_change_user_role(self):
         """
         Testing change of user role
@@ -61,3 +64,13 @@ class TestChangeUserRole(BaseTestCase):
             change_user_role_with_already_assigned_role_mutation,
             change_user_role_with_already_assigned_role_mutation_response
         )
+
+    def test_restricting_admin_to_create_super_admin(self):
+        """
+        Testing restriction of an admin to create a super admin
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            change_user_role_to_super_admin_mutation,
+            "You are not authorized to assign this role"
+            )


### PR DESCRIPTION
#### Description
This Pull request restricts an admin from creating a super admin. 

#### Context of the problem to be solved. 
On our application, a super admin can be created by an admin, this PR ensures that an admin is restricted from creating a super admin. 

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `story/CON-168-stop-admin-to-create-super-admin`
4. run the following query to change the role of a user. Make sure the email is valid and already exists in our database and its role_id = 2 or 1

```
mutation{
  changeUserRole(email:"email@andela.com", roleId: 3){
    user{
      id
      roles{
        id
      }
    }
  }
}
```

#### Type of Change
- [x] New feature (non-breaking change which adds functionality

#### How has this been tested
- [x] Unit tests
- [x] Integration tests

#### Checklist
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations



#### JIRA
[CON-168](https://andela-apprenticeship.atlassian.net/browse/CON-168)
