### PR TITLE
CON-210 Fix null user location

### DIFF
--- a/helpers/auth/authentication.py
+++ b/helpers/auth/authentication.py
@@ -133,21 +133,17 @@ class Authentication:
                         user = User.query.filter_by(email=email).first()
                     except Exception:
                         raise GraphQLError("The database cannot be reached")
-                    user_values = response['values']
-                    if len(user_values):
-                        for value in user_values:
-                            if user.email == value["email"]:
-                                if value['location'] and not user.location:
-                                    user_location = value['location'][
-                                        'name'
-                                    ] or "Nairobi"
-                                    user.location = user_location
-                                    user.save()
-                                    check_and_add_location(user_location)
-                    else:  # pragma: no cover
-                        if not user.location:
-                            user.location = "Nairobi"
-                            user.save()
+                    for value in response['values']:
+                        if user.email == value["email"]:
+                            if value['location'] and not user.location:
+                                user_location = value['location']['name']
+                                user.location = user_location
+                                user.save()
+                                check_and_add_location(user_location)
+                    if not user.location:  # pragma: no cover
+                        user.location = "Nairobi"
+                        user.save()
+                        check_and_add_location(user.location)
                     if user.roles and user.roles[0].role in expected_args:
                         return func(*args, **kwargs)
                     else:


### PR DESCRIPTION
## Description ##
 The issue of `null` user location in the DB is not yet fully fixed. Users with `null` location value on the Andela API still have their location set to `null` in our DB. This PR ensures the location field is default to Nairobi whenever there is no valid location detail from the Andela API.

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### JIRA
[CON-210](https://andela-apprenticeship.atlassian.net/browse/CON-210)