### PR TITLE
CON-336 Update device last seen time after end meeting

### DIFF
--- a/alembic/versions/98e4dbfc868a_add_last_activity_to_devices.py
+++ b/alembic/versions/98e4dbfc868a_add_last_activity_to_devices.py
@@ -1,0 +1,24 @@
+"""Add_last_activity_to_devices
+
+Revision ID: 98e4dbfc868a
+Revises: ace641b9b89b
+Create Date: 2019-10-15 09:22:19.847309
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '98e4dbfc868a'
+down_revision = 'ace641b9b89b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('devices', sa.Column('last_activity', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('devices', 'last_activity')

--- a/api/devices/models.py
+++ b/api/devices/models.py
@@ -18,6 +18,7 @@ class Devices(Base, Utility):
     room_id = Column(Integer, ForeignKey('rooms.id', ondelete="CASCADE"))
     room = relationship('Room')
     state = Column(Enum(StateType), nullable=False, default="active")
+    last_activity = Column(String, nullable=True)
 
     def __init__(self, **kwargs):
         validate_empty_fields(**kwargs)

--- a/helpers/devices/devices.py
+++ b/helpers/devices/devices.py
@@ -3,12 +3,13 @@ from api.devices.models import Devices as DeviceModel
 from api.devices.schema import Devices as DeviceSchema
 
 
-def update_device_last_seen(info, room_id, check_in_time):
+def update_device_last_activity(info, room_id, activity_time, activity):
     device_query = DeviceSchema.get_query(info)
     device = device_query.filter(
                 DeviceModel.room_id == room_id
             ).first()
     if not device:
         raise GraphQLError("Room device not found")
-    device.last_seen = check_in_time
+    device.last_seen = activity_time
+    device.last_activity = activity
     device.save()


### PR DESCRIPTION
#### Description

We should keep track of the last time we heard from a device so we can track its availability. Currently, the last time seen is updated when an event is cancelled or when check-in happens. Expand this to include when a meeting is ended (i.e when the End Meeting endpoint is called).

#### Type of change

Please select the relevant option

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] My changes generate no new warnings
- [x]  Existing unit tests pass locally with my changes
 Implementation works according to expectations
#### JIRA
[CON-336](https://andela-apprenticeship.atlassian.net/browse/CON-336)