### PR TITLE
CON-281 Fix activity page query

### DIFF
--- a/fixtures/events/events_query_by_date_fixtures.py
+++ b/fixtures/events/events_query_by_date_fixtures.py
@@ -104,6 +104,48 @@ event_query_with_pagination_response = {
     }
 }
 
+query_events_with_location = '''
+    query{
+        allEvents(startDate: "Jul 11 2018",
+                  endDate: "Jul 11 2018",
+                  page:1,
+                  perPage: 1){
+            events {
+                    id
+                    roomId
+                    room{
+                        name
+                        locationId
+                    }
+            },
+            hasNext,
+            hasPrevious,
+            pages,
+            queryTotal
+        }
+    }
+'''
+
+event_query_with_location_response = {
+    'data': {
+        'allEvents': {
+            'events': [{
+                    'id': '1',
+                    'roomId': 1,
+                    'room': {
+                        'name': 'Entebbe',
+                        'locationId': 1
+                        }
+            }],
+            'hasNext': False,
+            'hasPrevious': False,
+            'pages': 1,
+            'queryTotal': 1
+        }
+    }
+}
+
+
 query_events_page_without_per_page = '''
 query{
   allEvents(

--- a/tests/test_events/test_query_all_events_by_date.py
+++ b/tests/test_events/test_query_all_events_by_date.py
@@ -1,4 +1,5 @@
 from tests.base import BaseTestCase, CommonTestCases
+
 from fixtures.events.events_query_by_date_fixtures import (
     query_events,
     event_query_response,
@@ -6,6 +7,8 @@ from fixtures.events.events_query_by_date_fixtures import (
     event_query_with_start_date_before_end_date_response,
     query_events_with_pagination,
     event_query_with_pagination_response,
+    query_events_with_location,
+    event_query_with_location_response,
     query_events_page_without_per_page,
     event_query_page_without_per_page_response,
     query_events_per_page_without_page,
@@ -23,6 +26,7 @@ from fixtures.events.events_query_by_date_fixtures import (
     query_events_without_page_and_per_page,
     event_query_without_page_and_per_page_response
 )
+from tests.base import change_user_role_to_super_admin
 
 
 class TestEventsQuery(BaseTestCase):
@@ -56,6 +60,18 @@ class TestEventsQuery(BaseTestCase):
             self,
             query_events_with_pagination,
             event_query_with_pagination_response
+
+        )
+
+    @change_user_role_to_super_admin
+    def test_query_events_with_location(self):
+        """
+        Test a super_user can query for all events in all locations
+        """
+        CommonTestCases.admin_token_assert_equal(
+            self,
+            query_events_with_location,
+            event_query_with_location_response
         )
 
     def test_query_events_without_start_date(self):


### PR DESCRIPTION
#### What does this PR do?
creates a paginated response of events grouped by the user location

#### Description of Task to be completed?
- group paginated events response by the location of the user

#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_api.git`
2. Setup project according to `Readme.md`
3. checkout to branch `bug/CON-281-fix-activity-page-query`
4. on insomnia to fetch a list of paginated events by user-location send the query
 ```
{
  allEvents(startDate: "Mar 21 2017", endDate: "Mar 21 2019", page: 2, perPage: 6) {
    events {
      eventId
      eventTitle
      startTime
      endTime
      room {
        name
        locationId
      }
    }
    pages
    hasPrevious
    hasNext
    queryTotal
  }
}

```

#### What are the relevant JIRA stories?
[CON-281](https://andela-apprenticeship.atlassian.net/browse/CON-281)

#### Relevant Screenshots
<img width="1172" alt="Screenshot 2019-09-11 at 08 55 17" src="https://user-images.githubusercontent.com/35098691/64671791-33af5680-d472-11e9-87a3-4fd7bc5a6991.png">

