### PR TITLE
CON-211 Fix meeting room issue on staging

### DIFF
--- a/api/events/schema.py
+++ b/api/events/schema.py
@@ -157,7 +157,8 @@ class MrmNotification(graphene.Mutation):
         calendar_id = graphene.String()
 
     def mutate(self, info, calendar_id):
-        room = RoomModel.query.filter_by(calendar_id=calendar_id).first()
+        room = RoomModel.query.filter_by(
+            calendar_id=calendar_id, state="active").first()
         CalendarEvents().sync_single_room_events(room)
         return MrmNotification(message="success")
 

--- a/fixtures/room/query_room_fixtures.py
+++ b/fixtures/room/query_room_fixtures.py
@@ -11,6 +11,14 @@ all_remote_rooms_query = '''
 }
 '''
 
+all_dummy_rooms_response = {
+    "data": {
+        "allRemoteRooms": {
+            "rooms": []
+            }
+        }
+    }
+
 paginated_rooms_query = '''
  query {
   allRooms(page:1, perPage:1){

--- a/tests/test_rooms/test_query_rooms.py
+++ b/tests/test_rooms/test_query_rooms.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import patch
 from tests.base import BaseTestCase, CommonTestCases
 from helpers.calendar.calendar import get_calendar_list_mock_data
@@ -13,7 +14,8 @@ from fixtures.room.query_room_fixtures import (
     room_with_non_existant_id,
     room_query_with_non_existant_id_response,
     all_remote_rooms_query,
-    paginated_rooms_query_blank_page
+    paginated_rooms_query_blank_page,
+    all_dummy_rooms_response
 )
 from helpers.calendar.credentials import get_google_api_calendar_list
 
@@ -34,11 +36,37 @@ class QueryRooms(BaseTestCase):
 
     @patch("api.room.schema_query.get_google_api_calendar_list", spec=True,
            return_value=get_calendar_list_mock_data())
-    def test_query_remote_rooms(self, mock_get_json):
+    @patch.dict(os.environ, {"APP_SETTINGS": "production"})
+    def test_query_actual_remote_rooms(self, mock_get_json):
+        """
+           Mocks google calendar to return actual rooms
+           on the production enviroment.
+           Returns:
+           - Actual rooms
+           Actual rooms have no key words;
+           - Test or Dummy
+        """
         CommonTestCases.admin_token_assert_in(
             self,
             all_remote_rooms_query,
             "calendar.google.com"
+        )
+
+    @patch("api.room.schema_query.get_google_api_calendar_list", spec=True,
+           return_value=get_calendar_list_mock_data())
+    def test_query_test_remote_rooms(self, mock_get_json):
+        """
+           Mocks google calendar to return test rooms
+           on the staging enviroment.
+           Returns:
+           - Test rooms
+           Test rooms have the key words;
+           - Test or Dummy
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            all_remote_rooms_query,
+            all_dummy_rooms_response
         )
 
     @patch("helpers.calendar.credentials.Credentials")


### PR DESCRIPTION
### Description
This PR adds the capability to query test remote-rooms on the staging environment and query actual remote-rooms on the production environment.

The staging environment is set to ` development ` while the production ` environment ` is set to production.
### Type of change
This is a Fix.
### How can this be tested?
Follow these steps to test this out locally.
- Clone the repo: git clone https://github.com/andela/mrm_api.git.
- Setup the project as per the ` README.md `.
- Checkout to branch ` bug/CON-211-fix-meeting-room-issue-on-staging-environment`.
- Run ` make kill ` if necessary.

### To test for the production environment;
- Go to your ` .env ` file and switch your environment to ` production `.
- Set your environment to either ` production ` using this command ` export ` export APP_SETTINGS=production `.
- Restart your docker container.
- Run ` make build `.
- Run ` make run-app `.
- Run the query for all remote rooms.
### Sample production environment response
This is a sample response for querying actual remote rooms on the production environment.
```
{
  "data": {
    "allRemoteRooms": {
      "rooms": [
        {
          "name": "(Big Meeting Room)-Kampala-4-4th floor (40)"
        },
        {
          "name": "(Big Meeting Room)-Kampala-4-Rooftop (40)"
        },
        {
          "name": "(Meeting Room)-Kampala-3-New York-Times Square (6)"
        },
        {
          "name": "Kampala-3-New York-Bryant Park (6)"
        },
        {
          "name": "Kampala-3-New York-Mbarara (4)"
        },
        {
          "name": "(Meeting Room)-Kampala-3-New York-Brooklyn Bridge (10)"
        },
        {
          "name": "(Meeting Room)-Kampala-3-New York-Empire state - KLA (8)"
        }
      ]
    }
  }
}
```  

### To test for the staging environment;
- Go to your ` .env ` file and switch your environment to ` development `.
- Set your environment to either ` production ` using this command ` export APP_SETTINGS=development `.
- Restart your docker container.
- Run ` make build `.
- Run ` make run-app `.
- Run the query for all remote rooms.
### Sample staging environment response
This is a sample response for querying test remote rooms on the staging environment.
```
{
  "data": {
    "allRemoteRooms": {
      "rooms": [
        {
          "name": "Kampala-3-San Francisco-KLA -Test 1 (2)"
        },
        {
          "name": "Kampala-4-KLA -Test 2 (6)"
        }
      ]
    }
  }
}
```
### JIRA
[CON-211](https://andela-apprenticeship.atlassian.net/browse/CON-211)

### Relevant Screenshots
![image](https://user-images.githubusercontent.com/14992011/64242063-8e463100-cf0d-11e9-8ea3-4b1a84060deb.png)

![image](https://user-images.githubusercontent.com/14992011/64242153-b2a20d80-cf0d-11e9-8016-66aedb7b5f94.png)
