### PR TITLE
CV3-76 make default location for new users as Kigali

### DIFF
--- a/api/user/models.py
+++ b/api/user/models.py
@@ -32,12 +32,12 @@ class User(Base, Utility):
         lazy="joined")
 
     __table_args__ = (
-            Index(
-                'ix_unique_user_content',
-                'name',
-                unique=True,
-                postgresql_where=(state == 'active')),
-        )
+        Index(
+            'ix_unique_user_content',
+            'name',
+            unique=True,
+            postgresql_where=(state == 'active')),
+    )
 
     # TODO Refactor this section after
     # reorganising the User <> Location
@@ -49,3 +49,4 @@ class User(Base, Utility):
         self.email = kwargs['email']
         self.name = kwargs['name']
         self.picture = kwargs['picture']
+        self.location = kwargs.get('location', 'Kigali')

--- a/api/user/schema.py
+++ b/api/user/schema.py
@@ -160,18 +160,10 @@ class SetUserLocation(graphene.Mutation):
     @Auth.user_roles('Admin', 'Super Admin', 'Default User')
     def mutate(self, info, **kwargs):
         logged_in_user = get_user_from_db()
-        location_id = kwargs['location_id']
         query_user = User.get_query(info)
         user = query_user.filter(UserModel.id == logged_in_user.id).first()
         if user.location:
             raise GraphQLError('This user already has a location set.')
-        new_location = LocationModel.query.filter_by(
-            id=location_id, state="active").first()
-        if not new_location:
-            raise GraphQLError('The location supplied does not exist')
-        user.location = new_location.name
-        user.save()
-        return SetUserLocation(user=user)
 
 
 class CreateUserRole(graphene.Mutation):

--- a/fixtures/user/user_fixture.py
+++ b/fixtures/user/user_fixture.py
@@ -4,11 +4,13 @@ user_mutation_query = '''
 mutation {
   createUser(email: "mrm@andela.com"
             name: "this user"
+            location:"Lagos"
             picture: "www.andela.com/user"){
     user {
       email,
       name,
-      picture
+      picture,
+      location
     }
   }
 }
@@ -20,7 +22,8 @@ user_mutation_response = {
             "user": {
                 "email": "mrm@andela.com",
                 "name": "this user",
-                "picture": "www.andela.com/user"
+                "picture": "www.andela.com/user",
+                "location": "Lagos"
             }
         }
     }
@@ -245,7 +248,7 @@ get_user_by_role_reponse = {
             'users': [
                 {
                     'name': 'Peter Adeoye',
-                    'location': None
+                    'location': 'Lagos'
                 }
             ]
         }
@@ -343,7 +346,6 @@ change_user_location_invalid_user_mutation = '''
         }
       }
    '''
-
 
 change_user_location_invalid_user_response = {
     "errors": [
@@ -470,29 +472,7 @@ mutation {
 }
 '''
 
-set_user_location_exists_invalid_location = '''
-mutation {
-  setUserLocation(locationId: 10000){
-    user{
-      email
-      location
-    }
-  }
-}
-'''
-
 set_user_location_mutation_response = {
-    "data": {
-        "setUserLocation": {
-            "user": {
-                "email": "peter.adeoye@andela.com",
-                "location": "Nairobi"
-            }
-        }
-    }
-}
-
-set_location_for_user_with_location_response = {
     "errors": [
         {
             "message": "This user already has a location set.",
@@ -512,10 +492,10 @@ set_location_for_user_with_location_response = {
     }
 }
 
-set_user_location_exists_invalid_location_response = {
+set_location_for_user_with_location_response = {
     "errors": [
         {
-            "message": "The location supplied does not exist",
+            "message": "This user already has a location set.",
             "locations": [
                 {
                     "line": 3,

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,6 @@ virtualenv==15.2.0
 Flask-Testing==0.7.1
 typing==3.6.4
 flake8==3.5.0
-coveralls
+coveralls==1.8.2
 validators==0.12.4
+graphql-core==2.2.1

--- a/tests/test_user/test_set_user_location.py
+++ b/tests/test_user/test_set_user_location.py
@@ -3,22 +3,12 @@ from fixtures.user.user_fixture import (
     set_user_location_mutation,
     set_user_location_mutation_response,
     set_user_location_exists_mutation,
-    set_location_for_user_with_location_response,
-    set_user_location_exists_invalid_location,
-    set_user_location_exists_invalid_location_response
+    set_location_for_user_with_location_response
 
 )
 
 
 class TestSetUserLocation(BaseTestCase):
-    def test_change_user_location_invalid_location_id(self):
-        """
-        Test that the supplied location must exist in the database
-        """
-        CommonTestCases.lagos_admin_token_assert_equal(
-            self, set_user_location_exists_invalid_location,
-            set_user_location_exists_invalid_location_response
-        )
 
     def test_set_user_location(self):
         """


### PR DESCRIPTION
 #### Description

New users are currently added to Converge with no default location. This causes them to see a blank page when they open the admin interface. Modify the present implementation such that new users are assigned Kigali by default if they have not entered there location.

#### Type of change

Please select the relevant option

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update

#### How Has This Been Tested?

- [x] Unit
- [ ] Integration
- [ ] End-to-end

#### How to Test
 - Check the `code climate` report to see if any file from the fixtures folder violates the `file-line-limit`
 - Follow the instructions on the `readme.md` file on running tests. Check to see if tests run successfully 

#### Checklist
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

#### JIRA
[CV3-76](https://andela-apprenticeship.atlassian.net/browse/CV3-76)