### PR TITLE
Revert "CON-243 Fix log configuration error"

### DIFF
--- a/docker/prod/mrm_api.conf
+++ b/docker/prod/mrm_api.conf
@@ -11,7 +11,11 @@ stdout_logfile=/app/celery.out.log
 
 [program:mrm_api]
 directory=/app
+command=/bin/bash -c '. /app/docker/prod/start_gunicorn.sh'
+autostart=true
+autorestart=true
 stderr_logfile=/app/mrm.err.log
+stdout_logfile=/app/mrm.out.log
 
 [supervisorctl]
 serverurl=unix:///var/run/supervisord.sock


### PR DESCRIPTION
Reverts andela/mrm_api#489
This PR causes instability on the staging api.