### PR TITLE
CON-208 Enable regular user to query office structure

### DIFF
--- a/api/structure/schema.py
+++ b/api/structure/schema.py
@@ -154,7 +154,7 @@ class Query(graphene.ObjectType):
         Structure, structure_id=graphene.String(), description="Returns the office \
         structure corresponding to the provided structureId")
 
-    @Auth.user_roles('Admin', 'Super_Admin')
+    @Auth.user_roles('Admin', 'Default User', 'Super_Admin')
     def resolve_all_structures(self, info):
         query = Structure.get_query(info)
         location_id = admin_roles.user_location_for_analytics_view()
@@ -163,7 +163,7 @@ class Query(graphene.ObjectType):
             StructureModel.location_id == location_id).all()
         return all_structures
 
-    @Auth.user_roles('Admin', 'Super_Admin')
+    @Auth.user_roles('Admin', 'Default User', 'Super_Admin')
     def resolve_structure_by_structure_id(self, info, structure_id):
         if not structure_id.strip():
             raise GraphQLError("Please input a valid structureId")


### PR DESCRIPTION
#### Description
This Pull request enables a non-admin user to fetch an office structure

#### Context of the problem to be solved. 
On our application, only super admin user or admin user can query the office structure, this PR ensures that a regular user is authenticated to allow access to the office structure as well. 

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `story/CON-208-enable-regular-user-to-query-office-structure`
4. For token authorization, make sure that the email used is valid and already exists in our database and it's of role_id =  1(default user)

**How should this be manually tested?**

- use the query below to get all office structures
```query {
  allStructures {
    name
    tag
    locationId
  }
```
- use the query below to get a single office structure

```query {
  structureByStructureId(structureId: "some structureId") {
    name
    tag
    locationId
  }
```

#### Type of Change
- [x] New feature (non-breaking change which adds functionality

#### How has this been tested
- [x] Unit tests
- [x] Integration tests

#### Checklist
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations



#### JIRA
[CON-208](https://andela-apprenticeship.atlassian.net/browse/CON-208)
