### PR TITLE
CON-252 Delete node by its id

### DIFF
--- a/fixtures/office_structure/delete_office_structure_fixtures.py
+++ b/fixtures/office_structure/delete_office_structure_fixtures.py
@@ -1,0 +1,33 @@
+delete_node_by_id_mutation = """
+mutation{
+  deleteNode(nodeId:"C56A4180-65AA-42EC-A945-5FD21DEC0519"){
+    node{
+      id
+      name
+    }
+  }
+}
+"""
+
+delete_node_by_id_response = {
+    "data": {
+        "deleteNode": {
+            "node": {
+                "id": "c56a4180-65aa-42ec-a945-5fd21dec0519",
+                "name": "Gold Coast",
+            }
+        }
+    }
+}
+
+
+delete_node_invalid_id_mutation = """
+mutation{
+  deleteNode(nodeId:"C56A4180-65AA-42EC-A945-5FD21DEC0535"){
+    node{
+      id
+      name
+    }
+  }
+}
+"""

--- a/tests/test_office_structure/test_delete_node.py
+++ b/tests/test_office_structure/test_delete_node.py
@@ -1,0 +1,32 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.office_structure.delete_office_structure_fixtures import (
+    delete_node_by_id_mutation,
+    delete_node_by_id_response,
+    delete_node_invalid_id_mutation
+)
+
+
+class TestDeleteNode(BaseTestCase):
+
+    def test_delete_node_by_id(self):
+        """
+        Tests to delete a node given the node id
+        """
+
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            delete_node_by_id_mutation,
+            delete_node_by_id_response
+        )
+
+    def test_delete_node_by_id_invalid_node_id(self):
+        """
+        Test to show that error will be returned if no node with
+        provided node id exists
+        """
+
+        CommonTestCases.admin_token_assert_in(
+            self,
+            delete_node_invalid_id_mutation,
+            "The specified node does not exist"
+        )


### PR DESCRIPTION
#### Description
This feature enables the super admin or admin user to delete a node by use of its id. 

#### How this should be manually tested
Clone the repo: git clone https://github.com/andela/mrm_api.git.
Setup the project as per the README.md.
Checkout to branch story/CON-252-delete-node-by-id.
Make sure you have a valid structure in your db. You can refer to  [480](https://github.com/andela/mrm_api/pull/480)
Use the query below to delete an existing node:
```
mutation{
  deleteNode(nodeId:"c56a4180-65aa-42ec-a945-5fd21dec0536"){
    node{
      id
      name
    }
  }
}
``` 
#### Type of change
- [ ] Bug fix (nonbreaking change which fixes an issue)
- [x] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [x] End to end
- [x] Integration

#### Checklist:
- [x] My code follows the style guide for this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Jira
[CON-252](https://andela-apprenticeship.atlassian.net/browse/CON-252)