### PR TITLE
CON-326 Fix remote rooms for Kigali

### DIFF
--- a/helpers/remote_rooms/remote_rooms_location.py
+++ b/helpers/remote_rooms/remote_rooms_location.py
@@ -8,5 +8,6 @@ def map_remote_room_location_to_filter():
             'Lagos': lambda remote_room: remote_room.find('ET-') != -1,
             'Kampala': lambda remote_room: remote_room.find('Kampala') != -1
             and not remote_room.startswith('Nairobi'),
+            'Kigali': lambda remote_room: remote_room.find('Kigali') != -1,
             'all': lambda remote_room: True  # return True for all rooms
         }


### PR DESCRIPTION
## Description ##
 Currently, it is impossible for an admin in Kigali to fetch calendar rooms in the location. This PR fixes this issue


**How should this be manually tested?**
  - change your location to `Kigali` and use the below query
  - before: you will receive an error
  - now: you should be able to see remote rooms in `Kigali`
  

```
query {
allRemoteRooms  {
  rooms {
    name
    calendarId
  }
}
  
}
```

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### JIRA
[CON-326](https://andela-apprenticeship.atlassian.net/browse/CON-326)