### PR TITLE
CON 254 Implement functionality to enable users set their location

### DIFF
--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -334,21 +334,21 @@ change_user_location_invalid_user_mutation = '''
 
 change_user_location_invalid_user_response = {
     "errors": [
-      {
-        "message": "User not found",
-        "locations": [
-          {
-            "line": 3,
-            "column": 9
-          }
-        ],
-        "path": [
-          "changeUserLocation"
-        ]
-      }
+        {
+            "message": "User not found",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 9
+                }
+            ],
+            "path": [
+                "changeUserLocation"
+            ]
+        }
     ],
     "data": {
-      "changeUserLocation": null
+        "changeUserLocation": null
     }
 }
 
@@ -364,23 +364,23 @@ change_user_location_invalid_location_id_mutation = '''
   '''
 
 change_user_location_invalid_location_id_response = {
-  "errors": [
-    {
-      "message": "the location supplied does not exist",
-      "locations": [
+    "errors": [
         {
-          "line": 3,
-          "column": 7
+            "message": "the location supplied does not exist",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 7
+                }
+            ],
+            "path": [
+                "changeUserLocation"
+            ]
         }
-      ],
-      "path": [
-        "changeUserLocation"
-      ]
+    ],
+    "data": {
+        "changeUserLocation": null
     }
-  ],
-  "data": {
-    "changeUserLocation": null
-  }
 }
 
 change_user_location_to_same_location_mutation = '''
@@ -395,23 +395,23 @@ change_user_location_to_same_location_mutation = '''
    '''
 
 change_user_location_to_same_location_response = {
-  "errors": [
-    {
-      "message": "user already in this location",
-      "locations": [
+    "errors": [
         {
-          "line": 3,
-          "column": 9
+            "message": "user already in this location",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 9
+                }
+            ],
+            "path": [
+                "changeUserLocation"
+            ]
         }
-      ],
-      "path": [
-        "changeUserLocation"
-      ]
+    ],
+    "data": {
+        "changeUserLocation": null
     }
-  ],
-  "data": {
-    "changeUserLocation": null
-  }
 }
 
 change_user_location_valid_input_mutation = '''
@@ -426,12 +426,95 @@ change_user_location_valid_input_mutation = '''
    '''
 
 change_user_location_valid_input_response = {
-  "data": {
-    "changeUserLocation": {
-      "user": {
-        "name": "Peter Walugembe",
-        "location": "Nairobi"
-      }
+    "data": {
+        "changeUserLocation": {
+            "user": {
+                "name": "Peter Walugembe",
+                "location": "Nairobi"
+            }
+        }
+    }
+}
+
+set_user_location_mutation = '''
+mutation {
+  setUserLocation(locationId: 2){
+    user{
+      email
+      location
     }
   }
+}
+'''
+set_user_location_exists_mutation = '''
+mutation {
+  setUserLocation(locationId: 1){
+    user{
+      email
+      location
+    }
+  }
+}
+'''
+
+set_user_location_exists_invalid_location = '''
+mutation {
+  setUserLocation(locationId: 10000){
+    user{
+      email
+      location
+    }
+  }
+}
+'''
+
+set_user_location_mutation_response = {
+    "data": {
+        "setUserLocation": {
+            "user": {
+                "email": "peter.adeoye@andela.com",
+                "location": "Nairobi"
+            }
+        }
+    }
+}
+
+set_location_for_user_with_location_response = {
+    "errors": [
+        {
+            "message": "This user already has a location set.",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 3
+                }
+            ],
+            "path": [
+                "setUserLocation"
+            ]
+        }
+    ],
+    "data": {
+        "setUserLocation": None
+    }
+}
+
+set_user_location_exists_invalid_location_response = {
+    "errors": [
+        {
+            "message": "The location supplied does not exist",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 3
+                }
+            ],
+            "path": [
+                "setUserLocation"
+            ]
+        }
+    ],
+    "data": {
+        "setUserLocation": None
+    }
 }

--- a/helpers/auth/authentication.py
+++ b/helpers/auth/authentication.py
@@ -121,15 +121,8 @@ class Authentication:
                     for value in response['values']:
                         if user_data.email == value["email"]:
                             if value['location']:  # pragma: no cover
-                                user_data.location = value['location'][
-                                    'name'
-                                ] or "Nairobi"
-                                user_data.save()
-                    user_data.save()  # pragma: no cover
-                    if not user_data.location:  # pragma: no cover
-                        user_data.location = "Nairobi"
-                        user_data.save()
-                        check_and_add_location(user_data.location)
+                                check_and_add_location(
+                                    value['location']['name'])
                     notification_settings = NotificationModel(
                         user_id=user_data.id)
                     notification_settings.save()

--- a/tests/test_user/test_set_user_location.py
+++ b/tests/test_user/test_set_user_location.py
@@ -1,0 +1,39 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.user.user_fixture import (
+    set_user_location_mutation,
+    set_user_location_mutation_response,
+    set_user_location_exists_mutation,
+    set_location_for_user_with_location_response,
+    set_user_location_exists_invalid_location,
+    set_user_location_exists_invalid_location_response
+
+)
+
+
+class TestSetUserLocation(BaseTestCase):
+    def test_change_user_location_invalid_location_id(self):
+        """
+        Test that the supplied location must exist in the database
+        """
+        CommonTestCases.lagos_admin_token_assert_equal(
+            self, set_user_location_exists_invalid_location,
+            set_user_location_exists_invalid_location_response
+        )
+
+    def test_set_user_location(self):
+        """
+        Test to set a location for a user with no location
+        """
+        CommonTestCases.lagos_admin_token_assert_equal(
+            self, set_user_location_mutation,
+            set_user_location_mutation_response
+        )
+
+    def test_set_user_location_when_location_exists(self):
+        """
+        Test to set a location for a user who already has a location
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self, set_user_location_exists_mutation,
+            set_location_for_user_with_location_response
+        )


### PR DESCRIPTION

#### Description
This Pull request makes it possible for users to set a new location after sign up. Currently, when new users join the application they have a token set for the from the Andela API which is not always correct. we want to stop the autosave and enable users set for themselves

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to Readme.md
3. checkout to branch `story/CON-254-allow-users-set-location`
4. run the following query to set a new location for a user who doesn't have a location set. 
```
mutation {
  setUserLocation(locationId: 2){
    user{
      email
    }
  }
}
```

#### Type of Change
- [x] New feature (non-breaking change which adds functionality

#### How has this been tested
- [ ] Unit tests
- [ ] Integration tests

#### Checklist
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations



#### JIRA
[CON-254](https://andela-apprenticeship.atlassian.net/browse/CON-254)