### PR TITLE
CON-231 Mock test calendar api calls

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -7,6 +7,7 @@ from flask_testing import TestCase
 from graphene.test import Client
 from datetime import datetime
 from alembic import command, config
+from unittest.mock import patch
 
 from app import create_app
 from schema import schema
@@ -38,7 +39,8 @@ class BaseTestCase(TestCase):
         self.client = Client(schema)
         return app
 
-    def setUp(self):
+    @patch('api.room.models.verify_calendar_id')
+    def setUp(self, mock_verify_calendar_id):
         app = self.create_app()
         self.app_test = app.test_client()
         with app.app_context():

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -28,7 +28,8 @@ sys.path.append(os.getcwd())
 class TestCreateRoom(BaseTestCase):
 
     @patch('api.room.schema.subscriber.add_room.delay')
-    def test_room_creation(self, mock_subscriber):
+    @patch('api.room.models.verify_calendar_id')
+    def test_room_creation(self, mock_calendar_id, mock_subscriber):
         """
         Testing for room creation
         """
@@ -71,7 +72,8 @@ class TestCreateRoom(BaseTestCase):
             "Room label is not a valid string type")
 
     @patch('api.room.schema.subscriber.add_room.delay')
-    def test_valid_room_label_format(self, mock_subscriber):
+    @patch('api.room.models.verify_calendar_id')
+    def test_valid_room_label_format(self, mock_calendar_id, mock_subscriber):
         """
         Test when the room label inserted is valid
         """


### PR DESCRIPTION
## Description ##
 Currently, API calls are made to google calendar during tests, as there is an event listener in the room model that validates `calendar_ids` whenever a new row is inserted. Since our test `setUp` method creates rooms, and since this method is called per test case, this slows down our tests.  This PR ensures the google calendar API call is mocked, thereby, significantly reducing test run time.

### How Has This Been Tested?
  - Checkout this branch and run tests
  - Checkout `develop` and run tests
  - Compare the runtime

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### JIRA
[CON-231](https://andela-apprenticeship.atlassian.net/browse/CON-231)