### PR TITLE
CON-299 Fix deleted room device

### DIFF
--- a/api/room/models.py
+++ b/api/room/models.py
@@ -61,7 +61,8 @@ class Room(Base, Utility):
         lazy="joined")
     devices = relationship(
         'Devices', cascade="all, delete-orphan",
-        order_by="func.lower(Devices.name)")
+        order_by="func.lower(Devices.name)",
+        primaryjoin="and_(Room.id==Devices.room_id, Devices.state=='active')")
     resources = relationship("RoomResource", back_populates='room')
 
     __table_args__ = (


### PR DESCRIPTION
## Description ##
 
 Currently, whenever we delete a device or archive it, we still get that device when we query the rooms. This Pr adds logic to filter the returned devices such that only devices with the active state is returned.

**How should this be manually tested?**
   - git pull and checkout to the branch bug/CON-299-fix-deleted-room-device
   - archive or delete a device attached to a room_id  
   - Query the rooms, and it should not return the device.

Example query, to query all room names and devices
```
{
  allRooms {
    rooms {
      name
      devices {
        name
      }
    }
  }
}
```

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### JIRA
[CON-299](https://andela-apprenticeship.atlassian.net/browse/CON-299)