### PR TITLE
CV3-85 Add device downtime to report data

### DIFF
--- a/fixtures/analytics/query_all_analytics_fixtures.py
+++ b/fixtures/analytics/query_all_analytics_fixtures.py
@@ -1,4 +1,4 @@
-all_analytics_query = '''
+all_analytics_query = """
     query {
       allAnalytics(startDate:"jul 11 2018", endDate:"jul 12 2018", locationId:1) { # noqa: E501
           checkinsPercentage
@@ -25,10 +25,23 @@ all_analytics_query = '''
             totalBookings
             period
           }
+          deviceAnalytics{
+            deviceName
+            deviceId
+          }
         }
   }
-'''
-all_analytics_query_invalid_locationid = '''
+"""
+all_analytics_query_down_time = """
+    query {
+        allAnalytics(startDate:"jul 11 2018", endDate:"jul 12 2018", locationId:1) { # noqa: E501
+        deviceAnalytics{
+            downTime
+          }
+        }
+  }
+"""
+all_analytics_query_invalid_locationid = """
     query {
       allAnalytics(startDate:"jul 11 2018", endDate:"jul 12 2018", locationId:10) { # noqa: E501
           checkinsPercentage
@@ -57,84 +70,69 @@ all_analytics_query_invalid_locationid = '''
           }
         }
   }
-'''
+"""
 
 all_analytics_query_response = {
-  "data": {
-    "allAnalytics": {
-      "checkinsPercentage": 0.0,
-      "appBookingsPercentage": 0.0,
-      "autoCancellationsPercentage": 0.0,
-      "cancellationsPercentage": 0.0,
-      "bookings": 1,
-      "analytics": [
-        {
-          "roomName": "Entebbe",
-          "cancellations": 0,
-          "cancellationsPercentage": 0.0,
-          "autoCancellations": 0,
-          "numberOfBookings": 1,
-          "checkins": 0,
-          "checkinsPercentage": 0.0,
-          "bookingsPercentageShare": 100.0,
-          "appBookings": 0,
-          "appBookingsPercentage": 0.0,
-          "events": [
-            {
-              "durationInMinutes": 45
-            }
-          ]
-        },
-        {
-          "roomName": "Tana",
-          "cancellations": 0,
-          "cancellationsPercentage": 0.0,
-          "autoCancellations": 0,
-          "numberOfBookings": 0,
-          "checkins": 0,
-          "checkinsPercentage": 0.0,
-          "bookingsPercentageShare": 0.0,
-          "appBookings": 0,
-          "appBookingsPercentage": 0.0,
-          "events": [
-            {
-              "durationInMinutes": 0
-            }
-          ]
+    "data": {
+        "allAnalytics": {
+            "checkinsPercentage": 0.0,
+            "appBookingsPercentage": 0.0,
+            "autoCancellationsPercentage": 0.0,
+            "cancellationsPercentage": 0.0,
+            "bookings": 1,
+            "analytics": [
+                {
+                    "roomName": "Entebbe",
+                    "cancellations": 0,
+                    "cancellationsPercentage": 0.0,
+                    "autoCancellations": 0,
+                    "numberOfBookings": 1,
+                    "checkins": 0,
+                    "checkinsPercentage": 0.0,
+                    "bookingsPercentageShare": 100.0,
+                    "appBookings": 0,
+                    "appBookingsPercentage": 0.0,
+                    "events": [{"durationInMinutes": 45}],
+                },
+                {
+                    "roomName": "Tana",
+                    "cancellations": 0,
+                    "cancellationsPercentage": 0.0,
+                    "autoCancellations": 0,
+                    "numberOfBookings": 0,
+                    "checkins": 0,
+                    "checkinsPercentage": 0.0,
+                    "bookingsPercentageShare": 0.0,
+                    "appBookings": 0,
+                    "appBookingsPercentage": 0.0,
+                    "events": [{"durationInMinutes": 0}],
+                },
+            ],
+            "bookingsCount": [
+                {"totalBookings": 1, "period": "Jul 11 2018"},
+                {"totalBookings": 0, "period": "Jul 12 2018"},
+            ],
+            "deviceAnalytics": [
+                {
+                    "deviceName": "Samsung",
+                    "deviceId": 1,
+                    # "downTime": "this device was seen {}".format(
+                    #     downtime_value),
+                }
+            ],
         }
-      ],
-      "bookingsCount": [
-        {
-          "totalBookings": 1,
-          "period": "Jul 11 2018"
-        },
-        {
-          'totalBookings': 0,
-          'period': 'Jul 12 2018'
-        }
-      ]
     }
-  }
 }
 
 all_analytics_query_response_super_admin_with_invalid_locationid = {
     "errors": [
         {
             "message": "Location Id does not exist",
-            "locations": [
-                {
-                    "line": 3,
-                    "column": 7
-                }
-            ],
-            "path": [
-                "allAnalytics"
-            ]
+            "locations": [{"line": 3, "column": 7}],
+            "path": ["allAnalytics"],
         }
     ],
-    "data": {
-        "allAnalytics": None
-    }
+    "data": {"allAnalytics": None},
 }
 
 all_analytics_query_response_super_admin = {
@@ -157,11 +155,7 @@ all_analytics_query_response_super_admin = {
                     "bookingsPercentageShare": 50.0,
                     "appBookings": 0,
                     "appBookingsPercentage": 0.0,
-                    "events": [
-                        {
-                            "durationInMinutes": 890
-                        }
-                    ]
+                    "events": [{"durationInMinutes": 890}],
                 },
                 {
                     "roomName": "Krypton",
@@ -174,11 +168,7 @@ all_analytics_query_response_super_admin = {
                     "bookingsPercentageShare": 25.0,
                     "appBookings": 0,
                     "appBookingsPercentage": 0.0,
-                    "events": [
-                        {
-                            "durationInMinutes": 155
-                        }
-                    ]
+                    "events": [{"durationInMinutes": 155}],
                 },
                 {
                     "roomName": "Bujumbura",
@@ -191,11 +181,7 @@ all_analytics_query_response_super_admin = {
                     "bookingsPercentageShare": 25.0,
                     "appBookings": 0,
                     "appBookingsPercentage": 0.0,
-                    "events": [
-                        {
-                            "durationInMinutes": 92
-                        }
-                    ]
+                    "events": [{"durationInMinutes": 92}],
                 },
                 {
                     "roomName": "Kampala",
@@ -208,11 +194,7 @@ all_analytics_query_response_super_admin = {
                     "bookingsPercentageShare": 0.0,
                     "appBookings": 0,
                     "appBookingsPercentage": 0.0,
-                    "events": [
-                        {
-                            "durationInMinutes": 0
-                        }
-                    ]
+                    "events": [{"durationInMinutes": 0}],
                 },
                 {
                     "roomName": "Algiers",
@@ -225,28 +207,18 @@ all_analytics_query_response_super_admin = {
                     "bookingsPercentageShare": 0.0,
                     "appBookings": 0,
                     "appBookingsPercentage": 0.0,
-                    "events": [
-                        {
-                            "durationInMinutes": 0
-                        }
-                    ]
-                }
+                    "events": [{"durationInMinutes": 0}],
+                },
             ],
             "bookingsCount": [
-                {
-                    "totalBookings": 7,
-                    "period": "Jul 11 2018"
-                },
-                {
-                    "totalBookings": 5,
-                    "period": "Jul 12 2018"
-                }
-            ]
+                {"totalBookings": 7, "period": "Jul 11 2018"},
+                {"totalBookings": 5, "period": "Jul 12 2018"},
+            ],
         }
     }
 }
 
-analytics_query_for_date_ranges = '''
+analytics_query_for_date_ranges = """
     query {
       allAnalytics(startDate:"jul 11 2020", endDate:"jul 12 2018") {
           checkinsPercentage
@@ -275,4 +247,4 @@ analytics_query_for_date_ranges = '''
           }
         }
   }
-'''
+"""

--- a/fixtures/devices/devices_fixtures.py
+++ b/fixtures/devices/devices_fixtures.py
@@ -17,7 +17,7 @@ expected_response_devices = {
                                     "allDevices": [
                                         {
                                             "id": "1",
-                                            "lastSeen": "2018-06-08T11:17:58.785136",  # noqa: E501
+                                            "lastSeen": "2019-04-10T13:28:45",  # noqa: E501
                                             "dateAdded": "2018-06-08T11:17:58.785136",  # noqa: E501
                                             "name": "Samsung",
                                             "location": "Kampala"
@@ -44,7 +44,7 @@ expected_response_devices_with_filter = {
             {
                 "dateAdded": "2018-06-08T11:17:58.785136",
                 "id": "1",
-                "lastSeen": "2018-06-08T11:17:58.785136",
+                "lastSeen": "2019-04-10T13:28:45",
                 "location": "Kampala",
                 "name": "Samsung"
             }
@@ -68,7 +68,7 @@ expected_response_device = {
     "data": {
         "specificDevice": {
             "id": "1",
-            "lastSeen": "2018-06-08T11:17:58.785136",  # noqa: E501
+            "lastSeen": "2019-04-10T13:28:45",  # noqa: E501
             "dateAdded": "2018-06-08T11:17:58.785136",  # noqa: E501
             "name": "Samsung",
             "location": "Kampala"

--- a/helpers/calendar/all_analytics_helper.py
+++ b/helpers/calendar/all_analytics_helper.py
@@ -2,9 +2,10 @@ import graphene
 import pytz
 import dateutil.parser
 from graphql import GraphQLError
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 from helpers.calendar.analytics_helper import CommonAnalytics
 from utilities.utility import percentage_formater
-from dateutil.relativedelta import relativedelta
 
 
 class Event(graphene.ObjectType):
@@ -16,8 +17,13 @@ class BookingsCount(graphene.ObjectType):
     total_bookings = graphene.Int()
 
 
-class AllAnalyticsHelper:
+class DeviceAnalytics(graphene.ObjectType):
+    device_name = graphene.String()
+    device_id = graphene.Int()
+    down_time = graphene.String()
 
+
+class AllAnalyticsHelper:
     def count_bookings_within_period(events, date_pattern, string_date):
         """
         Counts the bookings within a specified period
@@ -25,7 +31,9 @@ class AllAnalyticsHelper:
         user_time_zone = CommonAnalytics.get_user_time_zone()
         bookings = 0
         for event in events:
-            start_timez = dateutil.parser.parse(event.start_time).astimezone(pytz.timezone(user_time_zone)) # noqa
+            start_timez = dateutil.parser.parse(event.start_time).astimezone(
+                pytz.timezone(user_time_zone)
+            )  # noqa
             if start_timez.strftime(date_pattern) == string_date:
                 bookings += 1
         return bookings
@@ -37,7 +45,9 @@ class AllAnalyticsHelper:
         bookings_count = []
         for date in dates:
             string_date = dateutil.parser.parse(date[0]).strftime(date_pattern)
-            bookings = AllAnalyticsHelper.count_bookings_within_period(events, date_pattern, string_date) # noqa
+            bookings = AllAnalyticsHelper.count_bookings_within_period(
+                events, date_pattern, string_date
+            )
             output = BookingsCount(period=string_date, total_bookings=bookings)
             bookings_count.append(output)
         return bookings_count
@@ -46,8 +56,8 @@ class AllAnalyticsHelper:
         """
         Get bookings count and period in a given room
         """
-        start_date = unconverted_dates['start']
-        day_after_end_date = unconverted_dates['end']
+        start_date = unconverted_dates["start"]
+        day_after_end_date = unconverted_dates["end"]
         parsed_start_date = dateutil.parser.parse(start_date)
         parsed_end_date = dateutil.parser.parse(day_after_end_date)
         parsed_day_after_end_date = parsed_end_date + relativedelta(days=1)
@@ -56,13 +66,14 @@ class AllAnalyticsHelper:
         date_pattern = "%b %d %Y"
         if number_of_days <= 30:
             dates = CommonAnalytics.get_list_of_dates(
-                 start_date, number_of_days)
+                start_date, number_of_days)
         else:
             dates = CommonAnalytics.get_list_of_month_dates(
                 start_date,
                 parsed_start_date,
                 day_after_end_date,
-                parsed_day_after_end_date)
+                parsed_day_after_end_date,
+            )
             date_pattern = "%b %Y"
 
         return AllAnalyticsHelper.map_bookings_to_period(
@@ -73,30 +84,88 @@ class AllAnalyticsHelper:
         Gets total checkins, app_bookings... from events
         """
         events_stats = {
-           "checkins": 0,
-           "app_bookings": 0,
-           "auto_cancellations": 0,
-           "cancellations": 0,
-           "duration_in_minutes": 0
+            "checkins": 0,
+            "app_bookings": 0,
+            "auto_cancellations": 0,
+            "cancellations": 0,
+            "duration_in_minutes": 0,
         }
         for event in events:
-            events_stats['checkins'] += bool(event.checked_in)
-            events_stats['app_bookings'] += bool(event.app_booking)
-            events_stats['auto_cancellations'] += bool(event.auto_cancelled)
-            events_stats['cancellations'] += bool(event.cancelled)
-            events_stats['duration_in_minutes'] += CommonAnalytics.get_time_duration_for_event( # noqa
+            events_stats["checkins"] += bool(event.checked_in)
+            events_stats["app_bookings"] += bool(event.app_booking)
+            events_stats["auto_cancellations"] += bool(event.auto_cancelled)
+            events_stats["cancellations"] += bool(event.cancelled)
+            events_stats[
+                "duration_in_minutes"
+            ] += CommonAnalytics.get_time_duration_for_event(  # noqa
                 self, event.start_time, event.end_time
             )
         return events_stats
+
+    def convert_to_human_readable(date_time):
+        """
+        converts a datetime object to the
+        format "X days, Y hours ago"
+
+        @param date_time: datetime object
+
+        @return:
+            Human readable date time
+        """
+        user_time_zone = CommonAnalytics.get_user_time_zone()
+        local_time = datetime.now().astimezone(
+            pytz.timezone(user_time_zone)
+        )
+        date_now = local_time.strftime("%Y-%m-%d %H:%M:%S")
+        current_time = datetime.strptime(str(date_now), "%Y-%m-%d %H:%M:%S")
+        last_seen = datetime.strptime(str(date_time), "%Y-%m-%d %H:%M:%S")
+        difference = relativedelta(current_time, last_seen)
+        years = difference.years
+        months = difference.months
+        days = difference.days
+        hours = difference.hours
+        minutes = difference.minutes
+        result = {
+            "years": years,
+            "months": months,
+            "days": days,
+            "hours": hours,
+            "minutes": minutes,
+        }
+        date = []
+        for key, value in result.items():
+            if value > 0:
+                date_string = str(value) + " " + key
+                date.append(date_string)
+
+        return ", ".join(date) + " ago."
+
+    def get_devices_analytics(self, query):
+        """
+        Get devices str(diff.months) + analytic
+        """
+        devices = query.filter_by(state="active").all()
+        device_analytics = []
+        for device in devices:
+            down_time = AllAnalyticsHelper.convert_to_human_readable(
+                device.last_seen)
+            device_obj = {
+                "device_name": device.name,
+                "device_id": device.id,
+                "down_time": "this device was seen {}".format(down_time),
+            }
+            device_analytics.append(device_obj)
+
+        return device_analytics
 
     def get_all_analytics(self, query, **kwargs):
         """
         Get all room analytics
         """
-        start_date = kwargs['start_date']
-        end_date = kwargs['end_date']
-        location_id = kwargs['location_id']
-        unconverted_dates = kwargs['unconverted_dates']
+        start_date = kwargs["start_date"]
+        end_date = kwargs["end_date"]
+        location_id = kwargs["location_id"]
+        unconverted_dates = kwargs["unconverted_dates"]
         rooms = query.filter_by(state="active", location_id=location_id).all()
         room_analytics = []
         bookings = 0
@@ -110,44 +179,54 @@ class AllAnalyticsHelper:
             events = []
             try:
                 events_result = CommonAnalytics.get_all_events_in_a_room(
-                    self, room.id, start_date, end_date)
+                    self, room.id, start_date, end_date
+                )
             except GraphQLError:
                 continue
             all_events += events_result
             bookings += len(events_result)
-            events_stats = AllAnalyticsHelper.get_events_statistics(self, events_result) # noqa
+            events_stats = AllAnalyticsHelper.get_events_statistics(
+                self, events_result
+            )  # noqa
             current_event = Event(
-                duration_in_minutes=events_stats['duration_in_minutes'])
+                duration_in_minutes=events_stats["duration_in_minutes"]
+            )
             events.append(current_event)
-            total_checkins += events_stats['checkins']
-            total_app_bookings += events_stats['app_bookings']
-            total_auto_cancellations += events_stats['auto_cancellations']
-            total_cancellations += events_stats['cancellations']
+            total_checkins += events_stats["checkins"]
+            total_app_bookings += events_stats["app_bookings"]
+            total_auto_cancellations += events_stats["auto_cancellations"]
+            total_cancellations += events_stats["cancellations"]
             num_of_events = len(events_result)
             room_analytic = {
-                'number_of_meetings': num_of_events,
-                'room_name': room.name,
-                'num_of_events': num_of_events,
-                'room_events': events,
-                'cancellations': events_stats['cancellations'],
-                'checkins': events_stats['checkins'],
-                'auto_cancellations': events_stats['auto_cancellations'],
-                'cancellations_percentage': percentage_formater(
-                    events_stats['cancellations'], num_of_events
+                "number_of_meetings": num_of_events,
+                "room_name": room.name,
+                "num_of_events": num_of_events,
+                "room_events": events,
+                "cancellations": events_stats["cancellations"],
+                "checkins": events_stats["checkins"],
+                "auto_cancellations": events_stats["auto_cancellations"],
+                "cancellations_percentage": percentage_formater(
+                    events_stats["cancellations"], num_of_events
                 ),
-                'checkins_percentage': percentage_formater(
-                    events_stats['checkins'], num_of_events
+                "checkins_percentage": percentage_formater(
+                    events_stats["checkins"], num_of_events
                 ),
-                'app_bookings': events_stats['app_bookings'],
-                'app_bookings_percentage': percentage_formater(events_stats['app_bookings'], num_of_events) # noqa
+                "app_bookings": events_stats["app_bookings"],
+                "app_bookings_percentage": percentage_formater(
+                    events_stats["app_bookings"], num_of_events
+                ),  # noqa
             }
             room_analytics.append(room_analytic)
-            room_analytics.sort(key=lambda x: x['number_of_meetings'], reverse=True) # noqa
+            room_analytics.sort(
+                key=lambda x: x["number_of_meetings"], reverse=True
+            )  # noqa
         percentages_dict = {
-            'total_checkins': total_checkins,
-            'total_auto_cancellations': total_auto_cancellations,
-            'total_app_bookings': total_app_bookings,
-            'total_cancellations': total_cancellations
+            "total_checkins": total_checkins,
+            "total_auto_cancellations": total_auto_cancellations,
+            "total_app_bookings": total_app_bookings,
+            "total_cancellations": total_cancellations,
         }
-        bookings_count += AllAnalyticsHelper.bookings_count(self, unconverted_dates, all_events) # noqa
+        bookings_count += AllAnalyticsHelper.bookings_count(
+            self, unconverted_dates, all_events
+        )  # noqa
         return room_analytics, bookings, percentages_dict, bookings_count

--- a/tests/base.py
+++ b/tests/base.py
@@ -111,7 +111,7 @@ class BaseTestCase(TestCase):
                                 quantity=3)
             resource.save()
             device = Devices(
-                last_seen="2018-06-08T11:17:58.785136",
+                last_seen="2019-04-10T13:28:45",
                 date_added="2018-06-08T11:17:58.785136",
                 name="Samsung",
                 location="Kampala",

--- a/tests/test_analytics/test_all_analytics_query.py
+++ b/tests/test_analytics/test_all_analytics_query.py
@@ -8,7 +8,8 @@ from fixtures.analytics.query_all_analytics_fixtures import (
     all_analytics_query_response,
     all_analytics_query_invalid_locationid,
     analytics_query_for_date_ranges,
-    all_analytics_query_response_super_admin_with_invalid_locationid
+    all_analytics_query_response_super_admin_with_invalid_locationid,
+    all_analytics_query_down_time
 )
 
 
@@ -24,6 +25,18 @@ class TestAllAnalytics(BaseTestCase):
             self,
             all_analytics_query,
             all_analytics_query_response
+        )
+
+    def test_all_analytics_query_donw(self):
+        """
+        Tests a user can query for analytics
+
+        """
+
+        CommonTestCases.admin_token_assert_in(
+            self,
+            all_analytics_query_down_time,
+            "this device was seen"
         )
 
     @change_user_role_to_super_admin


### PR DESCRIPTION
 #### Description

 When the analytics report data are retrieved, it should also include the downtime of the device i.e the time the device has been not used.

#### Type of change

Please select the relevant option

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update

#### How Has This Been Tested?

- [x] Unit
- [ ] Integration
- [ ] End-to-end

#### How to Test
 - Check the `code climate` report to see if any file from the fixtures folder violates the `file-line-limit`
 - Follow the instructions on the `readme.md` file on running tests. Check to see if tests run successfully 

#### Checklist
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations

#### How to Test
- `URL:`    `http://localhost:8000/mrm` 
- `HTTP:`   `POST` 
- In the query of getting all analytics, you should also include the device analytics that has deviceName, deviceId, and downTime as shown in an example below
```
query{
  allAnalytics(startDate: "jul 11 2018", endDate: "jul 12 2018", locationId: 1) {
    checkinsPercentage
    appBookingsPercentage
    autoCancellationsPercentage
    cancellationsPercentage
    bookings
    analytics {
      roomName
      cancellations
      cancellationsPercentage
      autoCancellations
      numberOfBookings
      checkins
      checkinsPercentage
      bookingsPercentageShare
      appBookings
      appBookingsPercentage
      events {
        durationInMinutes
      }
    }
    bookingsCount {
      totalBookings
      period
    }
    deviceAnalytics {
      deviceName
      deviceId
      downTime
    }
  }
}

```
- Expected response 
```
{
  "data": {
    "allAnalytics": {
      "checkinsPercentage": 0.0,
      "appBookingsPercentage": 0.0,
      "autoCancellationsPercentage": 0.0,
      "cancellationsPercentage": 0.0,
      "bookings": 13,
      "analytics": [
        {
          "roomName": "Kampala",
          "cancellations": 0,
          "cancellationsPercentage": 0.0,
          "autoCancellations": 0,
          "numberOfBookings": 0,
          "checkins": 0,
          "checkinsPercentage": 0.0,
          "bookingsPercentageShare": 0.0,
          "appBookings": 0,
          "appBookingsPercentage": 0.0,
          "events": [
            {
              "durationInMinutes": 0
            }
          ]
        }
      ],
      "bookingsCount": [
        {
          "totalBookings": 7,
          "period": "Jul 11 2018"
        },
        {
          "totalBookings": 6,
          "period": "Jul 12 2018"
        }
      ],
      "deviceAnalytics": [
        {
          "deviceName": "Apple tablet",
          "deviceId": 1,
          "downTime": "this device was seen 3 days, 23 hours, 13 minutes ago."
        },
        {
          "deviceName": "Samsung Flat screen",
          "deviceId": 2,
          "downTime": "this device was seen 8 months, 7 days, 2 hours, 44 minutes ago."
        }
      ]
    }
  }
}
```
#### JIRA
[CV3-85](https://andela-apprenticeship.atlassian.net/browse/CV3-85)