### PR TITLE
CON-249 Get full path of node

### DIFF
--- a/fixtures/office_structure/query_structure_fixture.py
+++ b/fixtures/office_structure/query_structure_fixture.py
@@ -1,0 +1,35 @@
+null = None
+
+node_path_by_name_query = """
+query {
+  nodePathByName(nodeName: "Gold Coast", order: ASC) {
+    name
+    tag
+  }
+}
+"""
+
+node_path_by_name_response = {
+    "data": {
+        "nodePathByName": [
+          {
+            "name": "Epic Tower",
+            "tag": "Lagos Building"
+          },
+          {
+            "name": "Gold Coast",
+            "tag": "First Floor"
+          }
+        ]
+      }
+    }
+
+
+node_path_by_name_invalid_node_query = """
+    query {
+      nodePathByName(nodeName: "Kente", order: ASC) {
+        name
+        tag
+      }
+    }
+    """

--- a/schema.py
+++ b/schema.py
@@ -34,6 +34,7 @@ class Query(
         api.structure.schema.Query,
         api.analytics.all_analytics_query.Query,
         api.events.schema.Query,
+        api.office_structure.schema.Query
 ):
     """Root for converge Graphql queries"""
     pass

--- a/tests/test_office_structure/test_query_structure.py
+++ b/tests/test_office_structure/test_query_structure.py
@@ -1,0 +1,32 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.office_structure.query_structure_fixture import (
+    node_path_by_name_query,
+    node_path_by_name_response,
+    node_path_by_name_invalid_node_query
+)
+
+
+class TestQueryStructure(BaseTestCase):
+
+    def test_node_path_by_name(self):
+        """
+        Test to get the full path of a node given the node_name
+        """
+
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            node_path_by_name_query,
+            node_path_by_name_response
+        )
+
+    def test_node_path_by_name_invalid_node(self):
+        """
+        Test to show that error will be returned if no node with
+        provided node_name exists
+        """
+
+        CommonTestCases.admin_token_assert_in(
+            self,
+            node_path_by_name_invalid_node_query,
+            "node not found"
+        )


### PR DESCRIPTION
## Description ##
 We want to be able to get the full path of a node. i.e. the node, its parent, its grandparent, ....  root_node. The node could be a `room`, `floor` or `wing` in the structure.
If for example, you pass a `node` named `Mara`, it should return `Mara -> Right Wing -> 4th Floor -> ET`


**How should this be manually tested?**
   - Make sure you have a valid structure in your db. You can refer to [480](https://github.com/andela/mrm_api/pull/480)
   - Use the query below to get the full path of a `node/room` called `Mara`.
   - The `order` field is optional and is `DESC` by default.
```
query {
  nodePathByName(nodeName: "Mara", order: ASC) {
    id
    name
    tag
    parent {
      name
    }
  }
}

```

## Type of change ##
Please select the relevant option
- [ ] Bug fix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### JIRA
[CON-249](https://andela-apprenticeship.atlassian.net/browse/CON-249)