### PR TITLE
CON-292 Allow hard delete of users

### DIFF
--- a/fixtures/user/delete_user.py
+++ b/fixtures/user/delete_user.py
@@ -27,6 +27,34 @@ mutation {
 }
 '''
 
+mutation_hard_delete_user = '''
+mutation {
+    deleteUser(email: "peter.adeoye@andela.com", remove: true) {
+        user{
+            email
+            roles {
+                role
+            }
+        }
+    }
+}
+'''
+
+expected_response_hard_delete_user = {
+    "data": {
+        "deleteUser": {
+            "user": {
+                "email": "peter.adeoye@andela.com",
+                "roles": [
+                    {
+                        "role": "Admin"
+                    }
+                ]
+            }
+        }
+    }
+}
+
 delete_self = '''
 mutation {
     deleteUser(email: "peter.walugembe@andela.com") {

--- a/tests/test_user/test_delete_user.py
+++ b/tests/test_user/test_delete_user.py
@@ -4,7 +4,10 @@ import os
 from tests.base import BaseTestCase, CommonTestCases
 from fixtures.user.delete_user import (
     delete_user, expected_query_after_delete, delete_self, user_not_found,
-    delete_user_2, user_invalid_email)
+    delete_user_2, user_invalid_email,
+    mutation_hard_delete_user,
+    expected_response_hard_delete_user
+    )
 from api.user.models import User
 from api.role.models import Role
 import tests.base as base
@@ -34,6 +37,17 @@ class TestDeleteUser(BaseTestCase):
             self,
             delete_user_2,
             expected_query_after_delete
+        )
+
+    def test_hard_delete_user(self):
+        """
+        Test to hard-delete a user
+        """
+
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            mutation_hard_delete_user,
+            expected_response_hard_delete_user
         )
 
     def test_user_delete_admin(self):


### PR DESCRIPTION
## Description ##
 This PR extends the `DeleteUser Mutation` by providing an option for the total removal of a user from the DB. This task allows for smooth simulation of the new onboarding experience feature currently being implemented by the frontend team on the staging-api.

**How should this be manually tested?**
   Use the below mutation while setting `remove` to `true`
   ```
  mutation {
    deleteUser(email: "andelauser@andela.com" remove: true) {
        user{
            id
            email
            location
            roles {
                id
                role
            }
        }
    }
}
   ```

## Type of change ##
Please select the relevant option
- [ ] Bug fix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### JIRA
[CON-292](https://andela-apprenticeship.atlassian.net/browse/CON-292)