### PR TITLE
CON-285 Fix error when deleted user tries to set their location

### DIFF
--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -241,8 +241,7 @@ class SetUserLocation(graphene.Mutation):
         logged_in_user = get_user_from_db()
         location_id = kwargs['location_id']
         query_user = User.get_query(info)
-        user = query_user.filter(
-            UserModel.state == "active", UserModel.id == logged_in_user.id).first() # noqa
+        user = query_user.filter(UserModel.id == logged_in_user.id).first()
         if user.location:
             raise GraphQLError('This user already has a location set.')
         new_location = LocationModel.query.filter_by(

--- a/helpers/auth/authentication.py
+++ b/helpers/auth/authentication.py
@@ -14,6 +14,7 @@ from api.role.models import Role
 from api.notification.models import Notification as NotificationModel
 from helpers.connection.connection_error_handler import handle_http_error
 from helpers.location.location import check_and_add_location
+from utilities.utility import StateType
 
 from helpers.database import db_session
 
@@ -146,6 +147,10 @@ class Authentication:
                         user = User.query.filter_by(email=email).first()
                     except Exception:
                         raise GraphQLError("The database cannot be reached")
+
+                    if user and user.state != StateType.active:  # pragma: no cover # noqa
+                        raise GraphQLError(
+                            "Your account is not active, please contact an admin")  # noqa
 
                     if not user:
                         self.save_user(email, *expected_args)

--- a/tests/base.py
+++ b/tests/base.py
@@ -25,7 +25,7 @@ from api.tag.models import Tag
 from api.structure.models import Structure
 from api.office_structure.models import OfficeStructure
 from fixtures.token.token_fixture import (
-    ADMIN_TOKEN, USER_TOKEN, ADMIN_NIGERIA_TOKEN, SUPER_ADMIN_TOKEN)
+    ADMIN_TOKEN, USER_TOKEN, ADMIN_NIGERIA_TOKEN)
 
 sys.path.append(os.getcwd())
 
@@ -251,24 +251,10 @@ class CommonTestCases(BaseTestCase):
     This code is used to reduce duplication
     :params
         - admin_token_assert_equal
-        - super_admin_token_assert_equal
         - admin_token_assert_in
         - user_token_assert_equal
         - user_token_assert_in
     """
-
-    def super_admin_token_assert_equal(self, query, expected_response):
-        """
-        Make a request with admin token and use assertEquals
-        to compare the values
-        :params
-            - query, expected_response
-        """
-        headers = {"Authorization": "Bearer" + " " + SUPER_ADMIN_TOKEN}
-        response = self.app_test.post(
-            '/mrm?query=' + query, headers=headers)
-        actual_response = json.loads(response.data)
-        self.assertEquals(actual_response, expected_response)
 
     def admin_token_assert_equal(self, query, expected_response):
         """

--- a/tests/test_analytics/test_all_analytics_query.py
+++ b/tests/test_analytics/test_all_analytics_query.py
@@ -39,7 +39,7 @@ class TestAllAnalytics(BaseTestCase):
             all_analytics_query_response
         )
 
-        CommonTestCases.super_admin_token_assert_equal(
+        CommonTestCases.admin_token_assert_equal(
             self,
             all_analytics_query_invalid_locationid,
             all_analytics_query_response_super_admin_with_invalid_locationid


### PR DESCRIPTION
## Description ##
 Currently, when a deleted user tries to set their location using the `setLocation` mutation we get an error, this PR handles that error and returns a descriptive error message

**How should this be manually tested?**
  - delete a user using the `deleteUser` mutation and the n try to set a location for the user.

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### JIRA
[CON-285](https://andela-apprenticeship.atlassian.net/browse/CON-285)