### PR TITLE
CON-200 Prevent users from having multiple roles

### DIFF
--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -278,6 +278,9 @@ class CreateUserRole(graphene.Mutation):
             if not exact_role:
                 raise GraphQLError('Role id does not exist')
 
+            if len(exact_user.roles) > 0:
+                raise GraphQLError('This user is already assigned a role')
+
             exact_user.roles.append(exact_role)
             exact_user.save()
 

--- a/fixtures/user_role/user_role_fixtures.py
+++ b/fixtures/user_role/user_role_fixtures.py
@@ -12,6 +12,19 @@ mutation{
 }
 '''
 
+user_mutation_query_for_duplicated_role = '''
+mutation{
+  createUserRole(userId: 1, roleId: 1){
+    userRole{
+      id
+      roles{
+        id
+      }
+    }
+  }
+}
+'''
+
 user_role_mutation_response = {
     "data": {
         "createUserRole": {

--- a/tests/test_user/test_create_user.py
+++ b/tests/test_user/test_create_user.py
@@ -48,4 +48,5 @@ class TestCreateUser(BaseTestCase):
         query_response = self.client.execute(
             non_Andela_email_mutation,
             context_value={'session': db_session})
-        self.assertEqual(query_response, non_Andela_email_mutation_response)
+        response_expected = non_Andela_email_mutation_response
+        self.assertEqual(query_response, response_expected)

--- a/tests/test_user_roles/test_create_user_role.py
+++ b/tests/test_user_roles/test_create_user_role.py
@@ -1,13 +1,22 @@
 from tests.base import BaseTestCase
 from fixtures.user_role.user_role_fixtures import (
-    user_role_mutation_query, user_role_mutation_response
+    user_role_mutation_query,
+    user_role_mutation_response,
+    user_mutation_query_for_duplicated_role,
 )
 from helpers.database import db_session
 from api.user.models import User
-
 import sys
 import os
 sys.path.append(os.getcwd())
+
+
+def create_user():
+    user = User(email="info@andela.com", location="Lagos",
+                name="test test",
+                picture="www.andela.com/test")
+    user.save()
+    db_session().commit()
 
 
 class TestCreateUserRole(BaseTestCase):
@@ -16,15 +25,26 @@ class TestCreateUserRole(BaseTestCase):
         """
         Testing for User Role creation
         """
-        user = User(email="info@andela.com", location="Lagos",
-                    name="test test",
-                    picture="www.andela.com/test")
-        user.save()
-        db_session().commit()
+
+        create_user()
 
         execute_query = self.client.execute(
             user_role_mutation_query,
             context_value={'session': db_session})
 
-        expected_responese = user_role_mutation_response
-        self.assertEqual(execute_query, expected_responese)
+        expected_response = user_role_mutation_response
+        self.assertEqual(execute_query, expected_response)
+
+    def test_user_role_duplication(self):
+        """
+        This test that one user can't be assigned two different roles
+        """
+        create_user()
+        use_query = self.client.execute(
+            user_mutation_query_for_duplicated_role,
+            context_value={'session': db_session})
+
+        self.assertIn(
+            "This user is already assigned a role",
+            str(use_query)
+            )


### PR DESCRIPTION
#### Description
This Pull request checks if a user was already assigned a role and doesn't allow for a duplicate in the role's table. 

#### Context of the problem to be solved. 

The user was allowed to be assigned two roles, now a user should only have one role.  

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `story/CON-200-validating-duplicates`
4. run the following query to create a user role. Make sure this user already exists and has at least one role assigned to him/her
```
mutation{
  createUserRole(userId: (user-role), roleId: 2){
    userRole{
      id
      roles{
        id
      }
    }
  }
}``

#### Type of Change
- [x] New feature (non-breaking change which adds functionality

#### How has this been tested
- [x] Unit tests
- [x] Integration tests

#### Checklist
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations



#### JIRA
[CON-200](https://andela-apprenticeship.atlassian.net/browse/CON-200)