### PR TITLE
CON-211 Fix meeting room issue on staging

### DIFF
--- a/api/analytics/analytic_report.py
+++ b/api/analytics/analytic_report.py
@@ -50,9 +50,7 @@ class AnalyticsReport():
 
         rooms_no_meetings_df = all_rooms_data_df.loc[
             lambda all_rooms_data_df: all_rooms_data_df['minutes'] == 0].rename(
-                columns={
-                    'roomName': 'Room'
-                }).assign(Meetings=0)
+                columns={'roomName': 'Room'}).assign(Meetings=0)
 
         rooms_no_meetings_df = rooms_no_meetings_df[['Room', 'Meetings']]
 
@@ -172,8 +170,7 @@ class AnalyticsReport():
             report_data_frame['Most Used Rooms'],
             report_data_frame['Least Used Rooms'],
             '<h1>Room Analytics Report Summary</h1><p> <h2>Report Period: From ' + start_date_formatted + ' to ' + end_date_formatted + '</h2>',   # noqa
-            'templates/analytics_report.html'
-            )
+            'templates/analytics_report.html')
         rendered = render_template('analytics_report.html')
 
         return rendered

--- a/fixtures/analytics/query_all_analytics_fixtures.py
+++ b/fixtures/analytics/query_all_analytics_fixtures.py
@@ -69,7 +69,7 @@ all_analytics_query_response = {
       "bookings": 1,
       "analytics": [
         {
-          "roomName": "Entebbe",
+          "roomName": "Entebbe Test",
           "cancellations": 0,
           "cancellationsPercentage": 0.0,
           "autoCancellations": 0,
@@ -86,7 +86,24 @@ all_analytics_query_response = {
           ]
         },
         {
-          "roomName": "Tana",
+          "roomName": "Tana Dummy",
+          "cancellations": 0,
+          "cancellationsPercentage": 0.0,
+          "autoCancellations": 0,
+          "numberOfBookings": 0,
+          "checkins": 0,
+          "checkinsPercentage": 0.0,
+          "bookingsPercentageShare": 0.0,
+          "appBookings": 0,
+          "appBookingsPercentage": 0.0,
+          "events": [
+            {
+              "durationInMinutes": 0
+            }
+          ]
+        },
+        {
+          "roomName": "Kampala",
           "cancellations": 0,
           "cancellationsPercentage": 0.0,
           "autoCancellations": 0,

--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -233,6 +233,18 @@ delete_device_mutation = '''
             }
 '''
 
+delete_non_exiting_device_mutation = '''
+    mutation{
+        deleteDevice(
+            deviceId:1000
+            ){
+                device{
+                    id
+                }
+            }
+        }
+'''
+
 delete_device_response = {
   "data": {
     "deleteDevice": {

--- a/fixtures/events/end_event_fixtures.py
+++ b/fixtures/events/end_event_fixtures.py
@@ -31,7 +31,7 @@ end_event_mutation_response = {
         "meetingEndTime": "2018-07-10T09:45:00Z",
         "room": {
           "id": "1",
-          "name": "Entebbe",
+          "name": "Entebbe Test",
           "calendarId": "andela.com_3630363835303531343031@resource.calendar.google.com"  # noqa: E501
         }
       }

--- a/fixtures/events/event_checkin_fixtures.py
+++ b/fixtures/events/event_checkin_fixtures.py
@@ -30,7 +30,7 @@ event_checkin_response = {
                 "cancelled": False,
                 "room": {
                     "id": "1",
-                    "name": "Entebbe",
+                    "name": "Entebbe Test",
                     "calendarId": "andela.com_3630363835303531343031@resource.calendar.google.com"  # noqa
                 }
             }
@@ -160,7 +160,7 @@ response_for_event_existing_in_db_checkin = {
                 "cancelled": False,
                 "room": {
                     "id": "1",
-                    "name": "Entebbe",
+                    "name": "Entebbe Test",
                     "calendarId": "andela.com_3630363835303531343031@resource.calendar.google.com"  # noqa
                 }
             }

--- a/fixtures/events/events_query_by_date_fixtures.py
+++ b/fixtures/events/events_query_by_date_fixtures.py
@@ -93,7 +93,7 @@ event_query_with_pagination_response = {
                     'id': '1',
                     'roomId': 1,
                     'room': {
-                        'name': 'Entebbe'
+                        'name': 'Entebbe Test'
                         }
             }],
             'hasNext': False,
@@ -366,7 +366,7 @@ event_query_without_page_and_per_page_response = {
                     'id': '1',
                     'roomId': 1,
                     'room': {
-                        'name': 'Entebbe'
+                        'name': 'Entebbe Test'
                         }
             }],
             'hasNext': None,

--- a/fixtures/location/all_locations_fixtures.py
+++ b/fixtures/location/all_locations_fixtures.py
@@ -25,7 +25,7 @@ expected_query_all_locations = {
                 "abbreviation": "KLA",
                 "rooms": [
                     {
-                        "name": "Entebbe",
+                        "name": "Entebbe Test",
                         "roomType": "meeting",
                         "capacity": 6,
                         "roomTags": [
@@ -37,7 +37,19 @@ expected_query_all_locations = {
                         ]
                     },
                     {
-                        "name": "Tana",
+                        "name": "Kampala",
+                        "roomType": "meeting",
+                        "capacity": 14,
+                        "roomTags": [
+                            {
+                                "name": "Block-B",
+                                "color": "green",
+                                "description": "The description"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Tana Dummy",
                         "roomType": "meeting",
                         "capacity": 14,
                         "roomTags": [
@@ -101,15 +113,20 @@ expected_all_location_no_hierachy = {
     'data': {'allLocations': [
         {'rooms': [
                 {
-                    'name': 'Entebbe',
+                    'name': 'Entebbe Test',
                     'roomType': 'meeting',
                     'capacity': 6
                 },
                 {
-                    'name': 'Tana',
+                    'name': 'Kampala',
                     'roomType': 'meeting',
                     'capacity': 14
                 },
+                {
+                    'name': 'Tana Dummy',
+                    'roomType': 'meeting',
+                    'capacity': 14
+                }
             ]},
         {'rooms': []},
         {'rooms': []}

--- a/fixtures/location/rooms_in_location_fixtures.py
+++ b/fixtures/location/rooms_in_location_fixtures.py
@@ -13,13 +13,19 @@ expected_query_get_rooms_in_location = {
 "data": {
         "getRoomsInALocation": [
             {
-                "name": "Entebbe",
+                "name": "Entebbe Test",
                 "capacity": 6,
                 "roomType": "meeting",
                 "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
             },
             {
-                "name": "Tana",
+                "name": "Tana Dummy",
+                "capacity": 14,
+                "roomType": "meeting",
+                "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+            },
+            {
+                "name": "Kampala",
                 "capacity": 14,
                 "roomType": "meeting",
                 "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501

--- a/fixtures/response/archive_response_fixtures.py
+++ b/fixtures/response/archive_response_fixtures.py
@@ -131,7 +131,7 @@ filter_archived_responses_response = {
             "responses": [
                 {
                     "roomId": 2,
-                    "roomName": "Tana",
+                    "roomName": "Tana Dummy",
                     "response": [
                         {
                             "id": 3,

--- a/fixtures/response/room_response_fixture.py
+++ b/fixtures/response/room_response_fixture.py
@@ -35,7 +35,7 @@ get_room_response_query = '''{
 get_room_response_query_data = {
     "data": {
         "roomResponse": {
-            "roomName": "Entebbe",
+            "roomName": "Entebbe Test",
             "totalResponses": 2
         }
     }
@@ -52,7 +52,7 @@ get_resolved_room_responses_query = '''{
 get_resolved_room_responses_query_data = {
     "data": {
         "roomResponse": {
-            "roomName": "Entebbe",
+            "roomName": "Entebbe Test",
             "totalResponses": 1
         }
     }
@@ -94,7 +94,7 @@ query{{
     allRoomResponses(startDate: "{}",
      endDate: "{}",
      upperLimitCount: 3, lowerLimitCount: 0,
-     room:"Entebbe" ){{
+     room:"Entebbe Test" ){{
         responses{{
             totalResponses
             roomName
@@ -190,7 +190,7 @@ get_room_response_query_by_date_data = {
             "responses": [
                 {
                     "totalResponses": 2,
-                    "roomName": "Entebbe",
+                    "roomName": "Entebbe Test",
                     "response": [
                         {
                             "id": 2,
@@ -277,7 +277,7 @@ summary_room_response_data = {
         "allRoomResponses": {
             "responses": [
                 {
-                    "roomName": "Entebbe",
+                    "roomName": "Entebbe Test",
                     "totalResponses": 2,
                     "response": [
                         {
@@ -337,7 +337,7 @@ all_resolved_room_response_data = {
         "allRoomResponses": {
             "responses": [
                 {
-                    "roomName": "Entebbe",
+                    "roomName": "Entebbe Test",
                     "totalResponses": 1,
                     "response": [
                         {
@@ -386,7 +386,8 @@ query{
 
 search_response_by_room_query = '''
  query{
-    allRoomResponses(lowerLimitCount: 1, upperLimitCount: 3, room:"Entebbe"){
+    allRoomResponses(
+      lowerLimitCount: 1, upperLimitCount: 3, room:"Entebbe Test"){
         responses{
             totalResponses
             roomName
@@ -428,7 +429,7 @@ query{
 
 search_response_by_room_only = '''
 query{
-    allRoomResponses(room:"Entebbe"){
+    allRoomResponses(room:"Entebbe Test"){
         responses{
             totalResponses
             roomName
@@ -483,7 +484,7 @@ filter_by_response_data = {
                         }
 
                     ],
-                    'roomName': 'Entebbe',
+                    'roomName': 'Entebbe Test',
                     'totalResponses': 2,
                 }
             ]
@@ -493,7 +494,7 @@ filter_by_response_data = {
 
 search_resolved_responses_by_room_name = '''
 query{
-    allRoomResponses(room:"Entebbe", resolved:true){
+    allRoomResponses(room:"Entebbe Test", resolved:true){
         responses{
             totalResponses
             roomName
@@ -527,7 +528,7 @@ search_resolved_responses_by_room_name_data = {
         "allRoomResponses": {
             "responses": [
                 {
-                    "roomName": "Entebbe",
+                    "roomName": "Entebbe Test",
                     "totalResponses": 1,
                     "response": [
                         {
@@ -584,7 +585,7 @@ query_paginated_responses_response = {
         "allRoomResponses": {
             "responses": [
                 {
-                    "roomName": "Entebbe",
+                    "roomName": "Entebbe Test",
                     "totalResponses": 2,
                     "response": [
                         {

--- a/fixtures/response/user_response_check.py
+++ b/fixtures/response/user_response_check.py
@@ -139,7 +139,7 @@ filter_question_by_room_response = {
     "getRoomResponse": {
       "responses": [
         {
-          "roomName": "Entebbe",
+          "roomName": "Entebbe Test",
           "roomId": 1,
           "response": [
             {
@@ -189,7 +189,7 @@ filter_response_by_room_with_pagination_response = {
     "getRoomResponse": {
       "responses": [
         {
-          "roomName": "Entebbe",
+          "roomName": "Entebbe Test",
           "roomId": 1,
           "response": [
             {

--- a/fixtures/room/create_room_fixtures.py
+++ b/fixtures/room/create_room_fixtures.py
@@ -268,13 +268,19 @@ db_rooms_query_response = {
     "data": {
         "rooms": [
             {
-                "name": "Entebbe",
+                "name": "Entebbe Test",
                 "capacity": 6,
                 "roomType": "meeting",
                 "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
             },
             {
-                "name": "Tana",
+                "name": "Tana Dummy",
+                "capacity": 14,
+                "roomType": "meeting",
+                "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+            },
+            {
+                "name": "Kampala",
                 "capacity": 14,
                 "roomType": "meeting",
                 "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
@@ -283,12 +289,33 @@ db_rooms_query_response = {
     }
 }
 
-query_rooms_response = {
+query_actual_rooms_response = {
     "data": {
         "allRooms": {
             "rooms": [
                 {
-                    "name": "Entebbe",
+                    "name": "Kampala",
+                    "capacity": 14,
+                    "roomType": "meeting",
+                    "roomTags": [
+                        {
+                            "name": "Block-B",
+                            "color": "green"
+                        }
+                    ],
+                    "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
+                }
+            ]
+        }
+    }
+}
+
+query_test_rooms_response = {
+    "data": {
+        "allRooms": {
+            "rooms": [
+                {
+                    "name": "Entebbe Test",
                     "capacity": 6,
                     "roomType": "meeting",
                     "roomTags": [
@@ -300,7 +327,7 @@ query_rooms_response = {
                     "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
                 },
                 {
-                    "name": "Tana",
+                    "name": "Tana Dummy",
                     "capacity": 14,
                     "roomType": "meeting",
                     "roomTags": [
@@ -319,7 +346,7 @@ query_rooms_response = {
 room_mutation_query_duplicate_name = '''
     mutation {
         createRoom(
-            name: "Entebbe", roomType: "Meeting", capacity: 4, locationId: 1,
+            name: "Entebbe Test", roomType: "Meeting", capacity: 4, locationId: 1,
             calendarId:"andela.com_3836323338323230343935@resource.calendar.google.com",
             structureId: "b05fc5f2-b4aa-4f48-a8fb-30bdcc3fc968",
             imageUrl: "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",
@@ -344,7 +371,7 @@ room_mutation_query_duplicate_name = '''
 room_mutation_query_duplicate_name_response = {
     "errors": [
         {
-            "message": "Entebbe Room already exists",
+            "message": "Entebbe Test Room already exists",
             "locations": [
                 {
                     "line": 3,

--- a/fixtures/room/filter_room_fixtures.py
+++ b/fixtures/room/filter_room_fixtures.py
@@ -14,7 +14,7 @@ filter_rooms_by_capacity_response = {
         "allRooms": {
             "rooms": [
                 {
-                    "name": "Entebbe",
+                    "name": "Entebbe Test",
                     "capacity": 6,
                     "roomType": "meeting",
                     "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
@@ -39,13 +39,13 @@ filter_rooms_by_location_response = {
         "allRooms": {
             "rooms": [
                 {
-                    "name": "Entebbe",
+                    "name": "Entebbe Test",
                     "capacity": 6,
                     "roomType": "meeting",
                     "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
                 },
                 {
-                    "name": "Tana",
+                    "name": "Tana Dummy",
                     "capacity": 14,
                     "roomType": "meeting",
                     "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
@@ -72,7 +72,7 @@ filter_rooms_by_wings_and_floors_response = {
             'rooms': [
                 {
                     'id': '1',
-                    'name': 'Entebbe',
+                    'name': 'Entebbe Test',
                     'roomLabels': [
                         '1st Floor',
                         'Wing A'
@@ -117,7 +117,7 @@ filter_rooms_by_location_capacity_response = {
         "allRooms": {
             "rooms": [
                 {
-                    "name": "Entebbe",
+                    "name": "Entebbe Test",
                     "capacity": 6,
                     "roomType": "meeting",
                     "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg"  # noqa: E501
@@ -204,7 +204,7 @@ filter_rooms_by_room_labels_response = {
         "allRooms": {
             "rooms": [
                 {
-                    "name": "Entebbe",
+                    "name": "Entebbe Test",
                     "capacity": 6,
                     "roomType": "meeting",
                     "imageUrl": "https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",  # noqa: E501

--- a/fixtures/room/query_room_fixtures.py
+++ b/fixtures/room/query_room_fixtures.py
@@ -24,12 +24,27 @@ paginated_rooms_query = '''
 }
 '''
 
-paginated_rooms_response = {
+paginated_actual_rooms_response = {
     "data": {
         "allRooms": {
             "rooms": [
                 {
-                    "name": "Entebbe"
+                    "name": "Kampala"
+                }
+            ],
+            "hasNext": False,
+            "hasPrevious": False,
+            "pages": 1
+        }
+    }
+}
+
+paginated_test_rooms_response = {
+    "data": {
+        "allRooms": {
+            "rooms": [
+                {
+                    "name": "Entebbe Test"
                 }
             ],
             "hasNext": True,
@@ -53,7 +68,7 @@ room_query_by_id_response = {
     "data": {
         "getRoomById": {
             "capacity": 6,
-            "name": "Entebbe",
+            "name": "Entebbe Test",
             "roomType": "meeting"
         }
     }
@@ -167,7 +182,7 @@ room_search_by_name_response = {
     "data": {
         "getRoomByName": [
             {
-                "name": "Entebbe"
+                "name": "Entebbe Test"
             }]
     }
 }

--- a/fixtures/room/room_update_fixtures.py
+++ b/fixtures/room/room_update_fixtures.py
@@ -82,7 +82,7 @@ query_without_room_id = '''mutation{
 
 query_room_id_non_existant = '''mutation{
     updateRoom(
-        roomId: 4,
+        roomId: 4000,
         name: "Jinja",
         capacity: 8,
         roomType: "board room",

--- a/fixtures/room_resource/get_rooms_with_resource_fixtures.py
+++ b/fixtures/room_resource/get_rooms_with_resource_fixtures.py
@@ -14,7 +14,7 @@ rooms_containing_resource_expected_response = {
         "roomsContainingResource": [
             {
                 "room": {
-                    "name": "Entebbe",
+                    "name": "Entebbe Test",
                     "capacity": 6
                 }
             },

--- a/tests/base.py
+++ b/tests/base.py
@@ -85,7 +85,7 @@ class BaseTestCase(TestCase):
                           color='blue',
                           description='The description')
             tag_two.save()
-            room = Room(name='Entebbe',
+            room = Room(name='Entebbe Test',
                         room_type='meeting',
                         capacity=6,
                         location_id=location.id,
@@ -95,7 +95,7 @@ class BaseTestCase(TestCase):
                         room_labels=["1st Floor", "Wing A"])
             room.save()
             room.room_tags.append(tag)
-            room_2 = Room(name='Tana',
+            room_2 = Room(name='Tana Dummy',
                         room_type='meeting',
                         capacity=14,
                         location_id=location.id,
@@ -105,6 +105,16 @@ class BaseTestCase(TestCase):
                         room_labels=["1st Floor", "Wing B"])
             room_2.save()
             room_2.room_tags.append(tag)
+            room_3 = Room(name='Kampala',
+                        room_type='meeting',
+                        capacity=14,
+                        location_id=location.id,
+                        structure_id='851ae8b3-48dd-46b5-89bc-ca3f8111ad87',
+                        calendar_id='andela.com_3432393432393935363436@resource.calendar.google.com',  # noqa: E501
+                        image_url="https://www.officelovin.com/wp-content/uploads/2016/10/andela-office-main-1.jpg",  # noqa: E501
+                        room_labels=["1st Floor", "Wing B"])
+            room_3.save()
+            room_3.room_tags.append(tag)
             resource = Resource(name='Markers',
                                 quantity=3)
             resource.save()
@@ -304,6 +314,17 @@ class CommonTestCases(BaseTestCase):
         headers = {"Authorization": "Bearer" + " " + ADMIN_TOKEN}
         response = self.app_test.post('/mrm?query=' + query, headers=headers)
         self.assertIn(expected_response, str(response.data))
+
+    def admin_token_assert_in_errors(self, query, expected_response):
+        """
+        Make a request with admin token and use assertIn
+        to compare the values for negative tests.
+        :params
+            - query, expected_response
+        """
+        headers = {"Authorization": "Bearer" + " " + ADMIN_TOKEN}
+        response = self.app_test.post('/mrm?query=' + query, headers=headers)
+        self.assertIn(expected_response, str(response.data.decode()))
 
     def lagos_admin_token_assert_in(self, query, expected_response):
         """

--- a/tests/test_devices/test_delete_device.py
+++ b/tests/test_devices/test_delete_device.py
@@ -1,8 +1,8 @@
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.devices.devices_fixtures import (
     delete_device_mutation,
-    delete_device_response
-)
+    delete_non_exiting_device_mutation,
+    delete_device_response)
 
 
 class TestDeleteDevices(BaseTestCase):
@@ -11,4 +11,11 @@ class TestDeleteDevices(BaseTestCase):
             self,
             delete_device_mutation,
             delete_device_response
+        )
+
+    def test_delete_non_existing_device(self):
+        CommonTestCases.admin_token_assert_in_errors(
+            self,
+            delete_non_exiting_device_mutation,
+            "Device not found"
         )

--- a/tests/test_location/test_query_locations.py
+++ b/tests/test_location/test_query_locations.py
@@ -1,5 +1,4 @@
 from tests.base import BaseTestCase
-
 from fixtures.location.all_locations_fixtures import (
     all_locations_query,
     expected_query_all_locations,

--- a/tests/test_rooms/test_create_room.py
+++ b/tests/test_rooms/test_create_room.py
@@ -1,11 +1,9 @@
 import sys
 import os
 from unittest.mock import patch
-
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.helpers.decorators_fixtures import (
-    query_string, query_string_response
-)
+    query_string, query_string_response)
 from fixtures.room.create_room_fixtures import (
     room_mutation_query,
     room_mutation_different_location_query,

--- a/tests/test_rooms/test_update_room.py
+++ b/tests/test_rooms/test_update_room.py
@@ -1,14 +1,10 @@
-
-
 from tests.base import BaseTestCase, CommonTestCases
-
 from fixtures.room.room_update_fixtures import (
     query_update_all_fields,
     query_without_room_id,
     query_room_id_non_existant,
     update_with_empty_field,
-    query_update_without_structure_id
-)
+    query_update_without_structure_id)
 
 
 class TestUpdateRoom(BaseTestCase):
@@ -32,7 +28,7 @@ class TestUpdateRoom(BaseTestCase):
             "required positional argument")
 
     def test_for_error_if_room_id_is_non_existant_room(self):
-        CommonTestCases.admin_token_assert_in(
+        CommonTestCases.admin_token_assert_in_errors(
             self,
             query_room_id_non_existant,
             "Room not found")


### PR DESCRIPTION
### Description
This PR adds the capability to query test rooms on the staging environment and query actual rooms on the production environment.

The staging environment is set to ` development ` while the production ` environment ` is set to production.
### Type of change
This is a Fix.
### How can this be tested?
Follow these steps to test this out locally.
- Clone the repo: git clone https://github.com/andela/mrm_api.git.
- Setup the project as per the ` README.md `.
- Checkout to branch ` bug/CON-211-fix-meeting-room-issue-on-staging`.
- Run ` make kill ` if necessary.
- Go to your ` .env ` file and switch your environment to either ` development ` or ` production `.
- Set your environment to either ` development ` or ` production ` using this command ` export APP_SETTINGS=development ` or ` export APP_SETTINGS=production `.
- Restart your docker container.
- Run ` make build `.
- Run ` make run-app `.
- Run your queries either for all rooms, paginated rooms or rooms by location.
### Sample response
This is a sample response for querying paginated test rooms.
```
"data": {
   "allRooms": {
     "rooms": [
       {
         "name": "Converge Dummy Room"
       },
       {
         "name": "Converge Test Room"
       },
       {
         "name": "Dummy bigapple Cognito"
       }
     ],
     "hasNext": false,
     "hasPrevious": false,
     "pages": 1
   }
 }
```       
### JIRA
[CON-211](https://andela-apprenticeship.atlassian.net/browse/CON-211)