### PR TITLE
CON-303 Create timezone and country type for Kigali location

### DIFF
--- a/alembic/versions/ace641b9b89b_create_timezone_countrytype_rwanda.py
+++ b/alembic/versions/ace641b9b89b_create_timezone_countrytype_rwanda.py
@@ -1,0 +1,48 @@
+"""create-timezone-countrytype-Rwanda
+
+Revision ID: ace641b9b89b
+Revises: 964435a2570d
+Create Date: 2019-09-05 13:02:37.703150
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'ace641b9b89b'
+down_revision = '964435a2570d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    timezone_type = postgresql.ENUM('EAST_AFRICA_TIME', 'WEST_AFRICA_TIME','CENTRAL_AFRICA_TIME', name='timezone_type')
+    country_type = postgresql.ENUM('Uganda', 'Kenya', 'Nigeria','Rwanda', name='country_type')
+
+    op.alter_column('locations', 'country', existing_type=sa.Enum('Uganda', 'Kenya', 'Nigeria', name='country_type'), type_=sa.VARCHAR())
+    country_type.drop(op.get_bind())
+    country_type.create(op.get_bind())
+    op.alter_column('locations', 'country', existing_type=sa.VARCHAR(), type_=country_type, postgresql_using='country::country_type')
+
+    op.alter_column('locations', 'time_zone', existing_type=sa.Enum('EAST_AFRICA_TIME', 'WEST_AFRICA_TIME', name='timezone_type'),type_=sa.VARCHAR())
+    timezone_type.drop(op.get_bind())
+    timezone_type.create(op.get_bind())
+    op.alter_column('locations', 'time_zone', existing_type=sa.Enum('EAST_AFRICA_TIME', 'WEST_AFRICA_TIME',
+                    name='timezone_type'), type_=timezone_type , postgresql_using='time_zone::timezone_type')
+
+
+def downgrade():
+    timezone_type = postgresql.ENUM('EAST_AFRICA_TIME', 'WEST_AFRICA_TIME', name='timezone_type')
+    country_type = postgresql.ENUM('Uganda', 'Kenya', 'Nigeria', name='country_type')
+
+    op.alter_column('locations', 'country', existing_type=sa.Enum('Uganda', 'Kenya', 'Nigeria','Rwanda', name='country_type'), type_=sa.VARCHAR())
+    country_type.drop(op.get_bind())
+    country_type.create(op.get_bind())
+    op.alter_column('locations', 'country', existing_type=sa.VARCHAR(), type_=country_type, postgresql_using='country::country_type')
+
+    op.alter_column('locations', 'time_zone', existing_type=sa.Enum('EAST_AFRICA_TIME', 'WEST_AFRICA_TIME', 'CENTRAL_AFRICA_TIME', name='timezone_type'),type_=sa.VARCHAR())
+    timezone_type.drop(op.get_bind())
+    timezone_type.create(op.get_bind())
+    op.alter_column('locations', 'time_zone', existing_type=sa.Enum('EAST_AFRICA_TIME', 'WEST_AFRICA_TIME',
+                    name='timezone_type'), type_=timezone_type , postgresql_using='time_zone::timezone_type')

--- a/api/location/models.py
+++ b/api/location/models.py
@@ -11,15 +11,18 @@ class CountryType(enum.Enum):
     Uganda = "Uganda"
     Kenya = "Kenya"
     Nigeria = "Nigeria"
+    Rwanda = "Rwanda"
 
 
 class TimeZoneType(enum.Enum):
     EAST_AFRICA_TIME = "UTC+3"
     WEST_AFRICA_TIME = "UTC+1"
+    CENTRAL_AFRICA_TIME = "UTC+2"
 
 
 class Location(Base, Utility):
     __tablename__ = 'locations'
+
     id = Column(Integer, Sequence('locations_id_seq',
                                   start=1, increment=1), primary_key=True)
     name = Column(String, nullable=False)


### PR DESCRIPTION
## Description ##
 
 This PR implements the feature to add the country type and timezone for Kigali in the locations table. 

**How should this be manually tested?**
   - git pull and checkout to the branch story/CON-303-create-timezone-countrytype-for-kigali
   - SSH into app 
   - run in docker `export $(cat .env | xargs)`
   - run in venv `source .env`
   - run ` alembic stamp head`
   - run ` alembic upgrade head`
   - your database should now have the location and timezone for kigali in you locations table
   - Use the below mutation to create a Kigali location 

```
mutation {
  createLocation(name: "Kigali", abbreviation: "KGL", country: "Rwanda", 
    timeZone: "CENTRAL_AFRICA_TIME", imageUrl: "https://lala.com") {
    location {
      name
    }
  }
}
```

## Type of change ##
Please select the relevant option
- [ ] Bug fix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes


### JIRA
[CON-303](https://andela-apprenticeship.atlassian.net/browse/CON-303)

## Relevant screenshot
<img width="1041" alt="Screenshot 2019-09-12 at 1 39 47 PM" src="https://user-images.githubusercontent.com/40043468/64784936-27ef8d00-d563-11e9-9cba-cc34d94f90f3.png">
