### PR TITLE
CON-243 Fix log configuration error

### DIFF
--- a/docker/prod/mrm_api.conf
+++ b/docker/prod/mrm_api.conf
@@ -11,11 +11,7 @@ stdout_logfile=/app/celery.out.log
 
 [program:mrm_api]
 directory=/app
-command=/bin/bash -c '. /app/docker/prod/start_gunicorn.sh'
-autostart=true
-autorestart=true
 stderr_logfile=/app/mrm.err.log
-stdout_logfile=/app/mrm.out.log
 
 [supervisorctl]
 serverurl=unix:///var/run/supervisord.sock


### PR DESCRIPTION
#### Description
Currently, the mrm.err.log file on staging and production is created. However, the logs file shows recurring errors that `the connection is in use`. This error is recurring due to trying to run the app again on the same port that is currently in use in the deployed environments. The removal of the command `command=/bin/bash -c '. /app/docker/prod/start_gunicorn.sh'` should ideally remove this recursion. 

#### How this should be manually tested
Clone the repo: git clone https://github.com/andela/mrm_api.git.
Setup the project as per the README.md.
Checkout to branch bug/CON-243-fix-display-of-logs-feature.
On your Insomnia, go to url `localhost:8000/logs` and send a `GET REQUEST` using a `Super Admin token`. 
Feature should still display logs
 
#### Type of change
- [x] Bug fix (nonbreaking change which fixes an issue)
- [ ] New feature (nonbreaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?
Please describe the tests that you ran to verify your changes
- [ ] End to end
- [ ] Integration

#### Checklist:
- [x] My code follows the style guide for this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



#### Jira
[CON-243](https://andela-apprenticeship.atlassian.net/jira/software/projects/CON/boards/15/backlog?label=backend&selectedIssue=CON-243)
