### PR TITLE
CON-284 Update a structure node

### DIFF
--- a/fixtures/office_structure/update_node_fixtures.py
+++ b/fixtures/office_structure/update_node_fixtures.py
@@ -1,0 +1,91 @@
+update_node_mutation = '''
+mutation {
+  updateNode(nodeId: "C56A4180-65AA-42EC-A945-5FD21DEC0518",
+             name: "Epic Tower", tag: "Building Name") {
+    node {
+      name
+      tag
+    }
+  }
+}
+'''
+
+update_node_mutation_response = {
+  "data": {
+      "updateNode": {
+        "node": {
+          "name": "Epic Tower",
+          "tag": "Building Name"
+        }
+      }
+    }
+  }
+
+update_node_only_name_response = {
+  "data": {
+      "updateNode": {
+        "node": {
+          "name": "Epic Tower",
+          "tag": "Lagos Building"
+        }
+      }
+    }
+  }
+
+update_node_only_name_mutation = '''
+mutation {
+  updateNode(nodeId: "C56A4180-65AA-42EC-A945-5FD21DEC0518",
+             name: "Epic Tower") {
+    node {
+      name
+      tag
+    }
+  }
+}
+'''
+
+update_node_only_tag_mutation = '''
+mutation {
+  updateNode(nodeId: "C56A4180-65AA-42EC-A945-5FD21DEC0518",
+             tag: "Building Name") {
+    node {
+      name
+      tag
+    }
+  }
+}
+'''
+
+update_node_empty_name_mutation = """
+mutation {
+  updateNode(nodeId: "C56A4180-65AA-42EC-A945-5FD21DEC0518", name: "") {
+    node {
+      name
+      tag
+    }
+  }
+}
+"""
+
+update_node_empty_tag_mutation = """
+mutation {
+  updateNode(nodeId: "C56A4180-65AA-42EC-A945-5FD21DEC0518", tag: "") {
+    node {
+      name
+      tag
+    }
+  }
+}
+"""
+
+update_node_not_exist_mutation = """
+mutation {
+  updateNode(nodeId: "C56A4180-65AA-42EC-A945-5FD21DEC0432",
+             name: "Epic Tower") {
+    node {
+      name
+      tag
+    }
+  }
+}
+"""

--- a/tests/test_office_structure/test_update_node.py
+++ b/tests/test_office_structure/test_update_node.py
@@ -1,0 +1,73 @@
+from tests.base import BaseTestCase, CommonTestCases
+from fixtures.office_structure.update_node_fixtures import (
+    update_node_mutation,
+    update_node_mutation_response,
+    update_node_only_name_mutation,
+    update_node_only_name_response,
+    update_node_only_tag_mutation,
+    update_node_empty_name_mutation,
+    update_node_empty_tag_mutation,
+    update_node_not_exist_mutation
+)
+
+
+class TestUpdateNode(BaseTestCase):
+    def test_node_update(self):
+        """
+        Test that an Admin or Super Admnin can update a node
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_node_mutation,
+            update_node_mutation_response
+        )
+
+    def test_only_name_node_update(self):
+        """
+        Test that only a name could be updated
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_node_only_name_mutation,
+            update_node_only_name_response
+        )
+
+    def test_only_tag_node_update(self):
+        """
+        Test that only a tag could be updated
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            update_node_only_tag_mutation,
+            update_node_mutation_response
+        )
+
+    def test_empty_name_update(self):
+        """
+        Test that an empty name is validated against
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_node_empty_name_mutation,
+            "name is required field"
+        )
+
+    def test_empty_tag_update(self):
+        """
+        Test that an empty tag is validated against
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_node_empty_tag_mutation,
+            "tag is required field"
+        )
+
+    def test_node_not_exist(self):
+        """
+        Test that the node to be updated exists before update attempt
+        """
+        CommonTestCases.admin_token_assert_in(
+            self,
+            update_node_not_exist_mutation,
+            "node not found"
+        )


### PR DESCRIPTION
## Description ##
 
 This PR implements the update node for a structure, this allows us to update a single node of the structure from the backend instead of being implemented from the front end. 

**How should this be manually tested?**
   - git pull and checkout to the branch story/CON-284-edit-office-structure
   - ensure you have the latest migrations
   - Use the below mutation to update a node in your development environment

```
mutation {
  updateNode(nodeId: "C56A4180-65AA-42EC-A945-5FD21DEC0518",
             name: "Epic Tower", tag: "Building Name") {
    node {
      name
      tag
    }
  }
}
```

## Type of change ##
Please select the relevant option
- [ ] Bug fix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### JIRA
[CON-284](https://andela-apprenticeship.atlassian.net/browse/CON-284)