### PR TITLE
CON-207 Display backend logs through http

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 from flask import Flask, render_template
-
 from flask_graphql import GraphQLView
 from flask_cors import CORS
 from flask_json import FlaskJSON
@@ -11,6 +10,7 @@ from schema import schema
 from healthcheck_schema import healthcheck_schema
 from helpers.auth.authentication import Auth
 from api.analytics.analytics_request import AnalyticsRequest
+from utilities.file_reader import read_log_file
 
 mail = Mail()
 
@@ -26,6 +26,12 @@ def create_app(config_name):
     @app.route("/", methods=['GET'])
     def index():
         return render_template('index.html')
+
+    @app.route("/logs", methods=['GET'])
+    @Auth.user_roles('Super Admin', 'REST')
+    def logs():
+        log_file = 'mrm.err.log'
+        return app.response_class(read_log_file(log_file), mimetype='text')
 
     app.add_url_rule(
         '/mrm',

--- a/tests/base.py
+++ b/tests/base.py
@@ -206,6 +206,10 @@ class BaseTestCase(TestCase):
             )
             structure.save()
             db_session.commit()
+            f = open('mrm.err.log', 'a+')
+            f.write('[2019-08-06 13:22:32 +0000] [1574] [ERROR] Error /logs\r')
+            f.write('Traceback (most recent call last):\r')
+            f.write('if pattern.search(line):\r')
 
     def get_admin_location_id(self):
         payload = jwt.decode(ADMIN_TOKEN, verify=False)
@@ -383,4 +387,17 @@ def change_test_user_role_to_super_admin(func):
         user.save()
         user.roles.append(user_role)
         db_session().commit()
+    return func_wrapper
+
+
+def change_admin_user_role_to_super_admin(func):
+    def func_wrapper(self):
+        user_role = Role(role='Super Admin')
+        user_role.save()
+        user = User.query.filter_by(email="peter.walugembe@andela.com").first()
+        user.roles.pop()
+        user.roles.append(user_role)
+        user.save()
+        db_session().commit()
+        return func(self)
     return func_wrapper

--- a/tests/test_logs/test_logs_endpoint.py
+++ b/tests/test_logs/test_logs_endpoint.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from tests.base import BaseTestCase, change_admin_user_role_to_super_admin
+from fixtures.token.token_fixture import ADMIN_TOKEN
+
+sys.path.append(os.getcwd())
+
+
+class TestLogs(BaseTestCase):
+    @change_admin_user_role_to_super_admin
+    def test_super_admin_can_view_logs(self):
+        """
+        Test successful display of the backend logs by the super admin
+        """
+        url = '/logs'
+        headers = {"Authorization": "Bearer " + ADMIN_TOKEN}
+        response = self.app_test.get(url, headers=headers)
+        self.assert200(response)

--- a/utilities/file_reader.py
+++ b/utilities/file_reader.py
@@ -1,0 +1,19 @@
+import re
+
+
+def read_log_file(log_file):
+    """
+    Function that accepts log file and opens it.
+    Opens the file in reverse order, iterates through
+    every line to return the logs.
+    """
+    timestamp_pattern = re.compile(r'(\d+-\d+-\d+ \d+:\d+:\d+)')
+    error_details = []
+    for line in reversed(list(open(log_file, 'r'))):
+        if timestamp_pattern.search(line):  # check if line contains timestamp
+            yield line
+            for detail in reversed(error_details):
+                yield detail
+            error_details.clear()
+        else:
+            error_details.append(line)  # add error log details to a list


### PR DESCRIPTION
#### Description
This PR enables the  Super Admin to view backend logs through a HTTP get request. The most recent logs appear at the top. Currently, we have to wait for the dev ops team to provide us with the log file on the staging app whenever debugging is required. This features enables one to view the logs immediately thus reducing the debugging time.

#### How this should be manually tested
Clone the repo: git clone https://github.com/andela/mrm_api.git.
Setup the project as per the README.md.
Checkout to branch story/CON-207-display-backend-logs.
On your Insomnia, go to url `localhost:8000/logs` and send a `GET REQUEST` using a `Super Admin token`. 
 
#### Type of change
- [ ] Bug fix (nonbreaking change which fixes an issue)
- [x] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [x] End to end
- [x] Integration

#### Checklist:
- [x] My code follows the style guide for this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Screenshots
![image](https://user-images.githubusercontent.com/41931013/62288842-f5337e80-b465-11e9-81c1-6a597717e7d1.png)



#### Jira
[CON-207](https://andela-apprenticeship.atlassian.net/jira/software/projects/CON/boards/15/backlog?label=backend&selectedIssue=CON-207)
